### PR TITLE
fix: The workflow should treat `release-0.293-clp-connector` as our "main" branch. 

### DIFF
--- a/.github/workflows/arrow-flight-tests.yml
+++ b/.github/workflows/arrow-flight-tests.yml
@@ -2,9 +2,11 @@ name: arrow flight tests
 
 on:
   pull_request:
+    branches: [release-0.293-clp-connector]
     paths-ignore:
       - 'presto-docs/**'
   push:
+    branches: [release-0.293-clp-connector]
     paths-ignore:
       - 'presto-docs/**'
 
@@ -19,9 +21,9 @@ env:
 concurrency:
   group: "${{github.workflow}}-${{github.ref}}"
 
-  # Cancel in-progress jobs for efficiency. Exclude the `main` branch so that each commit to main is
-  # checked completely.
-  cancel-in-progress: "${{github.ref != 'refs/heads/main'}}"
+  # Cancel in-progress jobs for efficiency. Exclude the `release-0.293-clp-connector` branch so
+  # that each commit to release-0.293-clp-connector is checked completely.
+  cancel-in-progress: "${{github.ref != 'refs/heads/release-0.293-clp-connector'}}"
 
 jobs:
   arrowflight-java-tests:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,9 +2,11 @@ name: docs
 
 on:
   pull_request:
+    branches: [release-0.293-clp-connector]
     paths:
       - 'presto-docs/**'
   push:
+    branches: [release-0.293-clp-connector]
     paths:
       - 'presto-docs/**'
 
@@ -20,9 +22,9 @@ env:
 concurrency:
   group: "${{github.workflow}}-${{github.ref}}"
 
-  # Cancel in-progress jobs for efficiency. Exclude the `main` branch so that each commit to main is
-  # checked completely.
-  cancel-in-progress: "${{github.ref != 'refs/heads/main'}}"
+  # Cancel in-progress jobs for efficiency. Exclude the `release-0.293-clp-connector` branch so
+  # that each commit to release-0.293-clp-connector is checked completely.
+  cancel-in-progress: "${{github.ref != 'refs/heads/release-0.293-clp-connector'}}"
 
 jobs:
   test:

--- a/.github/workflows/hive-tests.yml
+++ b/.github/workflows/hive-tests.yml
@@ -2,7 +2,9 @@ name: hive tests
 
 on:
   pull_request:
+    branches: [release-0.293-clp-connector]
   push:
+    branches: [release-0.293-clp-connector]
 
 env:
   # An envar that signals to tests we are executing in the CI environment
@@ -16,9 +18,9 @@ env:
 concurrency:
   group: "${{github.workflow}}-${{github.ref}}"
 
-  # Cancel in-progress jobs for efficiency. Exclude the `main` branch so that each commit to main is
-  # checked completely.
-  cancel-in-progress: "${{github.ref != 'refs/heads/main'}}"
+  # Cancel in-progress jobs for efficiency. Exclude the `release-0.293-clp-connector` branch so
+  # that each commit to release-0.293-clp-connector is checked completely.
+  cancel-in-progress: "${{github.ref != 'refs/heads/release-0.293-clp-connector'}}"
 
 jobs:
   changes:

--- a/.github/workflows/kudu.yml
+++ b/.github/workflows/kudu.yml
@@ -2,7 +2,9 @@ name: kudu
 
 on:
   pull_request:
+    branches: [release-0.293-clp-connector]
   push:
+    branches: [release-0.293-clp-connector]
 
 env:
   # An envar that signals to tests we are executing in the CI environment
@@ -15,9 +17,9 @@ env:
 concurrency:
   group: "${{github.workflow}}-${{github.ref}}"
 
-  # Cancel in-progress jobs for efficiency. Exclude the `main` branch so that each commit to main is
-  # checked completely.
-  cancel-in-progress: "${{github.ref != 'refs/heads/main'}}"
+  # Cancel in-progress jobs for efficiency. Exclude the `release-0.293-clp-connector` branch so
+  # that each commit to release-0.293-clp-connector is checked completely.
+  cancel-in-progress: "${{github.ref != 'refs/heads/release-0.293-clp-connector'}}"
 
 jobs:
   changes:

--- a/.github/workflows/maven-checks.yml
+++ b/.github/workflows/maven-checks.yml
@@ -2,7 +2,9 @@ name: maven checks
 
 on:
   pull_request:
+    branches: [release-0.293-clp-connector]
   push:
+    branches: [release-0.293-clp-connector]
 
 env:
   # An envar that signals to tests we are executing in the CI environment
@@ -14,9 +16,9 @@ env:
 concurrency:
   group: "${{github.workflow}}-${{github.ref}}"
 
-  # Cancel in-progress jobs for efficiency. Exclude the `main` branch so that each commit to main is
-  # checked completely.
-  cancel-in-progress: "${{github.ref != 'refs/heads/main'}}"
+  # Cancel in-progress jobs for efficiency. Exclude the `release-0.293-clp-connector` branch so
+  # that each commit to release-0.293-clp-connector is checked completely.
+  cancel-in-progress: "${{github.ref != 'refs/heads/release-0.293-clp-connector'}}"
 
 jobs:
   maven-checks:

--- a/.github/workflows/prestocpp-format-and-header-check.yml
+++ b/.github/workflows/prestocpp-format-and-header-check.yml
@@ -3,10 +3,12 @@ name: prestocpp-format-and-header-check
 on:
   workflow_dispatch:
   pull_request:
+    branches: [release-0.293-clp-connector]
     paths:
       - 'presto-native-execution/**'
       - '.github/workflows/prestocpp-format-and-header-check.yml'
   push:
+    branches: [release-0.293-clp-connector]
     paths:
       - 'presto-native-execution/**'
       - '.github/workflows/prestocpp-format-and-header-check.yml'
@@ -14,9 +16,9 @@ on:
 concurrency:
   group: "${{github.workflow}}-${{github.ref}}"
 
-  # Cancel in-progress jobs for efficiency. Exclude the `main` branch so that each commit to main is
-  # checked completely.
-  cancel-in-progress: "${{github.ref != 'refs/heads/main'}}"
+  # Cancel in-progress jobs for efficiency. Exclude the `release-0.293-clp-connector` branch so
+  # that each commit to release-0.293-clp-connector is checked completely.
+  cancel-in-progress: "${{github.ref != 'refs/heads/release-0.293-clp-connector'}}"
 
 jobs:
   prestocpp-format-and-header-check:

--- a/.github/workflows/prestocpp-linux-build-and-unit-test.yml
+++ b/.github/workflows/prestocpp-linux-build-and-unit-test.yml
@@ -3,20 +3,22 @@ name: prestocpp-linux-build-and-unit-test
 on:
   workflow_dispatch:
   pull_request:
+    branches: [release-0.293-clp-connector]
     paths:
       - 'presto-native-execution/**'
       - 'presto-native-sidecar-plugin/**'
       - '.github/workflows/prestocpp-linux-build-and-unit-test.yml'
   push:
+    branches: [release-0.293-clp-connector]
     paths-ignore:
       - 'presto-docs/**'
 
 concurrency:
   group: "${{github.workflow}}-${{github.ref}}"
 
-  # Cancel in-progress jobs for efficiency. Exclude the `main` branch so that each commit to main is
-  # checked completely.
-  cancel-in-progress: "${{github.ref != 'refs/heads/main'}}"
+  # Cancel in-progress jobs for efficiency. Exclude the `release-0.293-clp-connector` branch so
+  # that each commit to release-0.293-clp-connector is checked completely.
+  cancel-in-progress: "${{github.ref != 'refs/heads/release-0.293-clp-connector'}}"
 
 jobs:
   prestocpp-linux-build-for-test:

--- a/.github/workflows/prestocpp-linux-build.yml
+++ b/.github/workflows/prestocpp-linux-build.yml
@@ -3,6 +3,7 @@ name: prestocpp-linux-build
 on:
   workflow_dispatch:
   pull_request:
+    branches: [release-0.293-clp-connector]
     paths:
       - 'presto-native-execution/**'
       - '.github/workflows/prestocpp-linux-build.yml'
@@ -28,6 +29,7 @@ on:
       # tpch
       - 'presto-tpch/src/main/java/com/facebook/presto/tpch/**'
   push:
+    branches: [release-0.293-clp-connector]
     paths:
       - 'presto-native-execution/**'
       - '.github/workflows/prestocpp-linux-build.yml'
@@ -56,9 +58,9 @@ on:
 concurrency:
   group: "${{github.workflow}}-${{github.ref}}"
 
-  # Cancel in-progress jobs for efficiency. Exclude the `main` branch so that each commit to main is
-  # checked completely.
-  cancel-in-progress: "${{github.ref != 'refs/heads/main'}}"
+  # Cancel in-progress jobs for efficiency. Exclude the `release-0.293-clp-connector` branch so
+  # that each commit to release-0.293-clp-connector is checked completely.
+  cancel-in-progress: "${{github.ref != 'refs/heads/release-0.293-clp-connector'}}"
 
 jobs:
   prestocpp-linux-build-engine:

--- a/.github/workflows/product-tests-basic-environment.yml
+++ b/.github/workflows/product-tests-basic-environment.yml
@@ -2,7 +2,9 @@ name: product tests (basic)
 
 on:
   pull_request:
+    branches: [release-0.293-clp-connector]
   push:
+    branches: [release-0.293-clp-connector]
 
 env:
   # An envar that signals to tests we are executing in the CI environment
@@ -15,9 +17,9 @@ env:
 concurrency:
   group: "${{github.workflow}}-${{github.ref}}"
 
-  # Cancel in-progress jobs for efficiency. Exclude the `main` branch so that each commit to main is
-  # checked completely.
-  cancel-in-progress: "${{github.ref != 'refs/heads/main'}}"
+  # Cancel in-progress jobs for efficiency. Exclude the `release-0.293-clp-connector` branch so
+  # that each commit to release-0.293-clp-connector is checked completely.
+  cancel-in-progress: "${{github.ref != 'refs/heads/release-0.293-clp-connector'}}"
 
 jobs:
   changes:

--- a/.github/workflows/product-tests-specific-environment.yml
+++ b/.github/workflows/product-tests-specific-environment.yml
@@ -2,7 +2,9 @@ name: ci
 
 on:
   pull_request:
+    branches: [release-0.293-clp-connector]
   push:
+    branches: [release-0.293-clp-connector]
 
 env:
   # An envar that signals to tests we are executing in the CI environment
@@ -15,9 +17,9 @@ env:
 concurrency:
   group: "${{github.workflow}}-${{github.ref}}"
 
-  # Cancel in-progress jobs for efficiency. Exclude the `main` branch so that each commit to main is
-  # checked completely.
-  cancel-in-progress: "${{github.ref != 'refs/heads/main'}}"
+  # Cancel in-progress jobs for efficiency. Exclude the `release-0.293-clp-connector` branch so
+  # that each commit to release-0.293-clp-connector is checked completely.
+  cancel-in-progress: "${{github.ref != 'refs/heads/release-0.293-clp-connector'}}"
 
 jobs:
   changes:

--- a/.github/workflows/singlestore-tests.yml
+++ b/.github/workflows/singlestore-tests.yml
@@ -2,7 +2,9 @@ name: singlestore tests
 
 on:
   pull_request:
+    branches: [release-0.293-clp-connector]
   push:
+    branches: [release-0.293-clp-connector]
 
 env:
   # An envar that signals to tests we are executing in the CI environment
@@ -16,9 +18,9 @@ env:
 concurrency:
   group: "${{github.workflow}}-${{github.ref}}"
 
-  # Cancel in-progress jobs for efficiency. Exclude the `main` branch so that each commit to main is
-  # checked completely.
-  cancel-in-progress: "${{github.ref != 'refs/heads/main'}}"
+  # Cancel in-progress jobs for efficiency. Exclude the `release-0.293-clp-connector` branch so
+  # that each commit to release-0.293-clp-connector is checked completely.
+  cancel-in-progress: "${{github.ref != 'refs/heads/release-0.293-clp-connector'}}"
 
 jobs:
   changes:

--- a/.github/workflows/spark-integration.yml
+++ b/.github/workflows/spark-integration.yml
@@ -2,7 +2,9 @@ name: spark integration
 
 on:
   pull_request:
+    branches: [release-0.293-clp-connector]
   push:
+    branches: [release-0.293-clp-connector]
 
 env:
   # An envar that signals to tests we are executing in the CI environment
@@ -16,9 +18,9 @@ env:
 concurrency:
   group: "${{github.workflow}}-${{github.ref}}"
 
-  # Cancel in-progress jobs for efficiency. Exclude the `main` branch so that each commit to main is
-  # checked completely.
-  cancel-in-progress: "${{github.ref != 'refs/heads/main'}}"
+  # Cancel in-progress jobs for efficiency. Exclude the `release-0.293-clp-connector` branch so
+  # that each commit to release-0.293-clp-connector is checked completely.
+  cancel-in-progress: "${{github.ref != 'refs/heads/release-0.293-clp-connector'}}"
 
 jobs:
   changes:

--- a/.github/workflows/test-other-modules.yml
+++ b/.github/workflows/test-other-modules.yml
@@ -2,7 +2,9 @@ name: test other modules
 
 on:
   pull_request:
+    branches: [release-0.293-clp-connector]
   push:
+    branches: [release-0.293-clp-connector]
 
 env:
   # An envar that signals to tests we are executing in the CI environment
@@ -16,9 +18,9 @@ env:
 concurrency:
   group: "${{github.workflow}}-${{github.ref}}"
 
-  # Cancel in-progress jobs for efficiency. Exclude the `main` branch so that each commit to main is
-  # checked completely.
-  cancel-in-progress: "${{github.ref != 'refs/heads/main'}}"
+  # Cancel in-progress jobs for efficiency. Exclude the `release-0.293-clp-connector` branch so
+  # that each commit to release-0.293-clp-connector is checked completely.
+  cancel-in-progress: "${{github.ref != 'refs/heads/release-0.293-clp-connector'}}"
 
 jobs:
   changes:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,9 @@ name: test
 
 on:
   pull_request:
+    branches: [release-0.293-clp-connector]
   push:
+    branches: [release-0.293-clp-connector]
 
 env:
   # An envar that signals to tests we are executing in the CI environment
@@ -16,9 +18,9 @@ env:
 concurrency:
   group: "${{github.workflow}}-${{github.ref}}"
 
-  # Cancel in-progress jobs for efficiency. Exclude the `main` branch so that each commit to main is
-  # checked completely.
-  cancel-in-progress: "${{github.ref != 'refs/heads/main'}}"
+  # Cancel in-progress jobs for efficiency. Exclude the `release-0.293-clp-connector` branch so
+  # that each commit to release-0.293-clp-connector is checked completely.
+  cancel-in-progress: "${{github.ref != 'refs/heads/release-0.293-clp-connector'}}"
 
 jobs:
   changes:

--- a/.github/workflows/web-ui-checks.yml
+++ b/.github/workflows/web-ui-checks.yml
@@ -2,7 +2,9 @@ name: web ui checks
 
 on:
   pull_request:
+    branches: [release-0.293-clp-connector]
   push:
+    branches: [release-0.293-clp-connector]
 
 env:
   # An envar that signals to tests we are executing in the CI environment
@@ -12,9 +14,9 @@ env:
 concurrency:
   group: "${{github.workflow}}-${{github.ref}}"
 
-  # Cancel in-progress jobs for efficiency. Exclude the `main` branch so that each commit to main is
-  # checked completely.
-  cancel-in-progress: "${{github.ref != 'refs/heads/main'}}"
+  # Cancel in-progress jobs for efficiency. Exclude the `release-0.293-clp-connector` branch so
+  # that each commit to release-0.293-clp-connector is checked completely.
+  cancel-in-progress: "${{github.ref != 'refs/heads/release-0.293-clp-connector'}}"
 
 jobs:
   changes:


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR is to fix #7 , we should treat `release-0.293-clp-connector` as our "main" branch. Also we can limit the workflows to run only when directly pushing to `release-0.293-clp-connector` or the PR's target branch is `release-0.293-clp-connector` to avoid uncessary workflows run.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [ ] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [ ] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [ ] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* Validated the workflows succeeded in my fork.
* Validated that pushing a change while the workflows were in progress led to them being cancelled and restarted to run against the latest changes.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html