### PR TITLE
feat(presto-clp): Add a plan optimizer to push down supported filters to CLP.

### DIFF
--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpExpression.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpExpression.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.clp;
+
+import com.facebook.presto.spi.relation.RowExpression;
+
+import java.util.Optional;
+
+/**
+ * Represents the result of converting a Presto RowExpression into a CLP-compatible KQL query.
+ * There are three possible cases:
+ * 1. The entire RowExpression is convertible to KQL: `definition` is set, `remainingExpression` is empty.
+ * 2. Part of the RowExpression is convertible: the KQL part is stored in `definition`,
+ *    and the remaining untranslatable part is stored in `remainingExpression`.
+ * 3. None of the expression is convertible: the full RowExpression is stored in `remainingExpression`,
+ *    and `definition` is empty.
+ */
+public class ClpExpression
+{
+    // Optional KQL query string representing the fully or partially translatable part of the expression.
+    private final Optional<String> definition;
+
+    // The remaining (non-translatable) portion of the RowExpression, if any.
+    private final Optional<RowExpression> remainingExpression;
+
+    public ClpExpression(String definition, RowExpression remainingExpression)
+    {
+        this.definition = Optional.ofNullable(definition);
+        this.remainingExpression = Optional.ofNullable(remainingExpression);
+    }
+
+    // Creates an empty ClpExpression (no KQL definition, no remaining expression).
+    public ClpExpression()
+    {
+        this (null, null);
+    }
+
+    // Creates a ClpExpression from a fully translatable KQL string.
+    public ClpExpression(String definition)
+    {
+        this(definition, null);
+    }
+
+    // Creates a ClpExpression from a non-translatable RowExpression.
+    public ClpExpression(RowExpression remainingExpression)
+    {
+        this(null, remainingExpression);
+    }
+
+    public Optional<String> getDefinition()
+    {
+        return definition;
+    }
+
+    public Optional<RowExpression> getRemainingExpression()
+    {
+        return remainingExpression;
+    }
+}

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpExpression.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpExpression.java
@@ -40,19 +40,27 @@ public class ClpExpression
         this.remainingExpression = Optional.ofNullable(remainingExpression);
     }
 
-    // Creates an empty ClpExpression (no KQL definition, no remaining expression).
+    /**
+     * Creates an empty ClpExpression (no KQL definition, no remaining expression).
+     */
     public ClpExpression()
     {
-        this (null, null);
+        this(null, null);
     }
 
-    // Creates a ClpExpression from a fully translatable KQL string.
+    /**
+     * Creates a ClpExpression from a fully translatable KQL string.
+     * @param definition
+     */
     public ClpExpression(String definition)
     {
         this(definition, null);
     }
 
-    // Creates a ClpExpression from a non-translatable RowExpression.
+    /**
+     * Creates a ClpExpression from a non-translatable RowExpression.
+     * @param remainingExpression
+     */
     public ClpExpression(RowExpression remainingExpression)
     {
         this(null, remainingExpression);

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpExpression.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpExpression.java
@@ -24,20 +24,20 @@ import java.util.Optional;
  */
 public class ClpExpression
 {
-    // Optional KQL query string representing the fully or partially translatable part of the expression.
-    private final Optional<String> kqlQuery;
+    // Optional KQL query or column name representing the fully or partially translatable part of the expression.
+    private final Optional<String> pushDownExpression;
 
     // The remaining (non-translatable) portion of the RowExpression, if any.
     private final Optional<RowExpression> remainingExpression;
 
-    public ClpExpression(String kqlQuery, RowExpression remainingExpression)
+    public ClpExpression(String pushDownExpression, RowExpression remainingExpression)
     {
-        this.kqlQuery = Optional.ofNullable(kqlQuery);
+        this.pushDownExpression = Optional.ofNullable(pushDownExpression);
         this.remainingExpression = Optional.ofNullable(remainingExpression);
     }
 
     /**
-     * Creates an empty ClpExpression (no KQL definition, no remaining expression).
+     * Creates an empty ClpExpression with neither pushdown nor remaining expressions.
      */
     public ClpExpression()
     {
@@ -45,13 +45,13 @@ public class ClpExpression
     }
 
     /**
-     * Creates a ClpExpression from a fully translatable KQL string.
+     * Creates a ClpExpression from a fully translatable KQL query or column name.
      *
-     * @param kqlQuery
+     * @param pushDownExpression
      */
-    public ClpExpression(String kqlQuery)
+    public ClpExpression(String pushDownExpression)
     {
-        this(kqlQuery, null);
+        this(pushDownExpression, null);
     }
 
     /**
@@ -64,9 +64,9 @@ public class ClpExpression
         this(null, remainingExpression);
     }
 
-    public Optional<String> getKqlQuery()
+    public Optional<String> getPushDownExpression()
     {
-        return kqlQuery;
+        return pushDownExpression;
     }
 
     public Optional<RowExpression> getRemainingExpression()

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpExpression.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpExpression.java
@@ -18,25 +18,21 @@ import com.facebook.presto.spi.relation.RowExpression;
 import java.util.Optional;
 
 /**
- * Represents the result of converting a Presto RowExpression into a CLP-compatible KQL query.
- * There are three possible cases:
- * 1. The entire RowExpression is convertible to KQL: `definition` is set, `remainingExpression` is empty.
- * 2. Part of the RowExpression is convertible: the KQL part is stored in `definition`,
- *    and the remaining untranslatable part is stored in `remainingExpression`.
- * 3. None of the expression is convertible: the full RowExpression is stored in `remainingExpression`,
- *    and `definition` is empty.
+ * Represents the result of converting a Presto RowExpression into a CLP-compatible KQL query. In
+ * every case, `kqlQuery` represents the part of the RowExpression that could be converted to a
+ * KQL expression, and `remainingExpression` represents the part that could not be converted.
  */
 public class ClpExpression
 {
     // Optional KQL query string representing the fully or partially translatable part of the expression.
-    private final Optional<String> definition;
+    private final Optional<String> kqlQuery;
 
     // The remaining (non-translatable) portion of the RowExpression, if any.
     private final Optional<RowExpression> remainingExpression;
 
-    public ClpExpression(String definition, RowExpression remainingExpression)
+    public ClpExpression(String kqlQuery, RowExpression remainingExpression)
     {
-        this.definition = Optional.ofNullable(definition);
+        this.kqlQuery = Optional.ofNullable(kqlQuery);
         this.remainingExpression = Optional.ofNullable(remainingExpression);
     }
 
@@ -50,15 +46,17 @@ public class ClpExpression
 
     /**
      * Creates a ClpExpression from a fully translatable KQL string.
-     * @param definition
+     *
+     * @param kqlQuery
      */
-    public ClpExpression(String definition)
+    public ClpExpression(String kqlQuery)
     {
-        this(definition, null);
+        this(kqlQuery, null);
     }
 
     /**
      * Creates a ClpExpression from a non-translatable RowExpression.
+     *
      * @param remainingExpression
      */
     public ClpExpression(RowExpression remainingExpression)
@@ -66,9 +64,9 @@ public class ClpExpression
         this(null, remainingExpression);
     }
 
-    public Optional<String> getDefinition()
+    public Optional<String> getKqlQuery()
     {
-        return definition;
+        return kqlQuery;
     }
 
     public Optional<RowExpression> getRemainingExpression()

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpExpression.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpExpression.java
@@ -19,8 +19,9 @@ import java.util.Optional;
 
 /**
  * Represents the result of converting a Presto RowExpression into a CLP-compatible KQL query. In
- * every case, `kqlQuery` represents the part of the RowExpression that could be converted to a
- * KQL expression, and `remainingExpression` represents the part that could not be converted.
+ * every case, `pushDownExpression` represents the part of the RowExpression that could be
+ * converted to a KQL expression, and `remainingExpression` represents the part that could not be
+ * converted.
  */
 public class ClpExpression
 {

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpFilterToKqlConverter.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpFilterToKqlConverter.java
@@ -1,0 +1,679 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.clp;
+
+import com.facebook.presto.common.function.OperatorType;
+import com.facebook.presto.common.type.RowType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.VarcharType;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.function.FunctionHandle;
+import com.facebook.presto.spi.function.FunctionMetadata;
+import com.facebook.presto.spi.function.FunctionMetadataManager;
+import com.facebook.presto.spi.function.StandardFunctionResolution;
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.RowExpressionVisitor;
+import com.facebook.presto.spi.relation.SpecialFormExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.google.common.collect.ImmutableSet;
+import io.airlift.slice.Slice;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.facebook.presto.common.function.OperatorType.EQUAL;
+import static com.facebook.presto.common.function.OperatorType.GREATER_THAN;
+import static com.facebook.presto.common.function.OperatorType.GREATER_THAN_OR_EQUAL;
+import static com.facebook.presto.common.function.OperatorType.LESS_THAN;
+import static com.facebook.presto.common.function.OperatorType.LESS_THAN_OR_EQUAL;
+import static com.facebook.presto.common.function.OperatorType.NOT_EQUAL;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.plugin.clp.ClpErrorCode.CLP_PUSHDOWN_UNSUPPORTED_EXPRESSION;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.AND;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * ClpFilterToKqlConverter translates Presto RowExpressions into KQL (Kibana Query Language) filters
+ * used as CLP queries. This is used primarily for pushing down supported filters to the CLP engine.
+ * This class implements the RowExpressionVisitor interface and recursively walks Presto filter expressions,
+ * attempting to convert supported expressions (e.g., comparisons, logical AND/OR, LIKE, IN, IS NULL,
+ * and SUBSTR-based expressions) into corresponding KQL filter strings. Any part of the expression that
+ * cannot be translated is preserved as a "remaining expression" for potential fallback processing.
+ * Supported translations include:
+ * - Variable-to-literal comparisons (e.g., =, !=, <, >, <=, >=)
+ * - String pattern matches using LIKE
+ * - Membership checks using IN
+ * - NULL checks via IS NULL
+ * - Substring comparisons (e.g., SUBSTR(x, start, len) = "val") mapped to wildcard KQL queries
+ * - Dereferencing fields from row-typed variables
+ * - Logical operators AND, OR, and NOT
+ */
+public class ClpFilterToKqlConverter
+        implements RowExpressionVisitor<ClpExpression, Void>
+{
+    private static final Set<OperatorType> LOGICAL_BINARY_OPS_FILTER =
+            ImmutableSet.of(EQUAL, NOT_EQUAL, LESS_THAN, LESS_THAN_OR_EQUAL, GREATER_THAN, GREATER_THAN_OR_EQUAL);
+
+    private final StandardFunctionResolution standardFunctionResolution;
+    private final FunctionMetadataManager functionMetadataManager;
+    private final Map<VariableReferenceExpression, ColumnHandle> assignments;
+
+    public ClpFilterToKqlConverter(StandardFunctionResolution standardFunctionResolution,
+            FunctionMetadataManager functionMetadataManager,
+            Map<VariableReferenceExpression, ColumnHandle> assignments)
+    {
+        this.standardFunctionResolution = requireNonNull(standardFunctionResolution, "standardFunctionResolution is null");
+        this.functionMetadataManager = requireNonNull(functionMetadataManager, "function metadata manager is null");
+        this.assignments = requireNonNull(assignments, "assignments is null");
+    }
+
+    @Override
+    public ClpExpression visitCall(CallExpression node, Void context)
+    {
+        FunctionHandle functionHandle = node.getFunctionHandle();
+        if (standardFunctionResolution.isNotFunction(functionHandle)) {
+            return handleNot(node);
+        }
+
+        if (standardFunctionResolution.isLikeFunction(functionHandle)) {
+            return handleLike(node);
+        }
+
+        FunctionMetadata functionMetadata = functionMetadataManager.getFunctionMetadata(node.getFunctionHandle());
+        Optional<OperatorType> operatorTypeOptional = functionMetadata.getOperatorType();
+        if (operatorTypeOptional.isPresent()) {
+            OperatorType operatorType = operatorTypeOptional.get();
+            if (operatorType.isComparisonOperator() && operatorType != OperatorType.IS_DISTINCT_FROM) {
+                return handleLogicalBinary(operatorType, node);
+            }
+        }
+
+        return new ClpExpression(node);
+    }
+
+    @Override
+    public ClpExpression visitConstant(ConstantExpression node, Void context)
+    {
+        return new ClpExpression(getLiteralString(node));
+    }
+
+    @Override
+    public ClpExpression visitVariableReference(VariableReferenceExpression node, Void context)
+    {
+        return new ClpExpression(getVariableName(node));
+    }
+
+    @Override
+    public ClpExpression visitSpecialForm(SpecialFormExpression node, Void context)
+    {
+        switch (node.getForm()) {
+            case AND:
+                return handleAnd(node);
+            case OR:
+                return handleOr(node);
+            case IN:
+                return handleIn(node);
+            case IS_NULL:
+                return handleIsNull(node);
+            case DEREFERENCE:
+                return handleDereference(node);
+            default:
+                return new ClpExpression(node);
+        }
+    }
+
+    // For all other expressions, return the original expression
+    @Override
+    public ClpExpression visitExpression(RowExpression node, Void context)
+    {
+        return new ClpExpression(node);
+    }
+
+    private static String getLiteralString(ConstantExpression literal)
+    {
+        if (literal.getValue() instanceof Slice) {
+            return ((Slice) literal.getValue()).toStringUtf8();
+        }
+        return literal.toString();
+    }
+
+    private String getVariableName(VariableReferenceExpression variable)
+    {
+        return ((ClpColumnHandle) assignments.get(variable)).getOriginalColumnName();
+    }
+
+    /**
+     * Handles the logical NOT expression.
+     * Example:
+     *   Input: NOT (col1 = 5)
+     *   Output: NOT col1: 5
+     */
+    private ClpExpression handleNot(CallExpression node)
+    {
+        if (node.getArguments().size() != 1) {
+            throw new PrestoException(CLP_PUSHDOWN_UNSUPPORTED_EXPRESSION,
+                    "NOT operator must have exactly one argument. Received: " + node);
+        }
+
+        RowExpression input = node.getArguments().get(0);
+        ClpExpression expression = input.accept(this, null);
+        if (expression.getRemainingExpression().isPresent() || !expression.getDefinition().isPresent()) {
+            return new ClpExpression(node);
+        }
+        return new ClpExpression("NOT " + expression.getDefinition().get());
+    }
+
+    /**
+     * Handles the logical AND expression.
+     * Combines all definable child expressions into a single KQL query joined by AND.
+     * Any unsupported children are collected into remaining expressions.
+     * Example:
+     *   Input: col1 = 5 AND col2 = 'abc'
+     *   Output: (col1: 5 AND col2: "abc")
+     */
+    private ClpExpression handleAnd(SpecialFormExpression node)
+    {
+        StringBuilder queryBuilder = new StringBuilder();
+        queryBuilder.append("(");
+        ArrayList<RowExpression> remainingExpressions = new ArrayList<>();
+        boolean hasDefinition = false;
+        for (RowExpression argument : node.getArguments()) {
+            ClpExpression expression = argument.accept(this, null);
+            if (expression.getDefinition().isPresent()) {
+                hasDefinition = true;
+                queryBuilder.append(expression.getDefinition().get());
+                queryBuilder.append(" AND ");
+            }
+            if (expression.getRemainingExpression().isPresent()) {
+                remainingExpressions.add(expression.getRemainingExpression().get());
+            }
+        }
+        if (!hasDefinition) {
+            return new ClpExpression(node);
+        }
+        else if (!remainingExpressions.isEmpty()) {
+            if (remainingExpressions.size() == 1) {
+                return new ClpExpression(queryBuilder.substring(0, queryBuilder.length() - 5) + ")", remainingExpressions.get(0));
+            }
+            else {
+                return new ClpExpression(
+                        queryBuilder.substring(0, queryBuilder.length() - 5) + ")",
+                        new SpecialFormExpression(node.getSourceLocation(), AND, BOOLEAN, remainingExpressions));
+            }
+        }
+        // Remove the last " AND " from the query
+        return new ClpExpression(queryBuilder.substring(0, queryBuilder.length() - 5) + ")");
+    }
+
+    /**
+     * Handles the logical OR expression.
+     * Combines all fully convertible child expressions into a single CLP query joined by OR.
+     * Returns the original node if any child is unsupported.
+     * Example:
+     *   Input: col1 = 5 OR col1 = 10
+     *   Output: (col1: 5 OR col1: 10)
+     */
+    private ClpExpression handleOr(SpecialFormExpression node)
+    {
+        StringBuilder queryBuilder = new StringBuilder();
+        queryBuilder.append("(");
+        for (RowExpression argument : node.getArguments()) {
+            ClpExpression expression = argument.accept(this, null);
+            if (expression.getRemainingExpression().isPresent() || !expression.getDefinition().isPresent()) {
+                return new ClpExpression(node);
+            }
+            queryBuilder.append(expression.getDefinition().get());
+            queryBuilder.append(" OR ");
+        }
+        // Remove the last " OR " from the query
+        return new ClpExpression(queryBuilder.substring(0, queryBuilder.length() - 4) + ")");
+    }
+
+    /**
+     * Handles the IN predicate.
+     * Example:
+     *   Input: col1 IN (1, 2, 3)
+     *   Output: (col1: 1 OR col1: 2 OR col1: 3)
+     */
+    private ClpExpression handleIn(SpecialFormExpression node)
+    {
+        ClpExpression variable = node.getArguments().get(0).accept(this, null);
+        if (!variable.getDefinition().isPresent()) {
+            return new ClpExpression(node);
+        }
+        String variableName = variable.getDefinition().get();
+        StringBuilder queryBuilder = new StringBuilder();
+        queryBuilder.append("(");
+        for (RowExpression argument : node.getArguments().subList(1, node.getArguments().size())) {
+            if (!(argument instanceof ConstantExpression)) {
+                return new ClpExpression(node);
+            }
+            ConstantExpression literal = (ConstantExpression) argument;
+            String literalString = getLiteralString(literal);
+            queryBuilder.append(variableName).append(": ");
+            if (literal.getType() instanceof VarcharType) {
+                queryBuilder.append("\"").append(literalString).append("\"");
+            }
+            else {
+                queryBuilder.append(literalString);
+            }
+            queryBuilder.append(" OR ");
+        }
+        // Remove the last " OR " from the query
+        return new ClpExpression(queryBuilder.substring(0, queryBuilder.length() - 4) + ")");
+    }
+
+    /**
+     * Handles the IS NULL predicate.
+     * Example:
+     *   Input: col1 IS NULL
+     *   Output: NOT col1: *
+     */
+    private ClpExpression handleIsNull(SpecialFormExpression node)
+    {
+        if (node.getArguments().size() != 1) {
+            throw new PrestoException(CLP_PUSHDOWN_UNSUPPORTED_EXPRESSION,
+                    "IS NULL operator must have exactly one argument. Received: " + node);
+        }
+
+        ClpExpression expression = node.getArguments().get(0).accept(this, null);
+        if (!expression.getDefinition().isPresent()) {
+            return new ClpExpression(node);
+        }
+
+        String variableName = expression.getDefinition().get();
+        return new ClpExpression(String.format("NOT %s: *", variableName));
+    }
+
+    /**
+     * Handles dereference expressions on RowTypes (e.g., col.row_field).
+     * Converts row dereferences into dot-separated field access.
+     * Example:
+     *   Input: address.city (from a RowType 'address')
+     *   Output: address.city
+     */
+    private ClpExpression handleDereference(RowExpression expression)
+    {
+        if (expression instanceof VariableReferenceExpression) {
+            return expression.accept(this, null);
+        }
+
+        if (!(expression instanceof SpecialFormExpression)) {
+            return new ClpExpression(expression);
+        }
+
+        SpecialFormExpression specialForm = (SpecialFormExpression) expression;
+        List<RowExpression> arguments = specialForm.getArguments();
+        if (arguments.size() != 2) {
+            throw new PrestoException(CLP_PUSHDOWN_UNSUPPORTED_EXPRESSION, "DEREFERENCE expects 2 arguments");
+        }
+
+        RowExpression base = arguments.get(0);
+        RowExpression index = arguments.get(1);
+        if (!(index instanceof ConstantExpression)) {
+            throw new PrestoException(CLP_PUSHDOWN_UNSUPPORTED_EXPRESSION, "DEREFERENCE index must be a constant");
+        }
+
+        ConstantExpression constExpr = (ConstantExpression) index;
+        Object value = constExpr.getValue();
+        if (!(value instanceof Long)) {
+            throw new PrestoException(CLP_PUSHDOWN_UNSUPPORTED_EXPRESSION, "DEREFERENCE index constant is not a long");
+        }
+
+        int fieldIndex = ((Long) value).intValue();
+
+        Type baseType = base.getType();
+        if (!(baseType instanceof RowType)) {
+            throw new PrestoException(CLP_PUSHDOWN_UNSUPPORTED_EXPRESSION, "DEREFERENCE base is not a RowType: " + baseType);
+        }
+
+        RowType rowType = (RowType) baseType;
+        if (fieldIndex < 0 || fieldIndex >= rowType.getFields().size()) {
+            throw new PrestoException(CLP_PUSHDOWN_UNSUPPORTED_EXPRESSION, "Invalid field index " + fieldIndex + " for RowType: " + rowType);
+        }
+
+        RowType.Field field = rowType.getFields().get(fieldIndex);
+        String fieldName = field.getName().orElse("field" + fieldIndex);
+
+        ClpExpression baseString = handleDereference(base);
+        if (!baseString.getDefinition().isPresent()) {
+            return new ClpExpression(expression);
+        }
+        return new ClpExpression(baseString.getDefinition().get() + "." + fieldName);
+    }
+
+    /**
+     * Handles LIKE expressions.
+     * Transforms SQL LIKE into KQL queries using wildcards (* and ?).
+     * Supports constant patterns or constant casts only.
+     * Example:
+     *   Input: col1 LIKE 'a_bc%'
+     *   Output: col1: "a?bc*"
+     */
+    private ClpExpression handleLike(CallExpression node)
+    {
+        if (node.getArguments().size() != 2) {
+            throw new PrestoException(CLP_PUSHDOWN_UNSUPPORTED_EXPRESSION, "LIKE operator must have exactly two arguments. Received: " + node);
+        }
+        ClpExpression variable = node.getArguments().get(0).accept(this, null);
+        if (!variable.getDefinition().isPresent()) {
+            return new ClpExpression(node);
+        }
+
+        String variableName = variable.getDefinition().get();
+        RowExpression argument = node.getArguments().get(1);
+
+        String pattern;
+        if (argument instanceof ConstantExpression) {
+            ConstantExpression literal = (ConstantExpression) argument;
+            pattern = getLiteralString(literal);
+        }
+        else if (argument instanceof CallExpression) {
+            CallExpression callExpression = (CallExpression) argument;
+            if (!standardFunctionResolution.isCastFunction(callExpression.getFunctionHandle())) {
+                return new ClpExpression(node);
+            }
+            if (callExpression.getArguments().size() != 1) {
+                throw new PrestoException(CLP_PUSHDOWN_UNSUPPORTED_EXPRESSION, "CAST function must have exactly one argument. Received: " + callExpression);
+            }
+            if (!(callExpression.getArguments().get(0) instanceof ConstantExpression)) {
+                return new ClpExpression(node);
+            }
+            pattern = getLiteralString((ConstantExpression) callExpression.getArguments().get(0));
+        }
+        else {
+            return new ClpExpression(node);
+        }
+        pattern = pattern.replace("%", "*").replace("_", "?");
+        return new ClpExpression(String.format("%s: \"%s\"", variableName, pattern));
+    }
+
+    private static class SubstrInfo
+    {
+        String variableName;
+        RowExpression startExpression;
+        RowExpression lengthExpression;
+        SubstrInfo(String variableName, RowExpression start, RowExpression length)
+        {
+            this.variableName = variableName;
+            this.startExpression = start;
+            this.lengthExpression = length;
+        }
+    }
+
+    /**
+     * Parse SUBSTR(...) calls that appear either as:
+     *   SUBSTR(x, start)
+     * or
+     *   SUBSTR(x, start, length)
+     */
+    private Optional<SubstrInfo> parseSubstringCall(CallExpression callExpression)
+    {
+        FunctionMetadata functionMetadata = functionMetadataManager.getFunctionMetadata(callExpression.getFunctionHandle());
+        String functionName = functionMetadata.getName().getObjectName();
+        if (!functionName.equals("substr")) {
+            return Optional.empty();
+        }
+
+        int argCount = callExpression.getArguments().size();
+        if (argCount < 2 || argCount > 3) {
+            return Optional.empty();
+        }
+
+        ClpExpression variable = callExpression.getArguments().get(0).accept(this, null);
+        if (!variable.getDefinition().isPresent()) {
+            return Optional.empty();
+        }
+
+        String varName = variable.getDefinition().get();
+        RowExpression startExpression = callExpression.getArguments().get(1);
+        RowExpression lengthExpression = null;
+        if (argCount == 3) {
+            lengthExpression = callExpression.getArguments().get(2);
+        }
+
+        return Optional.of(new SubstrInfo(varName, startExpression, lengthExpression));
+    }
+
+    /**
+     * Attempt to parse "start" or "length" as an integer.
+     */
+    private Optional<Integer> parseIntValue(RowExpression expression)
+    {
+        if (expression instanceof ConstantExpression) {
+            try {
+                return Optional.of(Integer.parseInt(getLiteralString((ConstantExpression) expression)));
+            }
+            catch (NumberFormatException ignored) { }
+        }
+        else if (expression instanceof CallExpression) {
+            CallExpression call = (CallExpression) expression;
+            FunctionMetadata functionMetadata = functionMetadataManager.getFunctionMetadata(call.getFunctionHandle());
+            Optional<OperatorType> operatorTypeOptional = functionMetadata.getOperatorType();
+            if (operatorTypeOptional.isPresent() && operatorTypeOptional.get().equals(OperatorType.NEGATION)) {
+                RowExpression arg0 = call.getArguments().get(0);
+                if (arg0 instanceof ConstantExpression) {
+                    try {
+                        return Optional.of(-Integer.parseInt(getLiteralString((ConstantExpression) arg0)));
+                    }
+                    catch (NumberFormatException ignored) { }
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * If lengthExpression is a constant integer that matches targetString.length(),
+     * return that length. Otherwise empty.
+     */
+    private Optional<Integer> parseLengthLiteralOrFunction(RowExpression lengthExpression, String targetString)
+    {
+        if (lengthExpression instanceof ConstantExpression) {
+            String val = getLiteralString((ConstantExpression) lengthExpression);
+            try {
+                int parsed = Integer.parseInt(val);
+                if (parsed == targetString.length()) {
+                    return Optional.of(parsed);
+                }
+            }
+            catch (NumberFormatException ignored) { }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Translate SUBSTR(x, start) or SUBSTR(x, start, length) = 'someString' to KQL.
+     * Examples:
+     *   SUBSTR(message, 1, 3) = 'abc'
+     *     → message: "abc*"
+     *   SUBSTR(message, 4, 3) = 'abc'
+     *     → message: "???abc*"
+     *   SUBSTR(message, 2) = 'hello'
+     *     → message: "?hello"
+     *   SUBSTR(message, -5) = 'hello'
+     *     → message: "*hello"
+     */
+    private ClpExpression interpretSubstringEquality(SubstrInfo info, String targetString)
+    {
+        if (info.lengthExpression != null) {
+            Optional<Integer> maybeStart = parseIntValue(info.startExpression);
+            Optional<Integer> maybeLen = parseLengthLiteralOrFunction(info.lengthExpression, targetString);
+
+            if (maybeStart.isPresent() && maybeLen.isPresent()) {
+                int start = maybeStart.get();
+                int len = maybeLen.get();
+                if (start > 0 && len == targetString.length()) {
+                    StringBuilder result = new StringBuilder();
+                    result.append(info.variableName).append(": \"");
+                    for (int i = 1; i < start; i++) {
+                        result.append("?");
+                    }
+                    result.append(targetString).append("*\"");
+                    return new ClpExpression(result.toString());
+                }
+            }
+        }
+        else {
+            Optional<Integer> maybeStart = parseIntValue(info.startExpression);
+            if (maybeStart.isPresent()) {
+                int start = maybeStart.get();
+                if (start > 0) {
+                    StringBuilder result = new StringBuilder();
+                    result.append(info.variableName).append(": \"");
+                    for (int i = 1; i < start; i++) {
+                        result.append("?");
+                    }
+                    result.append(targetString).append("\"");
+                    return new ClpExpression(result.toString());
+                }
+                if (start == -targetString.length()) {
+                    return new ClpExpression(String.format("%s: \"*%s\"", info.variableName, targetString));
+                }
+            }
+        }
+
+        return new ClpExpression();
+    }
+
+    /**
+     * Checks whether the given expression matches the pattern SUBSTR(x, ...) = 'someString',
+     * and if so, attempts to convert it into a KQL query using wildcards and construct a CLP expression.
+     */
+    private ClpExpression tryInterpretSubstringEquality(
+            OperatorType operator,
+            RowExpression possibleSubstring,
+            RowExpression possibleLiteral)
+    {
+        if (!operator.equals(OperatorType.EQUAL)) {
+            return new ClpExpression();
+        }
+
+        if (!(possibleSubstring instanceof CallExpression) ||
+                !(possibleLiteral instanceof ConstantExpression)) {
+            return new ClpExpression();
+        }
+
+        Optional<SubstrInfo> maybeSubstringCall = parseSubstringCall((CallExpression) possibleSubstring);
+        if (!maybeSubstringCall.isPresent()) {
+            return new ClpExpression();
+        }
+
+        String targetString = getLiteralString((ConstantExpression) possibleLiteral);
+        return interpretSubstringEquality(maybeSubstringCall.get(), targetString);
+    }
+
+    /**
+     * Builds a CLP expression from a basic comparison between a variable and a literal.
+     * Handles different operator types (EQUAL, NOT_EQUAL, and logical binary ops like <, >, etc.)
+     * and formats them appropriately based on whether the literal is a string or a non-string type.
+     * Examples:
+     *   col = 'abc'       → col: "abc"
+     *   col != 42         → NOT col: 42
+     *   5 < col           → col > 5
+     */
+    private ClpExpression buildClpExpression(
+            String variableName,
+            String literalString,
+            OperatorType operator,
+            Type literalType,
+            RowExpression originalNode)
+    {
+        if (operator.equals(OperatorType.EQUAL)) {
+            if (literalType instanceof VarcharType) {
+                return new ClpExpression(String.format("%s: \"%s\"", variableName, literalString));
+            }
+            else {
+                return new ClpExpression(String.format("%s: %s", variableName, literalString));
+            }
+        }
+        else if (operator.equals(OperatorType.NOT_EQUAL)) {
+            if (literalType instanceof VarcharType) {
+                return new ClpExpression(String.format("NOT %s: \"%s\"", variableName, literalString));
+            }
+            else {
+                return new ClpExpression(String.format("NOT %s: %s", variableName, literalString));
+            }
+        }
+        else if (LOGICAL_BINARY_OPS_FILTER.contains(operator) && !(literalType instanceof VarcharType)) {
+            return new ClpExpression(String.format("%s %s %s", variableName, operator.getOperator(), literalString));
+        }
+        return new ClpExpression(originalNode);
+    }
+
+    /**
+     * Handles logical binary operators (e.g., =, !=, <, >) between two expressions.
+     * Supports constant on either side by flipping the operator when needed.
+     * Also checks for SUBSTR(x, ...) = 'value' patterns and delegates to substring handler.
+     */
+    private ClpExpression handleLogicalBinary(OperatorType operator, CallExpression node)
+    {
+        if (node.getArguments().size() != 2) {
+            throw new PrestoException(CLP_PUSHDOWN_UNSUPPORTED_EXPRESSION,
+                    "Logical binary operator must have exactly two arguments. Received: " + node);
+        }
+        RowExpression left = node.getArguments().get(0);
+        RowExpression right = node.getArguments().get(1);
+
+        ClpExpression maybeLeftSubstring = tryInterpretSubstringEquality(operator, left, right);
+        if (maybeLeftSubstring.getDefinition().isPresent()) {
+            return maybeLeftSubstring;
+        }
+
+        ClpExpression maybeRightSubstring = tryInterpretSubstringEquality(operator, right, left);
+        if (maybeRightSubstring.getDefinition().isPresent()) {
+            return maybeRightSubstring;
+        }
+
+        ClpExpression leftExpression = left.accept(this, null);
+        ClpExpression rightExpression = right.accept(this, null);
+        Optional<String> leftDefinition = leftExpression.getDefinition();
+        Optional<String> rightDefinition = rightExpression.getDefinition();
+        if (!leftDefinition.isPresent() || !rightDefinition.isPresent()) {
+            return new ClpExpression(node);
+        }
+
+        boolean leftIsConstant = (left instanceof ConstantExpression);
+        boolean rightIsConstant = (right instanceof ConstantExpression);
+
+        Type leftType = left.getType();
+        Type rightType = right.getType();
+
+        if (rightIsConstant) {
+            return buildClpExpression(
+                    leftDefinition.get(),    // variable
+                    rightDefinition.get(),   // literal
+                    operator,
+                    rightType,
+                    node);
+        }
+        else if (leftIsConstant) {
+            OperatorType newOperator = OperatorType.flip(operator);
+            return buildClpExpression(
+                    rightDefinition.get(),   // variable
+                    leftDefinition.get(),    // literal
+                    newOperator,
+                    leftType,
+                    node);
+        }
+        // fallback
+        return new ClpExpression(node);
+    }
+}

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpPlanOptimizer.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpPlanOptimizer.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.clp;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorPlanOptimizer;
+import com.facebook.presto.spi.ConnectorPlanRewriter;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.TableHandle;
+import com.facebook.presto.spi.VariableAllocator;
+import com.facebook.presto.spi.function.FunctionMetadataManager;
+import com.facebook.presto.spi.function.StandardFunctionResolution;
+import com.facebook.presto.spi.plan.FilterNode;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
+import com.facebook.presto.spi.plan.TableScanNode;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.spi.ConnectorPlanRewriter.rewriteWith;
+import static java.util.Objects.requireNonNull;
+
+public class ClpPlanOptimizer
+        implements ConnectorPlanOptimizer
+{
+    private static final Logger log = Logger.get(ClpPlanOptimizer.class);
+    private final FunctionMetadataManager functionManager;
+    private final StandardFunctionResolution functionResolution;
+
+    public ClpPlanOptimizer(FunctionMetadataManager functionManager,
+            StandardFunctionResolution functionResolution)
+    {
+        this.functionManager = requireNonNull(functionManager, "functionManager is null");
+        this.functionResolution = requireNonNull(functionResolution, "functionResolution is null");
+    }
+
+    @Override
+    public PlanNode optimize(PlanNode maxSubplan,
+            ConnectorSession session,
+            VariableAllocator variableAllocator,
+            PlanNodeIdAllocator idAllocator)
+    {
+        return rewriteWith(new Rewriter(idAllocator), maxSubplan);
+    }
+
+    private class Rewriter
+            extends ConnectorPlanRewriter<Void>
+    {
+        private final PlanNodeIdAllocator idAllocator;
+
+        public Rewriter(PlanNodeIdAllocator idAllocator)
+        {
+            this.idAllocator = idAllocator;
+        }
+
+        @Override
+        public PlanNode visitFilter(FilterNode node, RewriteContext<Void> context)
+        {
+            if (!(node.getSource() instanceof TableScanNode)) {
+                return node;
+            }
+
+            TableScanNode tableScanNode = (TableScanNode) node.getSource();
+            Map<VariableReferenceExpression, ColumnHandle> assignments = tableScanNode.getAssignments();
+            TableHandle tableHandle = tableScanNode.getTable();
+            ClpTableHandle clpTableHandle = (ClpTableHandle) tableHandle.getConnectorHandle();
+            ClpExpression clpExpression = node.getPredicate()
+                    .accept(new ClpFilterToKqlConverter(functionResolution, functionManager, assignments), null);
+            Optional<String> kqlQuery = clpExpression.getDefinition();
+            Optional<RowExpression> remainingPredicate = clpExpression.getRemainingExpression();
+            if (!kqlQuery.isPresent()) {
+                return node;
+            }
+            log.debug("KQL query: %s", kqlQuery.get());
+            ClpTableLayoutHandle clpTableLayoutHandle = new ClpTableLayoutHandle(clpTableHandle, kqlQuery);
+            TableScanNode newTableScanNode = new TableScanNode(
+                    tableScanNode.getSourceLocation(),
+                    idAllocator.getNextId(),
+                    new TableHandle(
+                            tableHandle.getConnectorId(),
+                            clpTableHandle,
+                            tableHandle.getTransaction(),
+                            Optional.of(clpTableLayoutHandle)),
+                    tableScanNode.getOutputVariables(),
+                    tableScanNode.getAssignments(),
+                    tableScanNode.getTableConstraints(),
+                    tableScanNode.getCurrentConstraint(),
+                    tableScanNode.getEnforcedConstraint(),
+                    tableScanNode.getCteMaterializationInfo());
+            if (!remainingPredicate.isPresent()) {
+                return newTableScanNode;
+            }
+
+            return new FilterNode(node.getSourceLocation(),
+                    idAllocator.getNextId(),
+                    newTableScanNode,
+                    remainingPredicate.get());
+        }
+    }
+}

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpPlanOptimizer.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpPlanOptimizer.java
@@ -77,7 +77,7 @@ public class ClpPlanOptimizer
             ClpTableHandle clpTableHandle = (ClpTableHandle) tableHandle.getConnectorHandle();
             ClpExpression clpExpression = node.getPredicate()
                     .accept(new ClpFilterToKqlConverter(functionResolution, functionManager, assignments), null);
-            Optional<String> kqlQuery = clpExpression.getKqlQuery();
+            Optional<String> kqlQuery = clpExpression.getPushDownExpression();
             Optional<RowExpression> remainingPredicate = clpExpression.getRemainingExpression();
             if (!kqlQuery.isPresent()) {
                 return node;

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpPlanOptimizer.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpPlanOptimizer.java
@@ -42,18 +42,14 @@ public class ClpPlanOptimizer
     private final FunctionMetadataManager functionManager;
     private final StandardFunctionResolution functionResolution;
 
-    public ClpPlanOptimizer(FunctionMetadataManager functionManager,
-            StandardFunctionResolution functionResolution)
+    public ClpPlanOptimizer(FunctionMetadataManager functionManager, StandardFunctionResolution functionResolution)
     {
         this.functionManager = requireNonNull(functionManager, "functionManager is null");
         this.functionResolution = requireNonNull(functionResolution, "functionResolution is null");
     }
 
     @Override
-    public PlanNode optimize(PlanNode maxSubplan,
-            ConnectorSession session,
-            VariableAllocator variableAllocator,
-            PlanNodeIdAllocator idAllocator)
+    public PlanNode optimize(PlanNode maxSubplan, ConnectorSession session, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator)
     {
         return rewriteWith(new Rewriter(idAllocator), maxSubplan);
     }
@@ -81,7 +77,7 @@ public class ClpPlanOptimizer
             ClpTableHandle clpTableHandle = (ClpTableHandle) tableHandle.getConnectorHandle();
             ClpExpression clpExpression = node.getPredicate()
                     .accept(new ClpFilterToKqlConverter(functionResolution, functionManager, assignments), null);
-            Optional<String> kqlQuery = clpExpression.getDefinition();
+            Optional<String> kqlQuery = clpExpression.getKqlQuery();
             Optional<RowExpression> remainingPredicate = clpExpression.getRemainingExpression();
             if (!kqlQuery.isPresent()) {
                 return node;

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpPlanOptimizerProvider.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpPlanOptimizerProvider.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.clp;
+
+import com.facebook.presto.spi.ConnectorPlanOptimizer;
+import com.facebook.presto.spi.connector.ConnectorPlanOptimizerProvider;
+import com.facebook.presto.spi.function.FunctionMetadataManager;
+import com.facebook.presto.spi.function.StandardFunctionResolution;
+import com.google.common.collect.ImmutableSet;
+
+import javax.inject.Inject;
+
+import java.util.Set;
+
+public class ClpPlanOptimizerProvider
+        implements ConnectorPlanOptimizerProvider
+{
+    private final FunctionMetadataManager functionManager;
+    private final StandardFunctionResolution functionResolution;
+
+    @Inject
+    public ClpPlanOptimizerProvider(FunctionMetadataManager functionManager,
+            StandardFunctionResolution functionResolution)
+    {
+        this.functionManager = functionManager;
+        this.functionResolution = functionResolution;
+    }
+
+    @Override
+    public Set<ConnectorPlanOptimizer> getLogicalPlanOptimizers()
+    {
+        return ImmutableSet.of();
+    }
+
+    @Override
+    public Set<ConnectorPlanOptimizer> getPhysicalPlanOptimizers()
+    {
+        return ImmutableSet.of(new ClpPlanOptimizer(functionManager, functionResolution));
+    }
+}

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpPlanOptimizerProvider.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpPlanOptimizerProvider.java
@@ -30,8 +30,7 @@ public class ClpPlanOptimizerProvider
     private final StandardFunctionResolution functionResolution;
 
     @Inject
-    public ClpPlanOptimizerProvider(FunctionMetadataManager functionManager,
-            StandardFunctionResolution functionResolution)
+    public ClpPlanOptimizerProvider(FunctionMetadataManager functionManager, StandardFunctionResolution functionResolution)
     {
         this.functionManager = functionManager;
         this.functionResolution = functionResolution;

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpMySqlSplitProvider.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpMySqlSplitProvider.java
@@ -38,10 +38,10 @@ public class ClpMySqlSplitProvider
     public static final String ARCHIVES_TABLE_COLUMN_ID = "id";
 
     // Table suffixes
-    public static final String ARCHIVE_TABLE_SUFFIX = "_archives";
+    public static final String ARCHIVES_TABLE_SUFFIX = "_archives";
 
     // SQL templates
-    private static final String SQL_SELECT_ARCHIVES_TEMPLATE = format("SELECT `%s` FROM `%%s%%s%s`", ARCHIVES_TABLE_COLUMN_ID, ARCHIVE_TABLE_SUFFIX);
+    private static final String SQL_SELECT_ARCHIVES_TEMPLATE = format("SELECT `%s` FROM `%%s%%s%s`", ARCHIVES_TABLE_COLUMN_ID, ARCHIVES_TABLE_SUFFIX);
 
     private static final Logger log = Logger.get(ClpMySqlSplitProvider.class);
 

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/ClpMetadataDbSetUp.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/ClpMetadataDbSetUp.java
@@ -38,7 +38,7 @@ import static com.facebook.presto.plugin.clp.metadata.ClpMySqlMetadataProvider.D
 import static com.facebook.presto.plugin.clp.metadata.ClpMySqlMetadataProvider.DATASETS_TABLE_COLUMN_NAME;
 import static com.facebook.presto.plugin.clp.metadata.ClpMySqlMetadataProvider.DATASETS_TABLE_SUFFIX;
 import static com.facebook.presto.plugin.clp.split.ClpMySqlSplitProvider.ARCHIVES_TABLE_COLUMN_ID;
-import static com.facebook.presto.plugin.clp.split.ClpMySqlSplitProvider.ARCHIVE_TABLE_SUFFIX;
+import static com.facebook.presto.plugin.clp.split.ClpMySqlSplitProvider.ARCHIVES_TABLE_SUFFIX;
 import static java.lang.String.format;
 import static java.util.UUID.randomUUID;
 import static org.testng.Assert.fail;
@@ -53,7 +53,7 @@ public final class ClpMetadataDbSetUp
 
     private static final Logger log = Logger.get(ClpMetadataDbSetUp.class);
     private static final String DATASETS_TABLE_NAME = METADATA_DB_TABLE_PREFIX + DATASETS_TABLE_SUFFIX;
-    private static final String ARCHIVE_TABLE_COLUMN_PAGINATION_ID = "pagination_id";
+    private static final String ARCHIVES_TABLE_COLUMN_PAGINATION_ID = "pagination_id";
 
     private ClpMetadataDbSetUp()
     {
@@ -122,7 +122,7 @@ public final class ClpMetadataDbSetUp
     public static ClpMySqlSplitProvider setupSplit(DbHandle dbHandle, Map<String, List<String>> splits)
     {
         final String metadataDbUrl = format(METADATA_DB_URL_TEMPLATE, dbHandle.dbPath);
-        final String archiveTableFormat = METADATA_DB_TABLE_PREFIX + "%s" + ARCHIVE_TABLE_SUFFIX;
+        final String archiveTableFormat = METADATA_DB_TABLE_PREFIX + "%s" + ARCHIVES_TABLE_SUFFIX;
 
         try (Connection conn = DriverManager.getConnection(metadataDbUrl, METADATA_DB_USER, METADATA_DB_PASSWORD); Statement stmt = conn.createStatement()) {
             createDatasetsTable(stmt);
@@ -138,7 +138,7 @@ public final class ClpMetadataDbSetUp
                                 "%s BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY, " +
                                 "%s VARCHAR(64) NOT NULL)",
                         archiveTableName,
-                        ARCHIVE_TABLE_COLUMN_PAGINATION_ID,
+                        ARCHIVES_TABLE_COLUMN_PAGINATION_ID,
                         ARCHIVES_TABLE_COLUMN_ID);
 
                 stmt.execute(createArchiveTableSQL);

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/TestClpFilterToKql.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/TestClpFilterToKql.java
@@ -194,9 +194,9 @@ public class TestClpFilterToKql
 
     private void testFilter(String sqlExpression, String expectedKqlExpression, String expectedRemainingExpression, SessionHolder sessionHolder)
     {
-        RowExpression pushDownExpression = getRowExpression(sqlExpression, sessionHolder);
-        ClpExpression clpExpression = pushDownExpression.accept(new ClpFilterToKqlConverter(standardFunctionResolution, functionAndTypeManager, variableToColumnHandleMap), null);
-        Optional<String> kqlExpression = clpExpression.getKqlQuery();
+        RowExpression actualExpression = getRowExpression(sqlExpression, sessionHolder);
+        ClpExpression clpExpression = actualExpression.accept(new ClpFilterToKqlConverter(standardFunctionResolution, functionAndTypeManager, variableToColumnHandleMap), null);
+        Optional<String> kqlExpression = clpExpression.getPushDownExpression();
         Optional<RowExpression> remainingExpression = clpExpression.getRemainingExpression();
         if (expectedKqlExpression != null) {
             assertTrue(kqlExpression.isPresent());

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/TestClpFilterToKql.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/TestClpFilterToKql.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.clp;
+
+import com.facebook.presto.spi.relation.RowExpression;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+@Test
+public class TestClpFilterToKql
+        extends TestClpQueryBase
+{
+    private void testFilter(String sqlExpression, Optional<String> expectedKqlExpression,
+                            Optional<String> expectedRemainingExpression, SessionHolder sessionHolder)
+    {
+        RowExpression pushDownExpression = getRowExpression(sqlExpression, sessionHolder);
+        ClpExpression clpExpression = pushDownExpression.accept(new ClpFilterToKqlConverter(standardFunctionResolution, functionAndTypeManager, variableToColumnHandleMap), null);
+        Optional<String> kqlExpression = clpExpression.getDefinition();
+        Optional<RowExpression> remainingExpression = clpExpression.getRemainingExpression();
+        if (expectedKqlExpression.isPresent()) {
+            assertTrue(kqlExpression.isPresent());
+            assertEquals(kqlExpression.get(), expectedKqlExpression.get());
+        }
+
+        if (expectedRemainingExpression.isPresent()) {
+            assertTrue(remainingExpression.isPresent());
+            assertEquals(remainingExpression.get(), getRowExpression(expectedRemainingExpression.get(), sessionHolder));
+        }
+        else {
+            assertFalse(remainingExpression.isPresent());
+        }
+    }
+
+    @Test
+    public void testStringMatchPushdown()
+    {
+        SessionHolder sessionHolder = new SessionHolder();
+
+        // Exact match
+        testFilter("city.Name = 'hello world'", Optional.of("city.Name: \"hello world\""), Optional.empty(), sessionHolder);
+        testFilter("'hello world' = city.Name", Optional.of("city.Name: \"hello world\""), Optional.empty(), sessionHolder);
+
+        // Like predicates that are transformed into substring match
+        testFilter("city.Name like 'hello%'", Optional.of("city.Name: \"hello*\""), Optional.empty(), sessionHolder);
+        testFilter("city.Name like '%hello'", Optional.of("city.Name: \"*hello\""), Optional.empty(), sessionHolder);
+
+        // Like predicates that are transformed into CARDINALITY(SPLIT(x, 'some string', 2)) = 2 form, and they are not pushed down for now
+        testFilter("city.Name like '%hello%'", Optional.empty(), Optional.of("city.Name like '%hello%'"), sessionHolder);
+
+        // Like predicates that are kept in the original forms
+        testFilter("city.Name like 'hello_'", Optional.of("city.Name: \"hello?\""), Optional.empty(), sessionHolder);
+        testFilter("city.Name like '_hello'", Optional.of("city.Name: \"?hello\""), Optional.empty(), sessionHolder);
+        testFilter("city.Name like 'hello_w%'", Optional.of("city.Name: \"hello?w*\""), Optional.empty(), sessionHolder);
+        testFilter("city.Name like '%hello_w'", Optional.of("city.Name: \"*hello?w\""), Optional.empty(), sessionHolder);
+        testFilter("city.Name like 'hello%world'", Optional.of("city.Name: \"hello*world\""), Optional.empty(), sessionHolder);
+        testFilter("city.Name like 'hello%wor%ld'", Optional.of("city.Name: \"hello*wor*ld\""), Optional.empty(), sessionHolder);
+    }
+
+    @Test
+    public void testSubStringPushdown()
+    {
+        SessionHolder sessionHolder = new SessionHolder();
+
+        testFilter("substr(city.Name, 1, 2) = 'he'", Optional.of("city.Name: \"he*\""), Optional.empty(), sessionHolder);
+        testFilter("substr(city.Name, 5, 2) = 'he'", Optional.of("city.Name: \"????he*\""), Optional.empty(), sessionHolder);
+        testFilter("substr(city.Name, 5) = 'he'", Optional.of("city.Name: \"????he\""), Optional.empty(), sessionHolder);
+        testFilter("substr(city.Name, -2) = 'he'", Optional.of("city.Name: \"*he\""), Optional.empty(), sessionHolder);
+
+        // Invalid substring index is not pushed down
+        testFilter("substr(city.Name, 1, 5) = 'he'", Optional.empty(), Optional.of("substr(city.Name, 1, 5) = 'he'"), sessionHolder);
+        testFilter("substr(city.Name, -5) = 'he'", Optional.empty(), Optional.of("substr(city.Name, -5) = 'he'"), sessionHolder);
+    }
+
+    @Test
+    public void testNumericComparisonPushdown()
+    {
+        SessionHolder sessionHolder = new SessionHolder();
+
+        testFilter("fare > 0", Optional.of("fare > 0"), Optional.empty(), sessionHolder);
+        testFilter("fare >= 0", Optional.of("fare >= 0"), Optional.empty(), sessionHolder);
+        testFilter("fare < 0", Optional.of("fare < 0"), Optional.empty(), sessionHolder);
+        testFilter("fare <= 0", Optional.of("fare <= 0"), Optional.empty(), sessionHolder);
+        testFilter("fare = 0", Optional.of("fare: 0"), Optional.empty(), sessionHolder);
+        testFilter("fare != 0", Optional.of("NOT fare: 0"), Optional.empty(), sessionHolder);
+        testFilter("fare <> 0", Optional.of("NOT fare: 0"), Optional.empty(), sessionHolder);
+        testFilter("0 < fare", Optional.of("fare > 0"), Optional.empty(), sessionHolder);
+        testFilter("0 <= fare", Optional.of("fare >= 0"), Optional.empty(), sessionHolder);
+        testFilter("0 > fare", Optional.of("fare < 0"), Optional.empty(), sessionHolder);
+        testFilter("0 >= fare", Optional.of("fare <= 0"), Optional.empty(), sessionHolder);
+        testFilter("0 = fare", Optional.of("fare: 0"), Optional.empty(), sessionHolder);
+        testFilter("0 != fare", Optional.of("NOT fare: 0"), Optional.empty(), sessionHolder);
+        testFilter("0 <> fare", Optional.of("NOT fare: 0"), Optional.empty(), sessionHolder);
+    }
+
+    @Test
+    public void testOrPushdown()
+    {
+        SessionHolder sessionHolder = new SessionHolder();
+
+        testFilter("fare > 0 OR city.Name like 'b%'", Optional.of("(fare > 0 OR city.Name: \"b*\")"), Optional.empty(), sessionHolder);
+        testFilter(
+                "lower(city.Region.Name) = 'hello world' OR city.Region.Id != 1",
+                Optional.empty(),
+                Optional.of("(lower(city.Region.Name) = 'hello world' OR city.Region.Id != 1)"),
+                sessionHolder);
+
+        // Multiple ORs
+        testFilter(
+                "fare > 0 OR city.Name like 'b%' OR lower(city.Region.Name) = 'hello world' OR city.Region.Id != 1",
+                Optional.empty(),
+                Optional.of("fare > 0 OR city.Name like 'b%' OR lower(city.Region.Name) = 'hello world' OR city.Region.Id != 1"),
+                sessionHolder);
+        testFilter(
+                "fare > 0 OR city.Name like 'b%' OR city.Region.Id != 1",
+                Optional.of("((fare > 0 OR city.Name: \"b*\") OR NOT city.Region.Id: 1)"),
+                Optional.empty(),
+                sessionHolder);
+    }
+
+    @Test
+    public void testAndPushdown()
+    {
+        SessionHolder sessionHolder = new SessionHolder();
+
+        testFilter("fare > 0 AND city.Name like 'b%'", Optional.of("(fare > 0 AND city.Name: \"b*\")"), Optional.empty(), sessionHolder);
+        testFilter(
+                "lower(city.Region.Name) = 'hello world' AND city.Region.Id != 1",
+                Optional.of("(NOT city.Region.Id: 1)"),
+                Optional.of("lower(city.Region.Name) = 'hello world'"),
+                sessionHolder);
+
+        // Multiple ANDs
+        testFilter(
+                "fare > 0 AND city.Name like 'b%' AND lower(city.Region.Name) = 'hello world' AND city.Region.Id != 1",
+                Optional.of("(((fare > 0 AND city.Name: \"b*\")) AND NOT city.Region.Id: 1)"),
+                Optional.of("(lower(city.Region.Name) = 'hello world')"),
+                sessionHolder);
+        testFilter(
+                "fare > 0 AND city.Name like '%b%' AND lower(city.Region.Name) = 'hello world' AND city.Region.Id != 1",
+                Optional.of("(((fare > 0)) AND NOT city.Region.Id: 1)"),
+                Optional.of("city.Name like '%b%' AND lower(city.Region.Name) = 'hello world'"),
+                sessionHolder);
+    }
+
+    @Test
+    public void testNotPushdown()
+    {
+        SessionHolder sessionHolder = new SessionHolder();
+
+        testFilter("city.Region.Name NOT LIKE 'hello%'", Optional.of("NOT city.Region.Name: \"hello*\""), Optional.empty(), sessionHolder);
+        testFilter("NOT (city.Region.Name LIKE 'hello%')", Optional.of("NOT city.Region.Name: \"hello*\""), Optional.empty(), sessionHolder);
+        testFilter("city.Name != 'hello world'", Optional.of("NOT city.Name: \"hello world\""), Optional.empty(), sessionHolder);
+        testFilter("city.Name <> 'hello world'", Optional.of("NOT city.Name: \"hello world\""), Optional.empty(), sessionHolder);
+        testFilter("NOT (city.Name = 'hello world')", Optional.of("NOT city.Name: \"hello world\""), Optional.empty(), sessionHolder);
+        testFilter("fare != 0", Optional.of("NOT fare: 0"), Optional.empty(), sessionHolder);
+        testFilter("fare <> 0", Optional.of("NOT fare: 0"), Optional.empty(), sessionHolder);
+        testFilter("NOT (fare = 0)", Optional.of("NOT fare: 0"), Optional.empty(), sessionHolder);
+
+        // Multiple NOTs
+        testFilter("NOT (NOT fare = 0)", Optional.of("NOT NOT fare: 0"), Optional.empty(), sessionHolder);
+        testFilter("NOT (fare = 0 AND city.Name = 'hello world')", Optional.of("NOT (fare: 0 AND city.Name: \"hello world\")"), Optional.empty(), sessionHolder);
+        testFilter("NOT (fare = 0 OR city.Name = 'hello world')", Optional.of("NOT (fare: 0 OR city.Name: \"hello world\")"), Optional.empty(), sessionHolder);
+    }
+
+    @Test
+    public void testInPushdown()
+    {
+        SessionHolder sessionHolder = new SessionHolder();
+
+        testFilter("city.Name IN ('hello world', 'hello world 2')", Optional.of("(city.Name: \"hello world\" OR city.Name: \"hello world 2\")"), Optional.empty(), sessionHolder);
+    }
+
+    @Test
+    public void testIsNullPushdown()
+    {
+        SessionHolder sessionHolder = new SessionHolder();
+
+        testFilter("city.Name IS NULL", Optional.of("NOT city.Name: *"), Optional.empty(), sessionHolder);
+        testFilter("city.Name IS NOT NULL", Optional.of("NOT NOT city.Name: *"), Optional.empty(), sessionHolder);
+        testFilter("NOT (city.Name IS NULL)", Optional.of("NOT NOT city.Name: *"), Optional.empty(), sessionHolder);
+    }
+
+    @Test
+    public void testComplexPushdown()
+    {
+        SessionHolder sessionHolder = new SessionHolder();
+
+        testFilter(
+                "(fare > 0 OR city.Name like 'b%') AND (lower(city.Region.Name) = 'hello world' OR city.Name IS NULL)",
+                Optional.of("((fare > 0 OR city.Name: \"b*\"))"),
+                Optional.of("(lower(city.Region.Name) = 'hello world' OR city.Name IS NULL)"),
+                sessionHolder);
+        testFilter(
+                "city.Region.Id = 1 AND (fare > 0 OR city.Name NOT like 'b%') AND (lower(city.Region.Name) = 'hello world' OR city.Name IS NULL)",
+                Optional.of("((city.Region.Id: 1 AND (fare > 0 OR NOT city.Name: \"b*\")))"),
+                Optional.of("lower(city.Region.Name) = 'hello world' OR city.Name IS NULL"),
+                sessionHolder);
+    }
+}

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/TestClpFilterToKql.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/TestClpFilterToKql.java
@@ -196,7 +196,7 @@ public class TestClpFilterToKql
     {
         RowExpression pushDownExpression = getRowExpression(sqlExpression, sessionHolder);
         ClpExpression clpExpression = pushDownExpression.accept(new ClpFilterToKqlConverter(standardFunctionResolution, functionAndTypeManager, variableToColumnHandleMap), null);
-        Optional<String> kqlExpression = clpExpression.getDefinition();
+        Optional<String> kqlExpression = clpExpression.getKqlQuery();
         Optional<RowExpression> remainingExpression = clpExpression.getRemainingExpression();
         if (expectedKqlExpression != null) {
             assertTrue(kqlExpression.isPresent());

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/TestClpFilterToKql.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/TestClpFilterToKql.java
@@ -26,27 +26,6 @@ import static org.testng.Assert.assertTrue;
 public class TestClpFilterToKql
         extends TestClpQueryBase
 {
-    private void testFilter(String sqlExpression, Optional<String> expectedKqlExpression,
-                            Optional<String> expectedRemainingExpression, SessionHolder sessionHolder)
-    {
-        RowExpression pushDownExpression = getRowExpression(sqlExpression, sessionHolder);
-        ClpExpression clpExpression = pushDownExpression.accept(new ClpFilterToKqlConverter(standardFunctionResolution, functionAndTypeManager, variableToColumnHandleMap), null);
-        Optional<String> kqlExpression = clpExpression.getDefinition();
-        Optional<RowExpression> remainingExpression = clpExpression.getRemainingExpression();
-        if (expectedKqlExpression.isPresent()) {
-            assertTrue(kqlExpression.isPresent());
-            assertEquals(kqlExpression.get(), expectedKqlExpression.get());
-        }
-
-        if (expectedRemainingExpression.isPresent()) {
-            assertTrue(remainingExpression.isPresent());
-            assertEquals(remainingExpression.get(), getRowExpression(expectedRemainingExpression.get(), sessionHolder));
-        }
-        else {
-            assertFalse(remainingExpression.isPresent());
-        }
-    }
-
     @Test
     public void testStringMatchPushdown()
     {
@@ -211,5 +190,25 @@ public class TestClpFilterToKql
                 Optional.of("((city.Region.Id: 1 AND (fare > 0 OR NOT city.Name: \"b*\")))"),
                 Optional.of("lower(city.Region.Name) = 'hello world' OR city.Name IS NULL"),
                 sessionHolder);
+    }
+
+    private void testFilter(String sqlExpression, Optional<String> expectedKqlExpression, Optional<String> expectedRemainingExpression, SessionHolder sessionHolder)
+    {
+        RowExpression pushDownExpression = getRowExpression(sqlExpression, sessionHolder);
+        ClpExpression clpExpression = pushDownExpression.accept(new ClpFilterToKqlConverter(standardFunctionResolution, functionAndTypeManager, variableToColumnHandleMap), null);
+        Optional<String> kqlExpression = clpExpression.getDefinition();
+        Optional<RowExpression> remainingExpression = clpExpression.getRemainingExpression();
+        if (expectedKqlExpression.isPresent()) {
+            assertTrue(kqlExpression.isPresent());
+            assertEquals(kqlExpression.get(), expectedKqlExpression.get());
+        }
+
+        if (expectedRemainingExpression.isPresent()) {
+            assertTrue(remainingExpression.isPresent());
+            assertEquals(remainingExpression.get(), getRowExpression(expectedRemainingExpression.get(), sessionHolder));
+        }
+        else {
+            assertFalse(remainingExpression.isPresent());
+        }
     }
 }

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/TestClpFilterToKql.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/TestClpFilterToKql.java
@@ -32,23 +32,23 @@ public class TestClpFilterToKql
         SessionHolder sessionHolder = new SessionHolder();
 
         // Exact match
-        testFilter("city.Name = 'hello world'", Optional.of("city.Name: \"hello world\""), Optional.empty(), sessionHolder);
-        testFilter("'hello world' = city.Name", Optional.of("city.Name: \"hello world\""), Optional.empty(), sessionHolder);
+        testFilter("city.Name = 'hello world'", "city.Name: \"hello world\"", null, sessionHolder);
+        testFilter("'hello world' = city.Name", "city.Name: \"hello world\"", null, sessionHolder);
 
         // Like predicates that are transformed into substring match
-        testFilter("city.Name like 'hello%'", Optional.of("city.Name: \"hello*\""), Optional.empty(), sessionHolder);
-        testFilter("city.Name like '%hello'", Optional.of("city.Name: \"*hello\""), Optional.empty(), sessionHolder);
+        testFilter("city.Name like 'hello%'", "city.Name: \"hello*\"", null, sessionHolder);
+        testFilter("city.Name like '%hello'", "city.Name: \"*hello\"", null, sessionHolder);
 
         // Like predicates that are transformed into CARDINALITY(SPLIT(x, 'some string', 2)) = 2 form, and they are not pushed down for now
-        testFilter("city.Name like '%hello%'", Optional.empty(), Optional.of("city.Name like '%hello%'"), sessionHolder);
+        testFilter("city.Name like '%hello%'", null, "city.Name like '%hello%'", sessionHolder);
 
         // Like predicates that are kept in the original forms
-        testFilter("city.Name like 'hello_'", Optional.of("city.Name: \"hello?\""), Optional.empty(), sessionHolder);
-        testFilter("city.Name like '_hello'", Optional.of("city.Name: \"?hello\""), Optional.empty(), sessionHolder);
-        testFilter("city.Name like 'hello_w%'", Optional.of("city.Name: \"hello?w*\""), Optional.empty(), sessionHolder);
-        testFilter("city.Name like '%hello_w'", Optional.of("city.Name: \"*hello?w\""), Optional.empty(), sessionHolder);
-        testFilter("city.Name like 'hello%world'", Optional.of("city.Name: \"hello*world\""), Optional.empty(), sessionHolder);
-        testFilter("city.Name like 'hello%wor%ld'", Optional.of("city.Name: \"hello*wor*ld\""), Optional.empty(), sessionHolder);
+        testFilter("city.Name like 'hello_'", "city.Name: \"hello?\"", null, sessionHolder);
+        testFilter("city.Name like '_hello'", "city.Name: \"?hello\"", null, sessionHolder);
+        testFilter("city.Name like 'hello_w%'", "city.Name: \"hello?w*\"", null, sessionHolder);
+        testFilter("city.Name like '%hello_w'", "city.Name: \"*hello?w\"", null, sessionHolder);
+        testFilter("city.Name like 'hello%world'", "city.Name: \"hello*world\"", null, sessionHolder);
+        testFilter("city.Name like 'hello%wor%ld'", "city.Name: \"hello*wor*ld\"", null, sessionHolder);
     }
 
     @Test
@@ -56,14 +56,14 @@ public class TestClpFilterToKql
     {
         SessionHolder sessionHolder = new SessionHolder();
 
-        testFilter("substr(city.Name, 1, 2) = 'he'", Optional.of("city.Name: \"he*\""), Optional.empty(), sessionHolder);
-        testFilter("substr(city.Name, 5, 2) = 'he'", Optional.of("city.Name: \"????he*\""), Optional.empty(), sessionHolder);
-        testFilter("substr(city.Name, 5) = 'he'", Optional.of("city.Name: \"????he\""), Optional.empty(), sessionHolder);
-        testFilter("substr(city.Name, -2) = 'he'", Optional.of("city.Name: \"*he\""), Optional.empty(), sessionHolder);
+        testFilter("substr(city.Name, 1, 2) = 'he'", "city.Name: \"he*\"", null, sessionHolder);
+        testFilter("substr(city.Name, 5, 2) = 'he'", "city.Name: \"????he*\"", null, sessionHolder);
+        testFilter("substr(city.Name, 5) = 'he'", "city.Name: \"????he\"", null, sessionHolder);
+        testFilter("substr(city.Name, -2) = 'he'", "city.Name: \"*he\"", null, sessionHolder);
 
         // Invalid substring index is not pushed down
-        testFilter("substr(city.Name, 1, 5) = 'he'", Optional.empty(), Optional.of("substr(city.Name, 1, 5) = 'he'"), sessionHolder);
-        testFilter("substr(city.Name, -5) = 'he'", Optional.empty(), Optional.of("substr(city.Name, -5) = 'he'"), sessionHolder);
+        testFilter("substr(city.Name, 1, 5) = 'he'", null, "substr(city.Name, 1, 5) = 'he'", sessionHolder);
+        testFilter("substr(city.Name, -5) = 'he'", null, "substr(city.Name, -5) = 'he'", sessionHolder);
     }
 
     @Test
@@ -71,20 +71,20 @@ public class TestClpFilterToKql
     {
         SessionHolder sessionHolder = new SessionHolder();
 
-        testFilter("fare > 0", Optional.of("fare > 0"), Optional.empty(), sessionHolder);
-        testFilter("fare >= 0", Optional.of("fare >= 0"), Optional.empty(), sessionHolder);
-        testFilter("fare < 0", Optional.of("fare < 0"), Optional.empty(), sessionHolder);
-        testFilter("fare <= 0", Optional.of("fare <= 0"), Optional.empty(), sessionHolder);
-        testFilter("fare = 0", Optional.of("fare: 0"), Optional.empty(), sessionHolder);
-        testFilter("fare != 0", Optional.of("NOT fare: 0"), Optional.empty(), sessionHolder);
-        testFilter("fare <> 0", Optional.of("NOT fare: 0"), Optional.empty(), sessionHolder);
-        testFilter("0 < fare", Optional.of("fare > 0"), Optional.empty(), sessionHolder);
-        testFilter("0 <= fare", Optional.of("fare >= 0"), Optional.empty(), sessionHolder);
-        testFilter("0 > fare", Optional.of("fare < 0"), Optional.empty(), sessionHolder);
-        testFilter("0 >= fare", Optional.of("fare <= 0"), Optional.empty(), sessionHolder);
-        testFilter("0 = fare", Optional.of("fare: 0"), Optional.empty(), sessionHolder);
-        testFilter("0 != fare", Optional.of("NOT fare: 0"), Optional.empty(), sessionHolder);
-        testFilter("0 <> fare", Optional.of("NOT fare: 0"), Optional.empty(), sessionHolder);
+        testFilter("fare > 0", "fare > 0", null, sessionHolder);
+        testFilter("fare >= 0", "fare >= 0", null, sessionHolder);
+        testFilter("fare < 0", "fare < 0", null, sessionHolder);
+        testFilter("fare <= 0", "fare <= 0", null, sessionHolder);
+        testFilter("fare = 0", "fare: 0", null, sessionHolder);
+        testFilter("fare != 0", "NOT fare: 0", null, sessionHolder);
+        testFilter("fare <> 0", "NOT fare: 0", null, sessionHolder);
+        testFilter("0 < fare", "fare > 0", null, sessionHolder);
+        testFilter("0 <= fare", "fare >= 0", null, sessionHolder);
+        testFilter("0 > fare", "fare < 0", null, sessionHolder);
+        testFilter("0 >= fare", "fare <= 0", null, sessionHolder);
+        testFilter("0 = fare", "fare: 0", null, sessionHolder);
+        testFilter("0 != fare", "NOT fare: 0", null, sessionHolder);
+        testFilter("0 <> fare", "NOT fare: 0", null, sessionHolder);
     }
 
     @Test
@@ -92,23 +92,23 @@ public class TestClpFilterToKql
     {
         SessionHolder sessionHolder = new SessionHolder();
 
-        testFilter("fare > 0 OR city.Name like 'b%'", Optional.of("(fare > 0 OR city.Name: \"b*\")"), Optional.empty(), sessionHolder);
+        testFilter("fare > 0 OR city.Name like 'b%'", "(fare > 0 OR city.Name: \"b*\")", null, sessionHolder);
         testFilter(
                 "lower(city.Region.Name) = 'hello world' OR city.Region.Id != 1",
-                Optional.empty(),
-                Optional.of("(lower(city.Region.Name) = 'hello world' OR city.Region.Id != 1)"),
+                null,
+                "(lower(city.Region.Name) = 'hello world' OR city.Region.Id != 1)",
                 sessionHolder);
 
         // Multiple ORs
         testFilter(
                 "fare > 0 OR city.Name like 'b%' OR lower(city.Region.Name) = 'hello world' OR city.Region.Id != 1",
-                Optional.empty(),
-                Optional.of("fare > 0 OR city.Name like 'b%' OR lower(city.Region.Name) = 'hello world' OR city.Region.Id != 1"),
+                null,
+                "fare > 0 OR city.Name like 'b%' OR lower(city.Region.Name) = 'hello world' OR city.Region.Id != 1",
                 sessionHolder);
         testFilter(
                 "fare > 0 OR city.Name like 'b%' OR city.Region.Id != 1",
-                Optional.of("((fare > 0 OR city.Name: \"b*\") OR NOT city.Region.Id: 1)"),
-                Optional.empty(),
+                "((fare > 0 OR city.Name: \"b*\") OR NOT city.Region.Id: 1)",
+                null,
                 sessionHolder);
     }
 
@@ -117,23 +117,23 @@ public class TestClpFilterToKql
     {
         SessionHolder sessionHolder = new SessionHolder();
 
-        testFilter("fare > 0 AND city.Name like 'b%'", Optional.of("(fare > 0 AND city.Name: \"b*\")"), Optional.empty(), sessionHolder);
+        testFilter("fare > 0 AND city.Name like 'b%'", "(fare > 0 AND city.Name: \"b*\")", null, sessionHolder);
         testFilter(
                 "lower(city.Region.Name) = 'hello world' AND city.Region.Id != 1",
-                Optional.of("(NOT city.Region.Id: 1)"),
-                Optional.of("lower(city.Region.Name) = 'hello world'"),
+                "(NOT city.Region.Id: 1)",
+                "lower(city.Region.Name) = 'hello world'",
                 sessionHolder);
 
         // Multiple ANDs
         testFilter(
                 "fare > 0 AND city.Name like 'b%' AND lower(city.Region.Name) = 'hello world' AND city.Region.Id != 1",
-                Optional.of("(((fare > 0 AND city.Name: \"b*\")) AND NOT city.Region.Id: 1)"),
-                Optional.of("(lower(city.Region.Name) = 'hello world')"),
+                "(((fare > 0 AND city.Name: \"b*\")) AND NOT city.Region.Id: 1)",
+                "(lower(city.Region.Name) = 'hello world')",
                 sessionHolder);
         testFilter(
                 "fare > 0 AND city.Name like '%b%' AND lower(city.Region.Name) = 'hello world' AND city.Region.Id != 1",
-                Optional.of("(((fare > 0)) AND NOT city.Region.Id: 1)"),
-                Optional.of("city.Name like '%b%' AND lower(city.Region.Name) = 'hello world'"),
+                "(((fare > 0)) AND NOT city.Region.Id: 1)",
+                "city.Name like '%b%' AND lower(city.Region.Name) = 'hello world'",
                 sessionHolder);
     }
 
@@ -142,19 +142,19 @@ public class TestClpFilterToKql
     {
         SessionHolder sessionHolder = new SessionHolder();
 
-        testFilter("city.Region.Name NOT LIKE 'hello%'", Optional.of("NOT city.Region.Name: \"hello*\""), Optional.empty(), sessionHolder);
-        testFilter("NOT (city.Region.Name LIKE 'hello%')", Optional.of("NOT city.Region.Name: \"hello*\""), Optional.empty(), sessionHolder);
-        testFilter("city.Name != 'hello world'", Optional.of("NOT city.Name: \"hello world\""), Optional.empty(), sessionHolder);
-        testFilter("city.Name <> 'hello world'", Optional.of("NOT city.Name: \"hello world\""), Optional.empty(), sessionHolder);
-        testFilter("NOT (city.Name = 'hello world')", Optional.of("NOT city.Name: \"hello world\""), Optional.empty(), sessionHolder);
-        testFilter("fare != 0", Optional.of("NOT fare: 0"), Optional.empty(), sessionHolder);
-        testFilter("fare <> 0", Optional.of("NOT fare: 0"), Optional.empty(), sessionHolder);
-        testFilter("NOT (fare = 0)", Optional.of("NOT fare: 0"), Optional.empty(), sessionHolder);
+        testFilter("city.Region.Name NOT LIKE 'hello%'", "NOT city.Region.Name: \"hello*\"", null, sessionHolder);
+        testFilter("NOT (city.Region.Name LIKE 'hello%')", "NOT city.Region.Name: \"hello*\"", null, sessionHolder);
+        testFilter("city.Name != 'hello world'", "NOT city.Name: \"hello world\"", null, sessionHolder);
+        testFilter("city.Name <> 'hello world'", "NOT city.Name: \"hello world\"", null, sessionHolder);
+        testFilter("NOT (city.Name = 'hello world')", "NOT city.Name: \"hello world\"", null, sessionHolder);
+        testFilter("fare != 0", "NOT fare: 0", null, sessionHolder);
+        testFilter("fare <> 0", "NOT fare: 0", null, sessionHolder);
+        testFilter("NOT (fare = 0)", "NOT fare: 0", null, sessionHolder);
 
         // Multiple NOTs
-        testFilter("NOT (NOT fare = 0)", Optional.of("NOT NOT fare: 0"), Optional.empty(), sessionHolder);
-        testFilter("NOT (fare = 0 AND city.Name = 'hello world')", Optional.of("NOT (fare: 0 AND city.Name: \"hello world\")"), Optional.empty(), sessionHolder);
-        testFilter("NOT (fare = 0 OR city.Name = 'hello world')", Optional.of("NOT (fare: 0 OR city.Name: \"hello world\")"), Optional.empty(), sessionHolder);
+        testFilter("NOT (NOT fare = 0)", "NOT NOT fare: 0", null, sessionHolder);
+        testFilter("NOT (fare = 0 AND city.Name = 'hello world')", "NOT (fare: 0 AND city.Name: \"hello world\")", null, sessionHolder);
+        testFilter("NOT (fare = 0 OR city.Name = 'hello world')", "NOT (fare: 0 OR city.Name: \"hello world\")", null, sessionHolder);
     }
 
     @Test
@@ -162,7 +162,7 @@ public class TestClpFilterToKql
     {
         SessionHolder sessionHolder = new SessionHolder();
 
-        testFilter("city.Name IN ('hello world', 'hello world 2')", Optional.of("(city.Name: \"hello world\" OR city.Name: \"hello world 2\")"), Optional.empty(), sessionHolder);
+        testFilter("city.Name IN ('hello world', 'hello world 2')", "(city.Name: \"hello world\" OR city.Name: \"hello world 2\")", null, sessionHolder);
     }
 
     @Test
@@ -170,9 +170,9 @@ public class TestClpFilterToKql
     {
         SessionHolder sessionHolder = new SessionHolder();
 
-        testFilter("city.Name IS NULL", Optional.of("NOT city.Name: *"), Optional.empty(), sessionHolder);
-        testFilter("city.Name IS NOT NULL", Optional.of("NOT NOT city.Name: *"), Optional.empty(), sessionHolder);
-        testFilter("NOT (city.Name IS NULL)", Optional.of("NOT NOT city.Name: *"), Optional.empty(), sessionHolder);
+        testFilter("city.Name IS NULL", "NOT city.Name: *", null, sessionHolder);
+        testFilter("city.Name IS NOT NULL", "NOT NOT city.Name: *", null, sessionHolder);
+        testFilter("NOT (city.Name IS NULL)", "NOT NOT city.Name: *", null, sessionHolder);
     }
 
     @Test
@@ -182,30 +182,30 @@ public class TestClpFilterToKql
 
         testFilter(
                 "(fare > 0 OR city.Name like 'b%') AND (lower(city.Region.Name) = 'hello world' OR city.Name IS NULL)",
-                Optional.of("((fare > 0 OR city.Name: \"b*\"))"),
-                Optional.of("(lower(city.Region.Name) = 'hello world' OR city.Name IS NULL)"),
+                "((fare > 0 OR city.Name: \"b*\"))",
+                "(lower(city.Region.Name) = 'hello world' OR city.Name IS NULL)",
                 sessionHolder);
         testFilter(
                 "city.Region.Id = 1 AND (fare > 0 OR city.Name NOT like 'b%') AND (lower(city.Region.Name) = 'hello world' OR city.Name IS NULL)",
-                Optional.of("((city.Region.Id: 1 AND (fare > 0 OR NOT city.Name: \"b*\")))"),
-                Optional.of("lower(city.Region.Name) = 'hello world' OR city.Name IS NULL"),
+                "((city.Region.Id: 1 AND (fare > 0 OR NOT city.Name: \"b*\")))",
+                "lower(city.Region.Name) = 'hello world' OR city.Name IS NULL",
                 sessionHolder);
     }
 
-    private void testFilter(String sqlExpression, Optional<String> expectedKqlExpression, Optional<String> expectedRemainingExpression, SessionHolder sessionHolder)
+    private void testFilter(String sqlExpression, String expectedKqlExpression, String expectedRemainingExpression, SessionHolder sessionHolder)
     {
         RowExpression pushDownExpression = getRowExpression(sqlExpression, sessionHolder);
         ClpExpression clpExpression = pushDownExpression.accept(new ClpFilterToKqlConverter(standardFunctionResolution, functionAndTypeManager, variableToColumnHandleMap), null);
         Optional<String> kqlExpression = clpExpression.getDefinition();
         Optional<RowExpression> remainingExpression = clpExpression.getRemainingExpression();
-        if (expectedKqlExpression.isPresent()) {
+        if (expectedKqlExpression != null) {
             assertTrue(kqlExpression.isPresent());
-            assertEquals(kqlExpression.get(), expectedKqlExpression.get());
+            assertEquals(kqlExpression.get(), expectedKqlExpression);
         }
 
-        if (expectedRemainingExpression.isPresent()) {
+        if (expectedRemainingExpression != null) {
             assertTrue(remainingExpression.isPresent());
-            assertEquals(remainingExpression.get(), getRowExpression(expectedRemainingExpression.get(), sessionHolder));
+            assertEquals(remainingExpression.get(), getRowExpression(expectedRemainingExpression, sessionHolder));
         }
         else {
             assertFalse(remainingExpression.isPresent());

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/TestClpQueryBase.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/TestClpQueryBase.java
@@ -29,11 +29,9 @@ import com.facebook.presto.metadata.TablePropertyManager;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.SchemaTableName;
-import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.function.StandardFunctionResolution;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
-import com.facebook.presto.sql.ExpressionUtils;
 import com.facebook.presto.sql.parser.ParsingOptions;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.TypeProvider;
@@ -55,7 +53,10 @@ import static com.facebook.presto.common.type.DoubleType.DOUBLE;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.metadata.FunctionAndTypeManager.createTestFunctionAndTypeManager;
 import static com.facebook.presto.metadata.SessionPropertyManager.createTestingSessionPropertyManager;
+import static com.facebook.presto.spi.WarningCollector.NOOP;
+import static com.facebook.presto.sql.ExpressionUtils.rewriteIdentifiersToSymbolReferences;
 import static com.facebook.presto.sql.analyzer.ExpressionAnalyzer.getExpressionTypes;
+import static com.facebook.presto.sql.parser.ParsingOptions.DecimalLiteralTreatment.AS_DECIMAL;
 import static com.facebook.presto.testing.TestingConnectorSession.SESSION;
 import static com.facebook.presto.transaction.InMemoryTransactionManager.createTestTransactionManager;
 import static java.util.stream.Collectors.toMap;
@@ -94,8 +95,8 @@ public class TestClpQueryBase
 
     public static Expression expression(String sql)
     {
-        return ExpressionUtils.rewriteIdentifiersToSymbolReferences(
-                new SqlParser().createExpression(sql, new ParsingOptions(ParsingOptions.DecimalLiteralTreatment.AS_DECIMAL)));
+        return rewriteIdentifiersToSymbolReferences(
+                new SqlParser().createExpression(sql, ParsingOptions.builder().setDecimalLiteralTreatment(AS_DECIMAL).build()));
     }
 
     protected RowExpression toRowExpression(Expression expression, TypeProvider typeProvider, Session session)
@@ -107,7 +108,7 @@ public class TestClpQueryBase
                 typeProvider,
                 expression,
                 ImmutableMap.of(),
-                WarningCollector.NOOP);
+                NOOP);
         return SqlToRowExpressionTranslator.translate(expression, expressionTypes, ImmutableMap.of(), functionAndTypeManager, session);
     }
 

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/TestClpQueryBase.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/TestClpQueryBase.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.clp;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.SystemSessionProperties;
+import com.facebook.presto.common.block.BlockEncodingManager;
+import com.facebook.presto.common.type.RowType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.metadata.AnalyzePropertyManager;
+import com.facebook.presto.metadata.CatalogManager;
+import com.facebook.presto.metadata.ColumnPropertyManager;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.metadata.SchemaPropertyManager;
+import com.facebook.presto.metadata.TablePropertyManager;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.function.StandardFunctionResolution;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.ExpressionUtils;
+import com.facebook.presto.sql.parser.ParsingOptions;
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.planner.TypeProvider;
+import com.facebook.presto.sql.relational.FunctionResolution;
+import com.facebook.presto.sql.relational.SqlToRowExpressionTranslator;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.NodeRef;
+import com.facebook.presto.testing.TestingSession;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.metadata.FunctionAndTypeManager.createTestFunctionAndTypeManager;
+import static com.facebook.presto.metadata.SessionPropertyManager.createTestingSessionPropertyManager;
+import static com.facebook.presto.sql.analyzer.ExpressionAnalyzer.getExpressionTypes;
+import static com.facebook.presto.testing.TestingConnectorSession.SESSION;
+import static com.facebook.presto.transaction.InMemoryTransactionManager.createTestTransactionManager;
+import static java.util.stream.Collectors.toMap;
+
+public class TestClpQueryBase
+{
+    protected static final FunctionAndTypeManager functionAndTypeManager = createTestFunctionAndTypeManager();
+    protected static final StandardFunctionResolution standardFunctionResolution = new FunctionResolution(functionAndTypeManager.getFunctionAndTypeResolver());
+    protected static final Metadata metadata = new MetadataManager(
+            functionAndTypeManager,
+            new BlockEncodingManager(),
+            createTestingSessionPropertyManager(),
+            new SchemaPropertyManager(),
+            new TablePropertyManager(),
+            new ColumnPropertyManager(),
+            new AnalyzePropertyManager(),
+            createTestTransactionManager(new CatalogManager()));
+
+    protected static final ClpTableHandle table = new ClpTableHandle(new SchemaTableName("default", "test"), "", ClpTableHandle.StorageType.FS);
+    protected static final ClpColumnHandle city = new ClpColumnHandle(
+            "city",
+            RowType.from(ImmutableList.of(
+                    RowType.field("Region", RowType.from(ImmutableList.of(
+                            RowType.field("Id", BIGINT),
+                            RowType.field("Name", VARCHAR)))),
+                    RowType.field("Name", VARCHAR))),
+            true);
+    protected static final ClpColumnHandle fare = new ClpColumnHandle("fare", DOUBLE, true);
+    protected static final ClpColumnHandle isHoliday = new ClpColumnHandle("isHoliday", BOOLEAN, true);
+    protected static final Map<VariableReferenceExpression, ColumnHandle> variableToColumnHandleMap =
+            Stream.of(city, fare, isHoliday)
+                    .collect(toMap(
+                            ch -> new VariableReferenceExpression(Optional.empty(), ch.getColumnName(), ch.getColumnType()),
+                            ch -> ch));
+    protected final TypeProvider typeProvider = TypeProvider.fromVariables(variableToColumnHandleMap.keySet());
+
+    public static Expression expression(String sql)
+    {
+        return ExpressionUtils.rewriteIdentifiersToSymbolReferences(
+                new SqlParser().createExpression(sql, new ParsingOptions(ParsingOptions.DecimalLiteralTreatment.AS_DECIMAL)));
+    }
+
+    protected RowExpression toRowExpression(Expression expression, TypeProvider typeProvider, Session session)
+    {
+        Map<NodeRef<Expression>, Type> expressionTypes = getExpressionTypes(
+                session,
+                metadata,
+                new SqlParser(),
+                typeProvider,
+                expression,
+                ImmutableMap.of(),
+                WarningCollector.NOOP);
+        return SqlToRowExpressionTranslator.translate(expression, expressionTypes, ImmutableMap.of(), functionAndTypeManager, session);
+    }
+
+    protected RowExpression getRowExpression(String sqlExpression, SessionHolder sessionHolder)
+    {
+        return toRowExpression(expression(sqlExpression), typeProvider, sessionHolder.getSession());
+    }
+
+    protected RowExpression getRowExpression(String sqlExpression, TypeProvider typeProvider, SessionHolder sessionHolder)
+    {
+        return toRowExpression(expression(sqlExpression), typeProvider, sessionHolder.getSession());
+    }
+
+    protected static class SessionHolder
+    {
+        private final ConnectorSession connectorSession;
+        private final Session session;
+
+        public SessionHolder()
+        {
+            connectorSession = SESSION;
+            session = TestingSession.testSessionBuilder(createTestingSessionPropertyManager(new SystemSessionProperties().getSessionProperties())).build();
+        }
+
+        public ConnectorSession getConnectorSession()
+        {
+            return connectorSession;
+        }
+
+        public Session getSession()
+        {
+            return session;
+        }
+    }
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR adds `ClpConnectorPlanOptimizer` and `ClpFilterToKqlConverter` and related unit tests to allow the CLP connector to push down relevant filters to CLP for improved query performance. More details can be found in [RFC](https://github.com/prestodb/rfcs/pull/37).

There are three main steps
1. Transforming filter predicates into [KQL](https://docs.yscope.com/clp/main/user-guide/reference-json-search-syntax.html) queries
2. Adding the generated KQL query to `ClpTableLayoutHandle` and constructing a new `TableScanNode`
3. Reconstructing a `FilterNode` with any remaining predicates and the new `TableScanNode`

`ClpFilterToKqlConverter` implements `RowExpressionVisitor<ClpExpression, Void>` and handles expression transformation and pushdown. Since KQL is not SQL-compatible, only certain types of filters can be converted, including:

- String exact match
- `LIKE` predicate (the `"^%[^%_]*%$"` pattern is not pushed down)
- Numeric comparisons
- Logical operators (`AND`, `OR`, `NOT`)
- `IS NULL`
- `substr(a, start, length) = 'abc'` and `substr(a, start) = 'abc'` forms

For comparison or match expressions, one side must contain a `VariableReferenceExpression`, and the other must be a `ConstantExpression`--specifically a string or numeric literal. Expressions like `a > c` or `substr(a, 2) = lower(c)` are not eligible for pushdown. In simple cases without logical operators, the SQL plan can be directly translated into a KQL query. However, for expressions involving logical operators, it's critical to ensure that all conditions are handled correctly.

A naive approach would be to convert only the pushdown-eligible parts of the SQL query into KQL, letting Presto or Prestissimo handle the rest. But this can lead to incorrect execution plans and unintended behavior.

Consider the following query:
```sql
SELECT * from clp_table WHERE regexp_like(a, '\d+b') OR b = 2
```
Since CLP doesn’t currently support `regexp_like`, if we simply push down `b = 2` to CLP, Presto will only receive results where `b = 2`, effectively changing the query semantics to `regexp_like(a, '\d+b') AND b = 2`.

To prevent such issues,  the pushdown logic follows these rules:

+ **`OR` pushdown**: An `OR` condition is pushable if and only if all child expressions can be pushed down. In this case, all child expressions are pushed down together with the OR operator.
+ **`AND` pushdown**: An `AND` condition is not pushable if and only if none of its child expressions are pushable. Otherwise, pushable expressions are pushed down with the `AND` operator, while non-pushable expressions remain in the original plan.
+ **General Pushdown Condition**: An expression is considered pushable if it’s a `CallExpression` and can be transformed into KQL syntax.

Example transformations:

1. **SQL WHERE Clause**: `a = 2 AND b = '3'`  
   - **KQL**: `a: 2 AND b: "3"`  
   - **Effect**: The `FilterNode` is removed.

2. **SQL WHERE Clause**: `a.b LIKE '%string another_string' OR "c.d" = TRUE`  
   - **KQL**: `a.b: "*string another_string" OR c.d: true`  
   - **Effect**: The `FilterNode` is removed.

3. **SQL WHERE Clause**: `a > 2 OR regexp_like(b, '\d+b')`  
   - **KQL**: `"*"`  
   - **Effect**: `a > 2 OR regexp_like(b, '\d+b')` remains in the `FilterNode`.

4. **SQL WHERE Clause**: `a > 2 AND regexp_like(b, '\d+b')`  
   - **KQL**: `a > 2`  
   - **Effect**: `regexp_like(b, '\d+b')` remains in the `FilterNode`.

5. **SQL WHERE Clause**: `NOT substr(a, 2, 5) = 'Hello' and b IS NULL`
   - **KQL**: `NOT a: "?Hello*" AND NOT b: *`  
   - **Effect**: The `FilterNode` is removed.
# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [ ] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [ ] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [ ] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for pushing down Presto filter expressions to CLP using KQL queries, improving query performance by reducing data scanned.
  - Introduced advanced filter translation, including support for logical operators, comparison operators, LIKE, IN, IS NULL, and substring matching.
  - Implemented a plan optimizer to rewrite query plans by embedding KQL filters into table scans for efficient pushdown.
  - Provided a plan optimizer provider to integrate the new optimizer into the query planning process.
- **Tests**
  - Added comprehensive tests to verify correct translation of SQL filters to KQL and proper handling of various filter scenarios.
- **Chores**
  - Introduced utility classes to support test infrastructure and expression handling for the new features.
  - Corrected naming inconsistencies related to archive table suffixes in MySQL split provider and test setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->