### PR TITLE
feat: Add metadata filtering based on archive-level timestamp.

### DIFF
--- a/presto-clp/pom.xml
+++ b/presto-clp/pom.xml
@@ -66,6 +66,16 @@
         </dependency>
 
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-spi</artifactId>
             <scope>provided</scope>

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpConfig.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpConfig.java
@@ -29,6 +29,7 @@ public class ClpConfig
     private String metadataDbName;
     private String metadataDbUser;
     private String metadataDbPassword;
+    private String metadataFilterConfig;
     private String metadataTablePrefix;
     private long metadataRefreshInterval = 60;
     private long metadataExpireInterval = 600;
@@ -104,6 +105,18 @@ public class ClpConfig
     public ClpConfig setMetadataDbPassword(String metadataDbPassword)
     {
         this.metadataDbPassword = metadataDbPassword;
+        return this;
+    }
+
+    public String getMetadataFilterConfig()
+    {
+        return metadataFilterConfig;
+    }
+
+    @Config("clp.metadata-filter-config")
+    public ClpConfig setMetadataFilterConfig(String metadataFilterConfig)
+    {
+        this.metadataFilterConfig = metadataFilterConfig;
         return this;
     }
 

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpConnectorFactory.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpConnectorFactory.java
@@ -33,10 +33,12 @@ import static java.util.Objects.requireNonNull;
 public class ClpConnectorFactory
         implements ConnectorFactory
 {
+    public static final String CONNECTOR_NAME = "clp";
+
     @Override
     public String getName()
     {
-        return "clp";
+        return CONNECTOR_NAME;
     }
 
     @Override

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpErrorCode.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpErrorCode.java
@@ -18,6 +18,7 @@ import com.facebook.presto.common.ErrorType;
 import com.facebook.presto.spi.ErrorCodeSupplier;
 
 import static com.facebook.presto.common.ErrorType.EXTERNAL;
+import static com.facebook.presto.common.ErrorType.USER_ERROR;
 
 public enum ClpErrorCode
         implements ErrorCodeSupplier
@@ -26,7 +27,10 @@ public enum ClpErrorCode
     CLP_UNSUPPORTED_METADATA_SOURCE(1, EXTERNAL),
     CLP_UNSUPPORTED_SPLIT_SOURCE(2, EXTERNAL),
     CLP_UNSUPPORTED_TYPE(3, EXTERNAL),
-    CLP_UNSUPPORTED_CONFIG_OPTION(4, EXTERNAL);
+    CLP_UNSUPPORTED_CONFIG_OPTION(4, EXTERNAL),
+
+    CLP_METADATA_FILTER_CONFIG_NOT_FOUND(10, USER_ERROR),
+    CLP_MANDATORY_METADATA_FILTER_NOT_VALID(11, USER_ERROR);
 
     private final ErrorCode errorCode;
 

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpExpression.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpExpression.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.clp;
+
+import com.facebook.presto.spi.relation.RowExpression;
+
+import java.util.Optional;
+
+/**
+ * Represents the result of converting a Presto RowExpression into a CLP-compatible KQL query.
+ * There are three possible cases:
+ * 1. The entire RowExpression is convertible to KQL: `definition` is set, `remainingExpression` is empty.
+ * 2. Part of the RowExpression is convertible: the KQL part is stored in `definition`,
+ *    and the remaining untranslatable part is stored in `remainingExpression`.
+ * 3. None of the expression is convertible: the full RowExpression is stored in `remainingExpression`,
+ *    and `definition` is empty.
+ */
+public class ClpExpression
+{
+    // Optional KQL query string representing the fully or partially translatable part of the expression.
+    private final Optional<String> definition;
+
+    // The remaining (non-translatable) portion of the RowExpression, if any.
+    private final Optional<RowExpression> remainingExpression;
+
+    public ClpExpression(String definition, RowExpression remainingExpression)
+    {
+        this.definition = Optional.ofNullable(definition);
+        this.remainingExpression = Optional.ofNullable(remainingExpression);
+    }
+
+    // Creates an empty ClpExpression (no KQL definition, no remaining expression).
+    public ClpExpression()
+    {
+        this (null, null);
+    }
+
+    // Creates a ClpExpression from a fully translatable KQL string.
+    public ClpExpression(String definition)
+    {
+        this(definition, null);
+    }
+
+    // Creates a ClpExpression from a non-translatable RowExpression.
+    public ClpExpression(RowExpression remainingExpression)
+    {
+        this(null, remainingExpression);
+    }
+
+    public Optional<String> getDefinition()
+    {
+        return definition;
+    }
+
+    public Optional<RowExpression> getRemainingExpression()
+    {
+        return remainingExpression;
+    }
+}

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpExpression.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpExpression.java
@@ -30,37 +30,51 @@ public class ClpExpression
 {
     // Optional KQL query string representing the fully or partially translatable part of the expression.
     private final Optional<String> definition;
+    // Optinal SQL string extracted from the definition, which is only made of given metadata columns.
+    private final Optional<String> metadataSql;
 
     // The remaining (non-translatable) portion of the RowExpression, if any.
     private final Optional<RowExpression> remainingExpression;
 
-    public ClpExpression(String definition, RowExpression remainingExpression)
+    public ClpExpression(String definition, String metadataSql, RowExpression remainingExpression)
     {
         this.definition = Optional.ofNullable(definition);
+        this.metadataSql = Optional.ofNullable(metadataSql);
         this.remainingExpression = Optional.ofNullable(remainingExpression);
     }
 
     // Creates an empty ClpExpression (no KQL definition, no remaining expression).
     public ClpExpression()
     {
-        this (null, null);
+        this (null, null, null);
     }
 
     // Creates a ClpExpression from a fully translatable KQL string.
     public ClpExpression(String definition)
     {
-        this(definition, null);
+        this(definition, null, null);
+    }
+
+    // Creates a ClpExpression from a fully translatable KQL string and give it metadata SQL.
+    public ClpExpression(String definition, String metadataSql)
+    {
+        this(definition, metadataSql, null);
     }
 
     // Creates a ClpExpression from a non-translatable RowExpression.
     public ClpExpression(RowExpression remainingExpression)
     {
-        this(null, remainingExpression);
+        this(null, null, remainingExpression);
     }
 
     public Optional<String> getDefinition()
     {
         return definition;
+    }
+
+    public Optional<String> getMetadataSql()
+    {
+        return metadataSql;
     }
 
     public Optional<RowExpression> getRemainingExpression()

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpFilterToKqlConverter.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpFilterToKqlConverter.java
@@ -1,0 +1,679 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.clp;
+
+import com.facebook.presto.common.function.OperatorType;
+import com.facebook.presto.common.type.RowType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.VarcharType;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.function.FunctionHandle;
+import com.facebook.presto.spi.function.FunctionMetadata;
+import com.facebook.presto.spi.function.FunctionMetadataManager;
+import com.facebook.presto.spi.function.StandardFunctionResolution;
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.RowExpressionVisitor;
+import com.facebook.presto.spi.relation.SpecialFormExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.google.common.collect.ImmutableSet;
+import io.airlift.slice.Slice;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.facebook.presto.common.function.OperatorType.EQUAL;
+import static com.facebook.presto.common.function.OperatorType.GREATER_THAN;
+import static com.facebook.presto.common.function.OperatorType.GREATER_THAN_OR_EQUAL;
+import static com.facebook.presto.common.function.OperatorType.LESS_THAN;
+import static com.facebook.presto.common.function.OperatorType.LESS_THAN_OR_EQUAL;
+import static com.facebook.presto.common.function.OperatorType.NOT_EQUAL;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.plugin.clp.ClpErrorCode.CLP_PUSHDOWN_UNSUPPORTED_EXPRESSION;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.AND;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * ClpFilterToKqlConverter translates Presto RowExpressions into KQL (Kibana Query Language) filters
+ * used as CLP queries. This is used primarily for pushing down supported filters to the CLP engine.
+ * This class implements the RowExpressionVisitor interface and recursively walks Presto filter expressions,
+ * attempting to convert supported expressions (e.g., comparisons, logical AND/OR, LIKE, IN, IS NULL,
+ * and SUBSTR-based expressions) into corresponding KQL filter strings. Any part of the expression that
+ * cannot be translated is preserved as a "remaining expression" for potential fallback processing.
+ * Supported translations include:
+ * - Variable-to-literal comparisons (e.g., =, !=, <, >, <=, >=)
+ * - String pattern matches using LIKE
+ * - Membership checks using IN
+ * - NULL checks via IS NULL
+ * - Substring comparisons (e.g., SUBSTR(x, start, len) = "val") mapped to wildcard KQL queries
+ * - Dereferencing fields from row-typed variables
+ * - Logical operators AND, OR, and NOT
+ */
+public class ClpFilterToKqlConverter
+        implements RowExpressionVisitor<ClpExpression, Void>
+{
+    private static final Set<OperatorType> LOGICAL_BINARY_OPS_FILTER =
+            ImmutableSet.of(EQUAL, NOT_EQUAL, LESS_THAN, LESS_THAN_OR_EQUAL, GREATER_THAN, GREATER_THAN_OR_EQUAL);
+
+    private final StandardFunctionResolution standardFunctionResolution;
+    private final FunctionMetadataManager functionMetadataManager;
+    private final Map<VariableReferenceExpression, ColumnHandle> assignments;
+
+    public ClpFilterToKqlConverter(StandardFunctionResolution standardFunctionResolution,
+            FunctionMetadataManager functionMetadataManager,
+            Map<VariableReferenceExpression, ColumnHandle> assignments)
+    {
+        this.standardFunctionResolution = requireNonNull(standardFunctionResolution, "standardFunctionResolution is null");
+        this.functionMetadataManager = requireNonNull(functionMetadataManager, "function metadata manager is null");
+        this.assignments = requireNonNull(assignments, "assignments is null");
+    }
+
+    @Override
+    public ClpExpression visitCall(CallExpression node, Void context)
+    {
+        FunctionHandle functionHandle = node.getFunctionHandle();
+        if (standardFunctionResolution.isNotFunction(functionHandle)) {
+            return handleNot(node);
+        }
+
+        if (standardFunctionResolution.isLikeFunction(functionHandle)) {
+            return handleLike(node);
+        }
+
+        FunctionMetadata functionMetadata = functionMetadataManager.getFunctionMetadata(node.getFunctionHandle());
+        Optional<OperatorType> operatorTypeOptional = functionMetadata.getOperatorType();
+        if (operatorTypeOptional.isPresent()) {
+            OperatorType operatorType = operatorTypeOptional.get();
+            if (operatorType.isComparisonOperator() && operatorType != OperatorType.IS_DISTINCT_FROM) {
+                return handleLogicalBinary(operatorType, node);
+            }
+        }
+
+        return new ClpExpression(node);
+    }
+
+    @Override
+    public ClpExpression visitConstant(ConstantExpression node, Void context)
+    {
+        return new ClpExpression(getLiteralString(node));
+    }
+
+    @Override
+    public ClpExpression visitVariableReference(VariableReferenceExpression node, Void context)
+    {
+        return new ClpExpression(getVariableName(node));
+    }
+
+    @Override
+    public ClpExpression visitSpecialForm(SpecialFormExpression node, Void context)
+    {
+        switch (node.getForm()) {
+            case AND:
+                return handleAnd(node);
+            case OR:
+                return handleOr(node);
+            case IN:
+                return handleIn(node);
+            case IS_NULL:
+                return handleIsNull(node);
+            case DEREFERENCE:
+                return handleDereference(node);
+            default:
+                return new ClpExpression(node);
+        }
+    }
+
+    // For all other expressions, return the original expression
+    @Override
+    public ClpExpression visitExpression(RowExpression node, Void context)
+    {
+        return new ClpExpression(node);
+    }
+
+    private static String getLiteralString(ConstantExpression literal)
+    {
+        if (literal.getValue() instanceof Slice) {
+            return ((Slice) literal.getValue()).toStringUtf8();
+        }
+        return literal.toString();
+    }
+
+    private String getVariableName(VariableReferenceExpression variable)
+    {
+        return ((ClpColumnHandle) assignments.get(variable)).getOriginalColumnName();
+    }
+
+    /**
+     * Handles the logical NOT expression.
+     * Example:
+     *   Input: NOT (col1 = 5)
+     *   Output: NOT col1: 5
+     */
+    private ClpExpression handleNot(CallExpression node)
+    {
+        if (node.getArguments().size() != 1) {
+            throw new PrestoException(CLP_PUSHDOWN_UNSUPPORTED_EXPRESSION,
+                    "NOT operator must have exactly one argument. Received: " + node);
+        }
+
+        RowExpression input = node.getArguments().get(0);
+        ClpExpression expression = input.accept(this, null);
+        if (expression.getRemainingExpression().isPresent() || !expression.getDefinition().isPresent()) {
+            return new ClpExpression(node);
+        }
+        return new ClpExpression("NOT " + expression.getDefinition().get());
+    }
+
+    /**
+     * Handles the logical AND expression.
+     * Combines all definable child expressions into a single KQL query joined by AND.
+     * Any unsupported children are collected into remaining expressions.
+     * Example:
+     *   Input: col1 = 5 AND col2 = 'abc'
+     *   Output: (col1: 5 AND col2: "abc")
+     */
+    private ClpExpression handleAnd(SpecialFormExpression node)
+    {
+        StringBuilder queryBuilder = new StringBuilder();
+        queryBuilder.append("(");
+        ArrayList<RowExpression> remainingExpressions = new ArrayList<>();
+        boolean hasDefinition = false;
+        for (RowExpression argument : node.getArguments()) {
+            ClpExpression expression = argument.accept(this, null);
+            if (expression.getDefinition().isPresent()) {
+                hasDefinition = true;
+                queryBuilder.append(expression.getDefinition().get());
+                queryBuilder.append(" AND ");
+            }
+            if (expression.getRemainingExpression().isPresent()) {
+                remainingExpressions.add(expression.getRemainingExpression().get());
+            }
+        }
+        if (!hasDefinition) {
+            return new ClpExpression(node);
+        }
+        else if (!remainingExpressions.isEmpty()) {
+            if (remainingExpressions.size() == 1) {
+                return new ClpExpression(queryBuilder.substring(0, queryBuilder.length() - 5) + ")", remainingExpressions.get(0));
+            }
+            else {
+                return new ClpExpression(
+                        queryBuilder.substring(0, queryBuilder.length() - 5) + ")",
+                        new SpecialFormExpression(node.getSourceLocation(), AND, BOOLEAN, remainingExpressions));
+            }
+        }
+        // Remove the last " AND " from the query
+        return new ClpExpression(queryBuilder.substring(0, queryBuilder.length() - 5) + ")");
+    }
+
+    /**
+     * Handles the logical OR expression.
+     * Combines all fully convertible child expressions into a single CLP query joined by OR.
+     * Returns the original node if any child is unsupported.
+     * Example:
+     *   Input: col1 = 5 OR col1 = 10
+     *   Output: (col1: 5 OR col1: 10)
+     */
+    private ClpExpression handleOr(SpecialFormExpression node)
+    {
+        StringBuilder queryBuilder = new StringBuilder();
+        queryBuilder.append("(");
+        for (RowExpression argument : node.getArguments()) {
+            ClpExpression expression = argument.accept(this, null);
+            if (expression.getRemainingExpression().isPresent() || !expression.getDefinition().isPresent()) {
+                return new ClpExpression(node);
+            }
+            queryBuilder.append(expression.getDefinition().get());
+            queryBuilder.append(" OR ");
+        }
+        // Remove the last " OR " from the query
+        return new ClpExpression(queryBuilder.substring(0, queryBuilder.length() - 4) + ")");
+    }
+
+    /**
+     * Handles the IN predicate.
+     * Example:
+     *   Input: col1 IN (1, 2, 3)
+     *   Output: (col1: 1 OR col1: 2 OR col1: 3)
+     */
+    private ClpExpression handleIn(SpecialFormExpression node)
+    {
+        ClpExpression variable = node.getArguments().get(0).accept(this, null);
+        if (!variable.getDefinition().isPresent()) {
+            return new ClpExpression(node);
+        }
+        String variableName = variable.getDefinition().get();
+        StringBuilder queryBuilder = new StringBuilder();
+        queryBuilder.append("(");
+        for (RowExpression argument : node.getArguments().subList(1, node.getArguments().size())) {
+            if (!(argument instanceof ConstantExpression)) {
+                return new ClpExpression(node);
+            }
+            ConstantExpression literal = (ConstantExpression) argument;
+            String literalString = getLiteralString(literal);
+            queryBuilder.append(variableName).append(": ");
+            if (literal.getType() instanceof VarcharType) {
+                queryBuilder.append("\"").append(literalString).append("\"");
+            }
+            else {
+                queryBuilder.append(literalString);
+            }
+            queryBuilder.append(" OR ");
+        }
+        // Remove the last " OR " from the query
+        return new ClpExpression(queryBuilder.substring(0, queryBuilder.length() - 4) + ")");
+    }
+
+    /**
+     * Handles the IS NULL predicate.
+     * Example:
+     *   Input: col1 IS NULL
+     *   Output: NOT col1: *
+     */
+    private ClpExpression handleIsNull(SpecialFormExpression node)
+    {
+        if (node.getArguments().size() != 1) {
+            throw new PrestoException(CLP_PUSHDOWN_UNSUPPORTED_EXPRESSION,
+                    "IS NULL operator must have exactly one argument. Received: " + node);
+        }
+
+        ClpExpression expression = node.getArguments().get(0).accept(this, null);
+        if (!expression.getDefinition().isPresent()) {
+            return new ClpExpression(node);
+        }
+
+        String variableName = expression.getDefinition().get();
+        return new ClpExpression(String.format("NOT %s: *", variableName));
+    }
+
+    /**
+     * Handles dereference expressions on RowTypes (e.g., col.row_field).
+     * Converts row dereferences into dot-separated field access.
+     * Example:
+     *   Input: address.city (from a RowType 'address')
+     *   Output: address.city
+     */
+    private ClpExpression handleDereference(RowExpression expression)
+    {
+        if (expression instanceof VariableReferenceExpression) {
+            return expression.accept(this, null);
+        }
+
+        if (!(expression instanceof SpecialFormExpression)) {
+            return new ClpExpression(expression);
+        }
+
+        SpecialFormExpression specialForm = (SpecialFormExpression) expression;
+        List<RowExpression> arguments = specialForm.getArguments();
+        if (arguments.size() != 2) {
+            throw new PrestoException(CLP_PUSHDOWN_UNSUPPORTED_EXPRESSION, "DEREFERENCE expects 2 arguments");
+        }
+
+        RowExpression base = arguments.get(0);
+        RowExpression index = arguments.get(1);
+        if (!(index instanceof ConstantExpression)) {
+            throw new PrestoException(CLP_PUSHDOWN_UNSUPPORTED_EXPRESSION, "DEREFERENCE index must be a constant");
+        }
+
+        ConstantExpression constExpr = (ConstantExpression) index;
+        Object value = constExpr.getValue();
+        if (!(value instanceof Long)) {
+            throw new PrestoException(CLP_PUSHDOWN_UNSUPPORTED_EXPRESSION, "DEREFERENCE index constant is not a long");
+        }
+
+        int fieldIndex = ((Long) value).intValue();
+
+        Type baseType = base.getType();
+        if (!(baseType instanceof RowType)) {
+            throw new PrestoException(CLP_PUSHDOWN_UNSUPPORTED_EXPRESSION, "DEREFERENCE base is not a RowType: " + baseType);
+        }
+
+        RowType rowType = (RowType) baseType;
+        if (fieldIndex < 0 || fieldIndex >= rowType.getFields().size()) {
+            throw new PrestoException(CLP_PUSHDOWN_UNSUPPORTED_EXPRESSION, "Invalid field index " + fieldIndex + " for RowType: " + rowType);
+        }
+
+        RowType.Field field = rowType.getFields().get(fieldIndex);
+        String fieldName = field.getName().orElse("field" + fieldIndex);
+
+        ClpExpression baseString = handleDereference(base);
+        if (!baseString.getDefinition().isPresent()) {
+            return new ClpExpression(expression);
+        }
+        return new ClpExpression(baseString.getDefinition().get() + "." + fieldName);
+    }
+
+    /**
+     * Handles LIKE expressions.
+     * Transforms SQL LIKE into KQL queries using wildcards (* and ?).
+     * Supports constant patterns or constant casts only.
+     * Example:
+     *   Input: col1 LIKE 'a_bc%'
+     *   Output: col1: "a?bc*"
+     */
+    private ClpExpression handleLike(CallExpression node)
+    {
+        if (node.getArguments().size() != 2) {
+            throw new PrestoException(CLP_PUSHDOWN_UNSUPPORTED_EXPRESSION, "LIKE operator must have exactly two arguments. Received: " + node);
+        }
+        ClpExpression variable = node.getArguments().get(0).accept(this, null);
+        if (!variable.getDefinition().isPresent()) {
+            return new ClpExpression(node);
+        }
+
+        String variableName = variable.getDefinition().get();
+        RowExpression argument = node.getArguments().get(1);
+
+        String pattern;
+        if (argument instanceof ConstantExpression) {
+            ConstantExpression literal = (ConstantExpression) argument;
+            pattern = getLiteralString(literal);
+        }
+        else if (argument instanceof CallExpression) {
+            CallExpression callExpression = (CallExpression) argument;
+            if (!standardFunctionResolution.isCastFunction(callExpression.getFunctionHandle())) {
+                return new ClpExpression(node);
+            }
+            if (callExpression.getArguments().size() != 1) {
+                throw new PrestoException(CLP_PUSHDOWN_UNSUPPORTED_EXPRESSION, "CAST function must have exactly one argument. Received: " + callExpression);
+            }
+            if (!(callExpression.getArguments().get(0) instanceof ConstantExpression)) {
+                return new ClpExpression(node);
+            }
+            pattern = getLiteralString((ConstantExpression) callExpression.getArguments().get(0));
+        }
+        else {
+            return new ClpExpression(node);
+        }
+        pattern = pattern.replace("%", "*").replace("_", "?");
+        return new ClpExpression(String.format("%s: \"%s\"", variableName, pattern));
+    }
+
+    private static class SubstrInfo
+    {
+        String variableName;
+        RowExpression startExpression;
+        RowExpression lengthExpression;
+        SubstrInfo(String variableName, RowExpression start, RowExpression length)
+        {
+            this.variableName = variableName;
+            this.startExpression = start;
+            this.lengthExpression = length;
+        }
+    }
+
+    /**
+     * Parse SUBSTR(...) calls that appear either as:
+     *   SUBSTR(x, start)
+     * or
+     *   SUBSTR(x, start, length)
+     */
+    private Optional<SubstrInfo> parseSubstringCall(CallExpression callExpression)
+    {
+        FunctionMetadata functionMetadata = functionMetadataManager.getFunctionMetadata(callExpression.getFunctionHandle());
+        String functionName = functionMetadata.getName().getObjectName();
+        if (!functionName.equals("substr")) {
+            return Optional.empty();
+        }
+
+        int argCount = callExpression.getArguments().size();
+        if (argCount < 2 || argCount > 3) {
+            return Optional.empty();
+        }
+
+        ClpExpression variable = callExpression.getArguments().get(0).accept(this, null);
+        if (!variable.getDefinition().isPresent()) {
+            return Optional.empty();
+        }
+
+        String varName = variable.getDefinition().get();
+        RowExpression startExpression = callExpression.getArguments().get(1);
+        RowExpression lengthExpression = null;
+        if (argCount == 3) {
+            lengthExpression = callExpression.getArguments().get(2);
+        }
+
+        return Optional.of(new SubstrInfo(varName, startExpression, lengthExpression));
+    }
+
+    /**
+     * Attempt to parse "start" or "length" as an integer.
+     */
+    private Optional<Integer> parseIntValue(RowExpression expression)
+    {
+        if (expression instanceof ConstantExpression) {
+            try {
+                return Optional.of(Integer.parseInt(getLiteralString((ConstantExpression) expression)));
+            }
+            catch (NumberFormatException ignored) { }
+        }
+        else if (expression instanceof CallExpression) {
+            CallExpression call = (CallExpression) expression;
+            FunctionMetadata functionMetadata = functionMetadataManager.getFunctionMetadata(call.getFunctionHandle());
+            Optional<OperatorType> operatorTypeOptional = functionMetadata.getOperatorType();
+            if (operatorTypeOptional.isPresent() && operatorTypeOptional.get().equals(OperatorType.NEGATION)) {
+                RowExpression arg0 = call.getArguments().get(0);
+                if (arg0 instanceof ConstantExpression) {
+                    try {
+                        return Optional.of(-Integer.parseInt(getLiteralString((ConstantExpression) arg0)));
+                    }
+                    catch (NumberFormatException ignored) { }
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * If lengthExpression is a constant integer that matches targetString.length(),
+     * return that length. Otherwise empty.
+     */
+    private Optional<Integer> parseLengthLiteralOrFunction(RowExpression lengthExpression, String targetString)
+    {
+        if (lengthExpression instanceof ConstantExpression) {
+            String val = getLiteralString((ConstantExpression) lengthExpression);
+            try {
+                int parsed = Integer.parseInt(val);
+                if (parsed == targetString.length()) {
+                    return Optional.of(parsed);
+                }
+            }
+            catch (NumberFormatException ignored) { }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Translate SUBSTR(x, start) or SUBSTR(x, start, length) = 'someString' to KQL.
+     * Examples:
+     *   SUBSTR(message, 1, 3) = 'abc'
+     *     → message: "abc*"
+     *   SUBSTR(message, 4, 3) = 'abc'
+     *     → message: "???abc*"
+     *   SUBSTR(message, 2) = 'hello'
+     *     → message: "?hello"
+     *   SUBSTR(message, -5) = 'hello'
+     *     → message: "*hello"
+     */
+    private ClpExpression interpretSubstringEquality(SubstrInfo info, String targetString)
+    {
+        if (info.lengthExpression != null) {
+            Optional<Integer> maybeStart = parseIntValue(info.startExpression);
+            Optional<Integer> maybeLen = parseLengthLiteralOrFunction(info.lengthExpression, targetString);
+
+            if (maybeStart.isPresent() && maybeLen.isPresent()) {
+                int start = maybeStart.get();
+                int len = maybeLen.get();
+                if (start > 0 && len == targetString.length()) {
+                    StringBuilder result = new StringBuilder();
+                    result.append(info.variableName).append(": \"");
+                    for (int i = 1; i < start; i++) {
+                        result.append("?");
+                    }
+                    result.append(targetString).append("*\"");
+                    return new ClpExpression(result.toString());
+                }
+            }
+        }
+        else {
+            Optional<Integer> maybeStart = parseIntValue(info.startExpression);
+            if (maybeStart.isPresent()) {
+                int start = maybeStart.get();
+                if (start > 0) {
+                    StringBuilder result = new StringBuilder();
+                    result.append(info.variableName).append(": \"");
+                    for (int i = 1; i < start; i++) {
+                        result.append("?");
+                    }
+                    result.append(targetString).append("\"");
+                    return new ClpExpression(result.toString());
+                }
+                if (start == -targetString.length()) {
+                    return new ClpExpression(String.format("%s: \"*%s\"", info.variableName, targetString));
+                }
+            }
+        }
+
+        return new ClpExpression();
+    }
+
+    /**
+     * Checks whether the given expression matches the pattern SUBSTR(x, ...) = 'someString',
+     * and if so, attempts to convert it into a KQL query using wildcards and construct a CLP expression.
+     */
+    private ClpExpression tryInterpretSubstringEquality(
+            OperatorType operator,
+            RowExpression possibleSubstring,
+            RowExpression possibleLiteral)
+    {
+        if (!operator.equals(OperatorType.EQUAL)) {
+            return new ClpExpression();
+        }
+
+        if (!(possibleSubstring instanceof CallExpression) ||
+                !(possibleLiteral instanceof ConstantExpression)) {
+            return new ClpExpression();
+        }
+
+        Optional<SubstrInfo> maybeSubstringCall = parseSubstringCall((CallExpression) possibleSubstring);
+        if (!maybeSubstringCall.isPresent()) {
+            return new ClpExpression();
+        }
+
+        String targetString = getLiteralString((ConstantExpression) possibleLiteral);
+        return interpretSubstringEquality(maybeSubstringCall.get(), targetString);
+    }
+
+    /**
+     * Builds a CLP expression from a basic comparison between a variable and a literal.
+     * Handles different operator types (EQUAL, NOT_EQUAL, and logical binary ops like <, >, etc.)
+     * and formats them appropriately based on whether the literal is a string or a non-string type.
+     * Examples:
+     *   col = 'abc'       → col: "abc"
+     *   col != 42         → NOT col: 42
+     *   5 < col           → col > 5
+     */
+    private ClpExpression buildClpExpression(
+            String variableName,
+            String literalString,
+            OperatorType operator,
+            Type literalType,
+            RowExpression originalNode)
+    {
+        if (operator.equals(OperatorType.EQUAL)) {
+            if (literalType instanceof VarcharType) {
+                return new ClpExpression(String.format("%s: \"%s\"", variableName, literalString));
+            }
+            else {
+                return new ClpExpression(String.format("%s: %s", variableName, literalString));
+            }
+        }
+        else if (operator.equals(OperatorType.NOT_EQUAL)) {
+            if (literalType instanceof VarcharType) {
+                return new ClpExpression(String.format("NOT %s: \"%s\"", variableName, literalString));
+            }
+            else {
+                return new ClpExpression(String.format("NOT %s: %s", variableName, literalString));
+            }
+        }
+        else if (LOGICAL_BINARY_OPS_FILTER.contains(operator) && !(literalType instanceof VarcharType)) {
+            return new ClpExpression(String.format("%s %s %s", variableName, operator.getOperator(), literalString));
+        }
+        return new ClpExpression(originalNode);
+    }
+
+    /**
+     * Handles logical binary operators (e.g., =, !=, <, >) between two expressions.
+     * Supports constant on either side by flipping the operator when needed.
+     * Also checks for SUBSTR(x, ...) = 'value' patterns and delegates to substring handler.
+     */
+    private ClpExpression handleLogicalBinary(OperatorType operator, CallExpression node)
+    {
+        if (node.getArguments().size() != 2) {
+            throw new PrestoException(CLP_PUSHDOWN_UNSUPPORTED_EXPRESSION,
+                    "Logical binary operator must have exactly two arguments. Received: " + node);
+        }
+        RowExpression left = node.getArguments().get(0);
+        RowExpression right = node.getArguments().get(1);
+
+        ClpExpression maybeLeftSubstring = tryInterpretSubstringEquality(operator, left, right);
+        if (maybeLeftSubstring.getDefinition().isPresent()) {
+            return maybeLeftSubstring;
+        }
+
+        ClpExpression maybeRightSubstring = tryInterpretSubstringEquality(operator, right, left);
+        if (maybeRightSubstring.getDefinition().isPresent()) {
+            return maybeRightSubstring;
+        }
+
+        ClpExpression leftExpression = left.accept(this, null);
+        ClpExpression rightExpression = right.accept(this, null);
+        Optional<String> leftDefinition = leftExpression.getDefinition();
+        Optional<String> rightDefinition = rightExpression.getDefinition();
+        if (!leftDefinition.isPresent() || !rightDefinition.isPresent()) {
+            return new ClpExpression(node);
+        }
+
+        boolean leftIsConstant = (left instanceof ConstantExpression);
+        boolean rightIsConstant = (right instanceof ConstantExpression);
+
+        Type leftType = left.getType();
+        Type rightType = right.getType();
+
+        if (rightIsConstant) {
+            return buildClpExpression(
+                    leftDefinition.get(),    // variable
+                    rightDefinition.get(),   // literal
+                    operator,
+                    rightType,
+                    node);
+        }
+        else if (leftIsConstant) {
+            OperatorType newOperator = OperatorType.flip(operator);
+            return buildClpExpression(
+                    rightDefinition.get(),   // variable
+                    leftDefinition.get(),    // literal
+                    newOperator,
+                    leftType,
+                    node);
+        }
+        // fallback
+        return new ClpExpression(node);
+    }
+}

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpMetadata.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpMetadata.java
@@ -119,7 +119,7 @@ public class ClpMetadata
             Optional<Set<ColumnHandle>> desiredColumns)
     {
         ClpTableHandle tableHandle = (ClpTableHandle) table;
-        ConnectorTableLayout layout = new ConnectorTableLayout(new ClpTableLayoutHandle(tableHandle, Optional.empty()));
+        ConnectorTableLayout layout = new ConnectorTableLayout(new ClpTableLayoutHandle(tableHandle, Optional.empty(), Optional.empty()));
         return new ConnectorTableLayoutResult(layout, constraint.getSummary());
     }
 

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpMetadataFilterProvider.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpMetadataFilterProvider.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.clp;
+
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.SchemaTableName;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Inject;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import static com.facebook.presto.plugin.clp.ClpConnectorFactory.CONNECTOR_NAME;
+import static com.facebook.presto.plugin.clp.ClpErrorCode.CLP_MANDATORY_METADATA_FILTER_NOT_VALID;
+import static com.facebook.presto.plugin.clp.ClpErrorCode.CLP_METADATA_FILTER_CONFIG_NOT_FOUND;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static java.util.Objects.requireNonNull;
+
+public class ClpMetadataFilterProvider
+{
+    private final Map<String, TableConfig> filterMap;
+
+    @Inject
+    public ClpMetadataFilterProvider(ClpConfig config)
+    {
+        requireNonNull(config, "config is null");
+
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            filterMap = mapper.readValue(
+                    new File(config.getMetadataFilterConfig()),
+                    new TypeReference<Map<String, TableConfig>>() {});
+        }
+        catch (IOException e) {
+            throw new PrestoException(CLP_METADATA_FILTER_CONFIG_NOT_FOUND, "Failed to metadata filter config file open.");
+        }
+    }
+
+    public Map<String, TableConfig> getFilterMap()
+    {
+        return filterMap;
+    }
+
+    public void checkContainsAllFilters(SchemaTableName schemaTableName, String metadataFilterKqlQuery)
+    {
+        boolean hasAllMetadataFilterColumns = true;
+        String notFoundFilterColumnName = "";
+        for (String columnName : getFilterNames(
+                CONNECTOR_NAME + "." + schemaTableName.toString())) {
+            if (!metadataFilterKqlQuery.contains(columnName)) {
+                hasAllMetadataFilterColumns = false;
+                notFoundFilterColumnName = columnName;
+                break;
+            }
+        }
+        if (!hasAllMetadataFilterColumns) {
+            throw new PrestoException(CLP_MANDATORY_METADATA_FILTER_NOT_VALID, notFoundFilterColumnName + " is a mandatory metadata filter column but not valid");
+        }
+    }
+
+    public String remapFilterSql(String scope, String sql)
+    {
+        String[] splitScope = scope.split("\\.");
+        if (0 == splitScope.length) {
+            return sql;
+        }
+
+        Map<String, RangeMapping> mappings = new HashMap<>(getAllMappingsFromTableConfig(filterMap.get(splitScope[0])));
+
+        if (1 < splitScope.length) {
+            mappings.putAll(getAllMappingsFromTableConfig(filterMap.get(splitScope[0] + "." + splitScope[1])));
+        }
+
+        if (3 == splitScope.length) {
+            mappings.putAll(getAllMappingsFromTableConfig(filterMap.get(scope)));
+        }
+
+        String remappedSql = sql;
+        for (Map.Entry<String, RangeMapping> entry : mappings.entrySet()) {
+            remappedSql = remappedSql.replaceAll(
+                    "\"(" + entry.getKey() + ")\"\\s(>=?)\\s([0-9]*)", entry.getValue().upperBound + " $2 $3");
+            remappedSql = remappedSql.replaceAll(
+                    "\"(" + entry.getKey() + ")\"\\s(<=?)\\s([0-9]*)", entry.getValue().lowerBound + " $2 $3");
+            remappedSql = remappedSql.replaceAll(
+                    "\"(" + entry.getKey() + ")\"\\s(=)\\s([0-9]*)",
+                    "(" + entry.getValue().lowerBound + " <= $3 AND " + entry.getValue().upperBound + " >= $3)");
+        }
+        return remappedSql;
+    }
+
+    public Set<String> getFilterNames(String scope)
+    {
+        String[] splitScope = scope.split("\\.");
+        if (0 == splitScope.length) {
+            return Collections.emptySet();
+        }
+        Set<String> filterNames = new HashSet<>(getAllFilerNamesFromTableConfig(filterMap.get(splitScope[0])));
+
+        if (1 < splitScope.length) {
+            filterNames.addAll(getAllFilerNamesFromTableConfig(filterMap.get(splitScope[0] + "." + splitScope[1])));
+        }
+
+        if (3 == splitScope.length) {
+            filterNames.addAll(getAllFilerNamesFromTableConfig(filterMap.get(scope)));
+        }
+        return ImmutableSet.copyOf(filterNames);
+    }
+
+    private Set<String> getAllFilerNamesFromTableConfig(TableConfig tableConfig)
+    {
+        return null != tableConfig ? tableConfig.filters.stream()
+                .map(filter -> filter.filterName)
+                .collect(toImmutableSet()) : ImmutableSet.of();
+    }
+
+    private Map<String, RangeMapping> getAllMappingsFromTableConfig(TableConfig tableConfig)
+    {
+        return tableConfig != null
+                ? tableConfig.filters.stream()
+                .filter(filter -> null != filter.rangeMapping)
+                .collect(toImmutableMap(
+                        filter -> filter.filterName,
+                        filter -> filter.rangeMapping))
+                : ImmutableMap.of();
+    }
+
+    private static class TableConfig
+    {
+        public List<Filter> filters;
+    }
+
+    private static class RangeMapping
+    {
+        @JsonProperty("lowerBound")
+        public String lowerBound;
+
+        @JsonProperty("upperBound")
+        public String upperBound;
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof RangeMapping)) {
+                return false;
+            }
+            RangeMapping that = (RangeMapping) o;
+            return Objects.equals(lowerBound, that.lowerBound) &&
+                    Objects.equals(upperBound, that.upperBound);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(lowerBound, upperBound);
+        }
+    }
+
+    private static class Filter
+    {
+        @JsonProperty("filterName")
+        public String filterName;
+
+        @JsonProperty("rangeMapping")
+        public RangeMapping rangeMapping;
+    }
+}

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpModule.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpModule.java
@@ -36,6 +36,7 @@ public class ClpModule
     {
         binder.bind(ClpConnector.class).in(Scopes.SINGLETON);
         binder.bind(ClpMetadata.class).in(Scopes.SINGLETON);
+        binder.bind(ClpMetadataFilterProvider.class).in(Scopes.SINGLETON);
         binder.bind(ClpRecordSetProvider.class).in(Scopes.SINGLETON);
         binder.bind(ClpSplitManager.class).in(Scopes.SINGLETON);
         configBinder(binder).bindConfig(ClpConfig.class);

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpPlanOptimizer.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpPlanOptimizer.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.clp;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorPlanOptimizer;
+import com.facebook.presto.spi.ConnectorPlanRewriter;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.TableHandle;
+import com.facebook.presto.spi.VariableAllocator;
+import com.facebook.presto.spi.function.FunctionMetadataManager;
+import com.facebook.presto.spi.function.StandardFunctionResolution;
+import com.facebook.presto.spi.plan.FilterNode;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
+import com.facebook.presto.spi.plan.TableScanNode;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.spi.ConnectorPlanRewriter.rewriteWith;
+import static java.util.Objects.requireNonNull;
+
+public class ClpPlanOptimizer
+        implements ConnectorPlanOptimizer
+{
+    private static final Logger log = Logger.get(ClpPlanOptimizer.class);
+    private final FunctionMetadataManager functionManager;
+    private final StandardFunctionResolution functionResolution;
+
+    public ClpPlanOptimizer(FunctionMetadataManager functionManager,
+            StandardFunctionResolution functionResolution)
+    {
+        this.functionManager = requireNonNull(functionManager, "functionManager is null");
+        this.functionResolution = requireNonNull(functionResolution, "functionResolution is null");
+    }
+
+    @Override
+    public PlanNode optimize(PlanNode maxSubplan,
+            ConnectorSession session,
+            VariableAllocator variableAllocator,
+            PlanNodeIdAllocator idAllocator)
+    {
+        return rewriteWith(new Rewriter(idAllocator), maxSubplan);
+    }
+
+    private class Rewriter
+            extends ConnectorPlanRewriter<Void>
+    {
+        private final PlanNodeIdAllocator idAllocator;
+
+        public Rewriter(PlanNodeIdAllocator idAllocator)
+        {
+            this.idAllocator = idAllocator;
+        }
+
+        @Override
+        public PlanNode visitFilter(FilterNode node, RewriteContext<Void> context)
+        {
+            if (!(node.getSource() instanceof TableScanNode)) {
+                return node;
+            }
+
+            TableScanNode tableScanNode = (TableScanNode) node.getSource();
+            Map<VariableReferenceExpression, ColumnHandle> assignments = tableScanNode.getAssignments();
+            TableHandle tableHandle = tableScanNode.getTable();
+            ClpTableHandle clpTableHandle = (ClpTableHandle) tableHandle.getConnectorHandle();
+            ClpExpression clpExpression = node.getPredicate()
+                    .accept(new ClpFilterToKqlConverter(functionResolution, functionManager, assignments), null);
+            Optional<String> kqlQuery = clpExpression.getDefinition();
+            Optional<RowExpression> remainingPredicate = clpExpression.getRemainingExpression();
+            if (!kqlQuery.isPresent()) {
+                return node;
+            }
+            log.debug("KQL query: %s", kqlQuery.get());
+            ClpTableLayoutHandle clpTableLayoutHandle = new ClpTableLayoutHandle(clpTableHandle, kqlQuery);
+            TableScanNode newTableScanNode = new TableScanNode(
+                    tableScanNode.getSourceLocation(),
+                    idAllocator.getNextId(),
+                    new TableHandle(
+                            tableHandle.getConnectorId(),
+                            clpTableHandle,
+                            tableHandle.getTransaction(),
+                            Optional.of(clpTableLayoutHandle)),
+                    tableScanNode.getOutputVariables(),
+                    tableScanNode.getAssignments(),
+                    tableScanNode.getTableConstraints(),
+                    tableScanNode.getCurrentConstraint(),
+                    tableScanNode.getEnforcedConstraint(),
+                    tableScanNode.getCteMaterializationInfo());
+            if (!remainingPredicate.isPresent()) {
+                return newTableScanNode;
+            }
+
+            return new FilterNode(node.getSourceLocation(),
+                    idAllocator.getNextId(),
+                    newTableScanNode,
+                    remainingPredicate.get());
+        }
+    }
+}

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpPlanOptimizer.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpPlanOptimizer.java
@@ -32,6 +32,7 @@ import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import java.util.Map;
 import java.util.Optional;
 
+import static com.facebook.presto.plugin.clp.ClpConnectorFactory.CONNECTOR_NAME;
 import static com.facebook.presto.spi.ConnectorPlanRewriter.rewriteWith;
 import static java.util.Objects.requireNonNull;
 
@@ -41,12 +42,16 @@ public class ClpPlanOptimizer
     private static final Logger log = Logger.get(ClpPlanOptimizer.class);
     private final FunctionMetadataManager functionManager;
     private final StandardFunctionResolution functionResolution;
+    private final ClpMetadataFilterProvider metadataFilterProvider;
 
-    public ClpPlanOptimizer(FunctionMetadataManager functionManager,
-            StandardFunctionResolution functionResolution)
+    public ClpPlanOptimizer(
+            FunctionMetadataManager functionManager,
+            StandardFunctionResolution functionResolution,
+            ClpMetadataFilterProvider metadataFilterProvider)
     {
         this.functionManager = requireNonNull(functionManager, "functionManager is null");
         this.functionResolution = requireNonNull(functionResolution, "functionResolution is null");
+        this.metadataFilterProvider = requireNonNull(metadataFilterProvider, "metadataFilterProvider is null");
     }
 
     @Override
@@ -79,15 +84,31 @@ public class ClpPlanOptimizer
             Map<VariableReferenceExpression, ColumnHandle> assignments = tableScanNode.getAssignments();
             TableHandle tableHandle = tableScanNode.getTable();
             ClpTableHandle clpTableHandle = (ClpTableHandle) tableHandle.getConnectorHandle();
+            String scope = CONNECTOR_NAME + "." + clpTableHandle.getSchemaTableName().toString();
             ClpExpression clpExpression = node.getPredicate()
-                    .accept(new ClpFilterToKqlConverter(functionResolution, functionManager, assignments), null);
+                    .accept(new ClpFilterToKqlConverter(
+                            functionResolution,
+                            functionManager,
+                            assignments,
+                            metadataFilterProvider.getFilterNames(scope)), null);
             Optional<String> kqlQuery = clpExpression.getDefinition();
+            Optional<String> metadataSql = clpExpression.getMetadataSql();
             Optional<RowExpression> remainingPredicate = clpExpression.getRemainingExpression();
+
+            // This must be checked before check if the KQL is present, otherwise KQL can be emptry then this function
+            // directly exits.
+            metadataFilterProvider.checkContainsAllFilters(clpTableHandle.getSchemaTableName(), metadataSql.orElse(""));
+            if (metadataSql.isPresent()) {
+                metadataSql = Optional.of(metadataFilterProvider.remapFilterSql(scope, metadataSql.get()));
+                log.info("Metadata filter SQL query: %s", metadataSql);
+            }
+
             if (!kqlQuery.isPresent()) {
                 return node;
             }
-            log.debug("KQL query: %s", kqlQuery.get());
-            ClpTableLayoutHandle clpTableLayoutHandle = new ClpTableLayoutHandle(clpTableHandle, kqlQuery);
+            log.debug("KQL query: %s", kqlQuery);
+
+            ClpTableLayoutHandle clpTableLayoutHandle = new ClpTableLayoutHandle(clpTableHandle, kqlQuery, metadataSql);
             TableScanNode newTableScanNode = new TableScanNode(
                     tableScanNode.getSourceLocation(),
                     idAllocator.getNextId(),

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpPlanOptimizerProvider.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpPlanOptimizerProvider.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.clp;
+
+import com.facebook.presto.spi.ConnectorPlanOptimizer;
+import com.facebook.presto.spi.connector.ConnectorPlanOptimizerProvider;
+import com.facebook.presto.spi.function.FunctionMetadataManager;
+import com.facebook.presto.spi.function.StandardFunctionResolution;
+import com.google.common.collect.ImmutableSet;
+
+import javax.inject.Inject;
+
+import java.util.Set;
+
+public class ClpPlanOptimizerProvider
+        implements ConnectorPlanOptimizerProvider
+{
+    private final FunctionMetadataManager functionManager;
+    private final StandardFunctionResolution functionResolution;
+
+    @Inject
+    public ClpPlanOptimizerProvider(FunctionMetadataManager functionManager,
+            StandardFunctionResolution functionResolution)
+    {
+        this.functionManager = functionManager;
+        this.functionResolution = functionResolution;
+    }
+
+    @Override
+    public Set<ConnectorPlanOptimizer> getLogicalPlanOptimizers()
+    {
+        return ImmutableSet.of();
+    }
+
+    @Override
+    public Set<ConnectorPlanOptimizer> getPhysicalPlanOptimizers()
+    {
+        return ImmutableSet.of(new ClpPlanOptimizer(functionManager, functionResolution));
+    }
+}

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpPlanOptimizerProvider.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpPlanOptimizerProvider.java
@@ -28,13 +28,17 @@ public class ClpPlanOptimizerProvider
 {
     private final FunctionMetadataManager functionManager;
     private final StandardFunctionResolution functionResolution;
+    private final ClpMetadataFilterProvider metadataFilterProvider;
 
     @Inject
-    public ClpPlanOptimizerProvider(FunctionMetadataManager functionManager,
-            StandardFunctionResolution functionResolution)
+    public ClpPlanOptimizerProvider(
+            FunctionMetadataManager functionManager,
+            StandardFunctionResolution functionResolution,
+            ClpMetadataFilterProvider metadataFilterProvider)
     {
         this.functionManager = functionManager;
         this.functionResolution = functionResolution;
+        this.metadataFilterProvider = metadataFilterProvider;
     }
 
     @Override
@@ -46,6 +50,6 @@ public class ClpPlanOptimizerProvider
     @Override
     public Set<ConnectorPlanOptimizer> getPhysicalPlanOptimizers()
     {
-        return ImmutableSet.of(new ClpPlanOptimizer(functionManager, functionResolution));
+        return ImmutableSet.of(new ClpPlanOptimizer(functionManager, functionResolution, metadataFilterProvider));
     }
 }

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpTableLayoutHandle.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpTableLayoutHandle.java
@@ -27,12 +27,17 @@ public class ClpTableLayoutHandle
 {
     private final ClpTableHandle table;
     private final Optional<String> kqlQuery;
+    private final Optional<String> metadataSql;
 
     @JsonCreator
-    public ClpTableLayoutHandle(@JsonProperty("table") ClpTableHandle table, @JsonProperty("kqlQuery") Optional<String> kqlQuery)
+    public ClpTableLayoutHandle(
+            @JsonProperty("table") ClpTableHandle table,
+            @JsonProperty("kqlQuery") Optional<String> kqlQuery,
+            @JsonProperty("metadataFilterQuery") Optional<String> metadataSql)
     {
         this.table = table;
         this.kqlQuery = kqlQuery;
+        this.metadataSql = metadataSql;
     }
 
     @JsonProperty
@@ -47,6 +52,12 @@ public class ClpTableLayoutHandle
         return kqlQuery;
     }
 
+    @JsonProperty
+    public Optional<String> getMetadataSql()
+    {
+        return metadataSql;
+    }
+
     @Override
     public boolean equals(Object o)
     {
@@ -58,13 +69,14 @@ public class ClpTableLayoutHandle
         }
         ClpTableLayoutHandle that = (ClpTableLayoutHandle) o;
         return Objects.equals(table, that.table) &&
-                Objects.equals(kqlQuery, that.kqlQuery);
+                Objects.equals(kqlQuery, that.kqlQuery) &&
+                Objects.equals(metadataSql, that.metadataSql);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(table, kqlQuery);
+        return Objects.hash(table, kqlQuery, metadataSql);
     }
 
     @Override
@@ -73,6 +85,7 @@ public class ClpTableLayoutHandle
         return toStringHelper(this)
                 .add("table", table)
                 .add("kqlQuery", kqlQuery)
+                .add("metadataSql", metadataSql)
                 .toString();
     }
 }

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpUtils.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpUtils.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.clp;
+
+import com.facebook.airlift.log.Logger;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class ClpUtils
+{
+    public static class KqlUtils
+    {
+        private static final Logger log = Logger.get(KqlUtils.class);
+
+        public static String toSql(String kqlQuery)
+        {
+            String sqlQuery = kqlQuery;
+
+            // Translate string filters
+            Pattern stringFilterPattern = Pattern.compile("([a-zA-Z_][a-zA-Z0-9_]*):\\s*\"([^\"]+)\"");
+            Matcher stringFilterMatcher = stringFilterPattern.matcher(sqlQuery);
+            StringBuilder translateStringFiltersSb = new StringBuilder();
+
+            int lastStringFilterEnd = 0;
+            while (stringFilterMatcher.find()) {
+                String columnName = stringFilterMatcher.group(1);
+                String value = stringFilterMatcher.group(2);
+
+                // Append everything between last match and this one
+                translateStringFiltersSb.append(sqlQuery, lastStringFilterEnd, stringFilterMatcher.start());
+
+                if (value.contains("*")) {
+                    translateStringFiltersSb.append("\"")
+                            .append(columnName)
+                            .append("\" LIKE '")
+                            .append(value.replace('*', '%'))
+                            .append("'");
+                }
+                else {
+                    translateStringFiltersSb.append("\"")
+                            .append(columnName)
+                            .append("\" = '")
+                            .append(value)
+                            .append("'");
+                }
+
+                lastStringFilterEnd = stringFilterMatcher.end();
+            }
+            translateStringFiltersSb.append(sqlQuery.substring(lastStringFilterEnd));
+            sqlQuery = translateStringFiltersSb.toString();
+
+            // Translate numeric filters
+            Pattern numericFilterPattern = Pattern.compile("([a-zA-Z_][a-zA-Z0-9_]*)\\s*([><]=?|:)\\s*(-?\\d+(?:\\.\\d+)?)");
+            Matcher numericFilterMatcher = numericFilterPattern.matcher(sqlQuery);
+            StringBuilder translateNumericFilterSb = new StringBuilder();
+
+            int lastNumericFilterEnd = 0;
+            while (numericFilterMatcher.find()) {
+                String columnName = numericFilterMatcher.group(1);
+                String operator = numericFilterMatcher.group(2);
+                if (":".equals(operator)) {
+                    operator = "=";
+                }
+                String value = numericFilterMatcher.group(3);
+
+                // Append everything between last match and this one
+                translateNumericFilterSb.append(sqlQuery, lastNumericFilterEnd, numericFilterMatcher.start());
+
+                translateNumericFilterSb.append("\"")
+                        .append(columnName)
+                        .append("\" ")
+                        .append(operator)
+                        .append(" ")
+                        .append(value);
+
+                lastNumericFilterEnd = numericFilterMatcher.end();
+            }
+            translateNumericFilterSb.append(sqlQuery.substring(lastNumericFilterEnd));
+            sqlQuery = translateNumericFilterSb.toString();
+
+            return sqlQuery;
+        }
+
+        public static String escapeKqlSpecialCharsForStringValue(String literalString)
+        {
+            String escaped = literalString;
+            escaped = escaped.replace("\\", "\\\\");
+            escaped = escaped.replace("\"", "\\\"");
+            escaped = escaped.replace("?", "\\?");
+            escaped = escaped.replace("*", "\\*");
+            return escaped;
+        }
+    }
+}

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/metadata/ClpSchemaTree.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/metadata/ClpSchemaTree.java
@@ -15,6 +15,7 @@ package com.facebook.presto.plugin.clp.metadata;
 
 import com.facebook.presto.common.type.ArrayType;
 import com.facebook.presto.common.type.RowType;
+import com.facebook.presto.common.type.TimestampType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.plugin.clp.ClpColumnHandle;
 import com.facebook.presto.spi.PrestoException;
@@ -119,9 +120,10 @@ public class ClpSchemaTree
                 return DOUBLE;
             case ClpString:
             case VarString:
-            case DateString:
             case NullValue:
                 return VARCHAR;
+            case DateString:
+                return TimestampType.TIMESTAMP;
             case UnstructuredArray:
                 return new ArrayType(VARCHAR);
             case Boolean:

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpMySqlSplitProvider.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpMySqlSplitProvider.java
@@ -41,7 +41,7 @@ public class ClpMySqlSplitProvider
     public static final String ARCHIVE_TABLE_SUFFIX = "_archives";
 
     // SQL templates
-    private static final String SQL_SELECT_ARCHIVES_TEMPLATE = format("SELECT `%s` FROM `%%s%%s%s`", ARCHIVES_TABLE_COLUMN_ID, ARCHIVE_TABLE_SUFFIX);
+    private static final String SQL_SELECT_ARCHIVES_TEMPLATE = format("SELECT `%s` FROM `%%s%%s%s` WHERE 1 = 1", ARCHIVES_TABLE_COLUMN_ID, ARCHIVE_TABLE_SUFFIX);
 
     private static final Logger log = Logger.get(ClpMySqlSplitProvider.class);
 
@@ -69,6 +69,12 @@ public class ClpMySqlSplitProvider
         String tableName = clpTableHandle.getSchemaTableName().getTableName();
         String archivePathQuery = format(SQL_SELECT_ARCHIVES_TEMPLATE, config.getMetadataTablePrefix(), tableName);
 
+        if (clpTableLayoutHandle.getMetadataSql().isPresent()) {
+            String metadataFilterQuery = clpTableLayoutHandle.getMetadataSql().get();
+            archivePathQuery += " AND (" + metadataFilterQuery + ")";
+        }
+        log.info("Query for archive: %s", archivePathQuery);
+
         try (Connection connection = getConnection()) {
             // Fetch archive IDs and create splits
             try (PreparedStatement statement = connection.prepareStatement(archivePathQuery); ResultSet resultSet = statement.executeQuery()) {
@@ -83,7 +89,9 @@ public class ClpMySqlSplitProvider
             log.warn("Database error while processing splits for %s: %s", tableName, e);
         }
 
-        return splits.build();
+        ImmutableList<ClpSplit> filteredSplits = splits.build();
+        log.debug("Number of splits: %s", filteredSplits.size());
+        return filteredSplits;
     }
 
     private Connection getConnection()

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/TestClpFilterToKql.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/TestClpFilterToKql.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.clp;
+
+import com.facebook.presto.spi.relation.RowExpression;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+@Test
+public class TestClpFilterToKql
+        extends TestClpQueryBase
+{
+    private void testFilter(String sqlExpression, Optional<String> expectedKqlExpression,
+                            Optional<String> expectedRemainingExpression, SessionHolder sessionHolder)
+    {
+        RowExpression pushDownExpression = getRowExpression(sqlExpression, sessionHolder);
+        ClpExpression clpExpression = pushDownExpression.accept(new ClpFilterToKqlConverter(standardFunctionResolution, functionAndTypeManager, variableToColumnHandleMap), null);
+        Optional<String> kqlExpression = clpExpression.getDefinition();
+        Optional<RowExpression> remainingExpression = clpExpression.getRemainingExpression();
+        if (expectedKqlExpression.isPresent()) {
+            assertTrue(kqlExpression.isPresent());
+            assertEquals(kqlExpression.get(), expectedKqlExpression.get());
+        }
+
+        if (expectedRemainingExpression.isPresent()) {
+            assertTrue(remainingExpression.isPresent());
+            assertEquals(remainingExpression.get(), getRowExpression(expectedRemainingExpression.get(), sessionHolder));
+        }
+        else {
+            assertFalse(remainingExpression.isPresent());
+        }
+    }
+
+    @Test
+    public void testStringMatchPushdown()
+    {
+        SessionHolder sessionHolder = new SessionHolder();
+
+        // Exact match
+        testFilter("city.Name = 'hello world'", Optional.of("city.Name: \"hello world\""), Optional.empty(), sessionHolder);
+        testFilter("'hello world' = city.Name", Optional.of("city.Name: \"hello world\""), Optional.empty(), sessionHolder);
+
+        // Like predicates that are transformed into substring match
+        testFilter("city.Name like 'hello%'", Optional.of("city.Name: \"hello*\""), Optional.empty(), sessionHolder);
+        testFilter("city.Name like '%hello'", Optional.of("city.Name: \"*hello\""), Optional.empty(), sessionHolder);
+
+        // Like predicates that are transformed into CARDINALITY(SPLIT(x, 'some string', 2)) = 2 form, and they are not pushed down for now
+        testFilter("city.Name like '%hello%'", Optional.empty(), Optional.of("city.Name like '%hello%'"), sessionHolder);
+
+        // Like predicates that are kept in the original forms
+        testFilter("city.Name like 'hello_'", Optional.of("city.Name: \"hello?\""), Optional.empty(), sessionHolder);
+        testFilter("city.Name like '_hello'", Optional.of("city.Name: \"?hello\""), Optional.empty(), sessionHolder);
+        testFilter("city.Name like 'hello_w%'", Optional.of("city.Name: \"hello?w*\""), Optional.empty(), sessionHolder);
+        testFilter("city.Name like '%hello_w'", Optional.of("city.Name: \"*hello?w\""), Optional.empty(), sessionHolder);
+        testFilter("city.Name like 'hello%world'", Optional.of("city.Name: \"hello*world\""), Optional.empty(), sessionHolder);
+        testFilter("city.Name like 'hello%wor%ld'", Optional.of("city.Name: \"hello*wor*ld\""), Optional.empty(), sessionHolder);
+    }
+
+    @Test
+    public void testSubStringPushdown()
+    {
+        SessionHolder sessionHolder = new SessionHolder();
+
+        testFilter("substr(city.Name, 1, 2) = 'he'", Optional.of("city.Name: \"he*\""), Optional.empty(), sessionHolder);
+        testFilter("substr(city.Name, 5, 2) = 'he'", Optional.of("city.Name: \"????he*\""), Optional.empty(), sessionHolder);
+        testFilter("substr(city.Name, 5) = 'he'", Optional.of("city.Name: \"????he\""), Optional.empty(), sessionHolder);
+        testFilter("substr(city.Name, -2) = 'he'", Optional.of("city.Name: \"*he\""), Optional.empty(), sessionHolder);
+
+        // Invalid substring index is not pushed down
+        testFilter("substr(city.Name, 1, 5) = 'he'", Optional.empty(), Optional.of("substr(city.Name, 1, 5) = 'he'"), sessionHolder);
+        testFilter("substr(city.Name, -5) = 'he'", Optional.empty(), Optional.of("substr(city.Name, -5) = 'he'"), sessionHolder);
+    }
+
+    @Test
+    public void testNumericComparisonPushdown()
+    {
+        SessionHolder sessionHolder = new SessionHolder();
+
+        testFilter("fare > 0", Optional.of("fare > 0"), Optional.empty(), sessionHolder);
+        testFilter("fare >= 0", Optional.of("fare >= 0"), Optional.empty(), sessionHolder);
+        testFilter("fare < 0", Optional.of("fare < 0"), Optional.empty(), sessionHolder);
+        testFilter("fare <= 0", Optional.of("fare <= 0"), Optional.empty(), sessionHolder);
+        testFilter("fare = 0", Optional.of("fare: 0"), Optional.empty(), sessionHolder);
+        testFilter("fare != 0", Optional.of("NOT fare: 0"), Optional.empty(), sessionHolder);
+        testFilter("fare <> 0", Optional.of("NOT fare: 0"), Optional.empty(), sessionHolder);
+        testFilter("0 < fare", Optional.of("fare > 0"), Optional.empty(), sessionHolder);
+        testFilter("0 <= fare", Optional.of("fare >= 0"), Optional.empty(), sessionHolder);
+        testFilter("0 > fare", Optional.of("fare < 0"), Optional.empty(), sessionHolder);
+        testFilter("0 >= fare", Optional.of("fare <= 0"), Optional.empty(), sessionHolder);
+        testFilter("0 = fare", Optional.of("fare: 0"), Optional.empty(), sessionHolder);
+        testFilter("0 != fare", Optional.of("NOT fare: 0"), Optional.empty(), sessionHolder);
+        testFilter("0 <> fare", Optional.of("NOT fare: 0"), Optional.empty(), sessionHolder);
+    }
+
+    @Test
+    public void testOrPushdown()
+    {
+        SessionHolder sessionHolder = new SessionHolder();
+
+        testFilter("fare > 0 OR city.Name like 'b%'", Optional.of("(fare > 0 OR city.Name: \"b*\")"), Optional.empty(), sessionHolder);
+        testFilter(
+                "lower(city.Region.Name) = 'hello world' OR city.Region.Id != 1",
+                Optional.empty(),
+                Optional.of("(lower(city.Region.Name) = 'hello world' OR city.Region.Id != 1)"),
+                sessionHolder);
+
+        // Multiple ORs
+        testFilter(
+                "fare > 0 OR city.Name like 'b%' OR lower(city.Region.Name) = 'hello world' OR city.Region.Id != 1",
+                Optional.empty(),
+                Optional.of("fare > 0 OR city.Name like 'b%' OR lower(city.Region.Name) = 'hello world' OR city.Region.Id != 1"),
+                sessionHolder);
+        testFilter(
+                "fare > 0 OR city.Name like 'b%' OR city.Region.Id != 1",
+                Optional.of("((fare > 0 OR city.Name: \"b*\") OR NOT city.Region.Id: 1)"),
+                Optional.empty(),
+                sessionHolder);
+    }
+
+    @Test
+    public void testAndPushdown()
+    {
+        SessionHolder sessionHolder = new SessionHolder();
+
+        testFilter("fare > 0 AND city.Name like 'b%'", Optional.of("(fare > 0 AND city.Name: \"b*\")"), Optional.empty(), sessionHolder);
+        testFilter(
+                "lower(city.Region.Name) = 'hello world' AND city.Region.Id != 1",
+                Optional.of("(NOT city.Region.Id: 1)"),
+                Optional.of("lower(city.Region.Name) = 'hello world'"),
+                sessionHolder);
+
+        // Multiple ANDs
+        testFilter(
+                "fare > 0 AND city.Name like 'b%' AND lower(city.Region.Name) = 'hello world' AND city.Region.Id != 1",
+                Optional.of("(((fare > 0 AND city.Name: \"b*\")) AND NOT city.Region.Id: 1)"),
+                Optional.of("(lower(city.Region.Name) = 'hello world')"),
+                sessionHolder);
+        testFilter(
+                "fare > 0 AND city.Name like '%b%' AND lower(city.Region.Name) = 'hello world' AND city.Region.Id != 1",
+                Optional.of("(((fare > 0)) AND NOT city.Region.Id: 1)"),
+                Optional.of("city.Name like '%b%' AND lower(city.Region.Name) = 'hello world'"),
+                sessionHolder);
+    }
+
+    @Test
+    public void testNotPushdown()
+    {
+        SessionHolder sessionHolder = new SessionHolder();
+
+        testFilter("city.Region.Name NOT LIKE 'hello%'", Optional.of("NOT city.Region.Name: \"hello*\""), Optional.empty(), sessionHolder);
+        testFilter("NOT (city.Region.Name LIKE 'hello%')", Optional.of("NOT city.Region.Name: \"hello*\""), Optional.empty(), sessionHolder);
+        testFilter("city.Name != 'hello world'", Optional.of("NOT city.Name: \"hello world\""), Optional.empty(), sessionHolder);
+        testFilter("city.Name <> 'hello world'", Optional.of("NOT city.Name: \"hello world\""), Optional.empty(), sessionHolder);
+        testFilter("NOT (city.Name = 'hello world')", Optional.of("NOT city.Name: \"hello world\""), Optional.empty(), sessionHolder);
+        testFilter("fare != 0", Optional.of("NOT fare: 0"), Optional.empty(), sessionHolder);
+        testFilter("fare <> 0", Optional.of("NOT fare: 0"), Optional.empty(), sessionHolder);
+        testFilter("NOT (fare = 0)", Optional.of("NOT fare: 0"), Optional.empty(), sessionHolder);
+
+        // Multiple NOTs
+        testFilter("NOT (NOT fare = 0)", Optional.of("NOT NOT fare: 0"), Optional.empty(), sessionHolder);
+        testFilter("NOT (fare = 0 AND city.Name = 'hello world')", Optional.of("NOT (fare: 0 AND city.Name: \"hello world\")"), Optional.empty(), sessionHolder);
+        testFilter("NOT (fare = 0 OR city.Name = 'hello world')", Optional.of("NOT (fare: 0 OR city.Name: \"hello world\")"), Optional.empty(), sessionHolder);
+    }
+
+    @Test
+    public void testInPushdown()
+    {
+        SessionHolder sessionHolder = new SessionHolder();
+
+        testFilter("city.Name IN ('hello world', 'hello world 2')", Optional.of("(city.Name: \"hello world\" OR city.Name: \"hello world 2\")"), Optional.empty(), sessionHolder);
+    }
+
+    @Test
+    public void testIsNullPushdown()
+    {
+        SessionHolder sessionHolder = new SessionHolder();
+
+        testFilter("city.Name IS NULL", Optional.of("NOT city.Name: *"), Optional.empty(), sessionHolder);
+        testFilter("city.Name IS NOT NULL", Optional.of("NOT NOT city.Name: *"), Optional.empty(), sessionHolder);
+        testFilter("NOT (city.Name IS NULL)", Optional.of("NOT NOT city.Name: *"), Optional.empty(), sessionHolder);
+    }
+
+    @Test
+    public void testComplexPushdown()
+    {
+        SessionHolder sessionHolder = new SessionHolder();
+
+        testFilter(
+                "(fare > 0 OR city.Name like 'b%') AND (lower(city.Region.Name) = 'hello world' OR city.Name IS NULL)",
+                Optional.of("((fare > 0 OR city.Name: \"b*\"))"),
+                Optional.of("(lower(city.Region.Name) = 'hello world' OR city.Name IS NULL)"),
+                sessionHolder);
+        testFilter(
+                "city.Region.Id = 1 AND (fare > 0 OR city.Name NOT like 'b%') AND (lower(city.Region.Name) = 'hello world' OR city.Name IS NULL)",
+                Optional.of("((city.Region.Id: 1 AND (fare > 0 OR NOT city.Name: \"b*\")))"),
+                Optional.of("lower(city.Region.Name) = 'hello world' OR city.Name IS NULL"),
+                sessionHolder);
+    }
+}

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/TestClpFilterToKql.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/TestClpFilterToKql.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.plugin.clp;
 
 import com.facebook.presto.spi.relation.RowExpression;
+import com.google.common.collect.ImmutableSet;
 import org.testng.annotations.Test;
 
 import java.util.Optional;
@@ -26,16 +27,31 @@ import static org.testng.Assert.assertTrue;
 public class TestClpFilterToKql
         extends TestClpQueryBase
 {
-    private void testFilter(String sqlExpression, Optional<String> expectedKqlExpression,
-                            Optional<String> expectedRemainingExpression, SessionHolder sessionHolder)
+    private ClpExpression tryPushDown(String sqlExpression, SessionHolder sessionHolder)
     {
         RowExpression pushDownExpression = getRowExpression(sqlExpression, sessionHolder);
-        ClpExpression clpExpression = pushDownExpression.accept(new ClpFilterToKqlConverter(standardFunctionResolution, functionAndTypeManager, variableToColumnHandleMap), null);
+        ClpExpression clpExpression = pushDownExpression.accept(new ClpFilterToKqlConverter(
+                        standardFunctionResolution,
+                        functionAndTypeManager,
+                        variableToColumnHandleMap,
+                        ImmutableSet.of("fare")),
+                null);
+        return clpExpression;
+    }
+
+    private void testFilter(ClpExpression clpExpression,
+                            SessionHolder sessionHolder,
+                            Optional<String> expectedKqlExpression,
+                            Optional<String> expectedRemainingExpression)
+    {
         Optional<String> kqlExpression = clpExpression.getDefinition();
         Optional<RowExpression> remainingExpression = clpExpression.getRemainingExpression();
         if (expectedKqlExpression.isPresent()) {
             assertTrue(kqlExpression.isPresent());
             assertEquals(kqlExpression.get(), expectedKqlExpression.get());
+        }
+        else {
+            assertFalse(kqlExpression.isPresent());
         }
 
         if (expectedRemainingExpression.isPresent()) {
@@ -47,29 +63,45 @@ public class TestClpFilterToKql
         }
     }
 
+    private void testFilterWithMetadataSql(
+            ClpExpression clpExpression,
+            SessionHolder sessionHolder,
+            Optional<String> expectedKqlExpression,
+            Optional<String> expectedMetadataSqlExpression,
+            Optional<String> expectedRemainingExpression)
+    {
+        testFilter(clpExpression, sessionHolder, expectedKqlExpression, expectedRemainingExpression);
+        if (clpExpression.getMetadataSql().isPresent()) {
+            assertEquals(clpExpression.getMetadataSql().get(), expectedMetadataSqlExpression.get());
+        }
+        else {
+            assertFalse(expectedMetadataSqlExpression.isPresent());
+        }
+    }
+
     @Test
-    public void testStringMatchPushdown()
+    public void testStringMatchPushDown()
     {
         SessionHolder sessionHolder = new SessionHolder();
 
         // Exact match
-        testFilter("city.Name = 'hello world'", Optional.of("city.Name: \"hello world\""), Optional.empty(), sessionHolder);
-        testFilter("'hello world' = city.Name", Optional.of("city.Name: \"hello world\""), Optional.empty(), sessionHolder);
+        testFilter(tryPushDown("city.Name = 'hello world'", sessionHolder), sessionHolder, Optional.of("city.Name: \"hello world\""), Optional.empty());
+        testFilter(tryPushDown("'hello world' = city.Name", sessionHolder), sessionHolder, Optional.of("city.Name: \"hello world\""), Optional.empty());
 
         // Like predicates that are transformed into substring match
-        testFilter("city.Name like 'hello%'", Optional.of("city.Name: \"hello*\""), Optional.empty(), sessionHolder);
-        testFilter("city.Name like '%hello'", Optional.of("city.Name: \"*hello\""), Optional.empty(), sessionHolder);
+        testFilter(tryPushDown("city.Name like 'hello%'", sessionHolder), sessionHolder, Optional.of("city.Name: \"hello*\""), Optional.empty());
+        testFilter(tryPushDown("city.Name like '%hello'", sessionHolder), sessionHolder, Optional.of("city.Name: \"*hello\""), Optional.empty());
 
         // Like predicates that are transformed into CARDINALITY(SPLIT(x, 'some string', 2)) = 2 form, and they are not pushed down for now
-        testFilter("city.Name like '%hello%'", Optional.empty(), Optional.of("city.Name like '%hello%'"), sessionHolder);
+        testFilter(tryPushDown("city.Name like '%hello%'", sessionHolder), sessionHolder, Optional.empty(), Optional.of("city.Name like '%hello%'"));
 
         // Like predicates that are kept in the original forms
-        testFilter("city.Name like 'hello_'", Optional.of("city.Name: \"hello?\""), Optional.empty(), sessionHolder);
-        testFilter("city.Name like '_hello'", Optional.of("city.Name: \"?hello\""), Optional.empty(), sessionHolder);
-        testFilter("city.Name like 'hello_w%'", Optional.of("city.Name: \"hello?w*\""), Optional.empty(), sessionHolder);
-        testFilter("city.Name like '%hello_w'", Optional.of("city.Name: \"*hello?w\""), Optional.empty(), sessionHolder);
-        testFilter("city.Name like 'hello%world'", Optional.of("city.Name: \"hello*world\""), Optional.empty(), sessionHolder);
-        testFilter("city.Name like 'hello%wor%ld'", Optional.of("city.Name: \"hello*wor*ld\""), Optional.empty(), sessionHolder);
+        testFilter(tryPushDown("city.Name like 'hello_'", sessionHolder), sessionHolder, Optional.of("city.Name: \"hello?\""), Optional.empty());
+        testFilter(tryPushDown("city.Name like '_hello'", sessionHolder), sessionHolder, Optional.of("city.Name: \"?hello\""), Optional.empty());
+        testFilter(tryPushDown("city.Name like 'hello_w%'", sessionHolder), sessionHolder, Optional.of("city.Name: \"hello?w*\""), Optional.empty());
+        testFilter(tryPushDown("city.Name like '%hello_w'", sessionHolder), sessionHolder, Optional.of("city.Name: \"*hello?w\""), Optional.empty());
+        testFilter(tryPushDown("city.Name like 'hello%world'", sessionHolder), sessionHolder, Optional.of("city.Name: \"hello*world\""), Optional.empty());
+        testFilter(tryPushDown("city.Name like 'hello%wor%ld'", sessionHolder), sessionHolder, Optional.of("city.Name: \"hello*wor*ld\""), Optional.empty());
     }
 
     @Test
@@ -77,14 +109,14 @@ public class TestClpFilterToKql
     {
         SessionHolder sessionHolder = new SessionHolder();
 
-        testFilter("substr(city.Name, 1, 2) = 'he'", Optional.of("city.Name: \"he*\""), Optional.empty(), sessionHolder);
-        testFilter("substr(city.Name, 5, 2) = 'he'", Optional.of("city.Name: \"????he*\""), Optional.empty(), sessionHolder);
-        testFilter("substr(city.Name, 5) = 'he'", Optional.of("city.Name: \"????he\""), Optional.empty(), sessionHolder);
-        testFilter("substr(city.Name, -2) = 'he'", Optional.of("city.Name: \"*he\""), Optional.empty(), sessionHolder);
+        testFilter(tryPushDown("substr(city.Name, 1, 2) = 'he'", sessionHolder), sessionHolder, Optional.of("city.Name: \"he*\""), Optional.empty());
+        testFilter(tryPushDown("substr(city.Name, 5, 2) = 'he'", sessionHolder), sessionHolder, Optional.of("city.Name: \"????he*\""), Optional.empty());
+        testFilter(tryPushDown("substr(city.Name, 5) = 'he'", sessionHolder), sessionHolder, Optional.of("city.Name: \"????he\""), Optional.empty());
+        testFilter(tryPushDown("substr(city.Name, -2) = 'he'", sessionHolder), sessionHolder, Optional.of("city.Name: \"*he\""), Optional.empty());
 
         // Invalid substring index is not pushed down
-        testFilter("substr(city.Name, 1, 5) = 'he'", Optional.empty(), Optional.of("substr(city.Name, 1, 5) = 'he'"), sessionHolder);
-        testFilter("substr(city.Name, -5) = 'he'", Optional.empty(), Optional.of("substr(city.Name, -5) = 'he'"), sessionHolder);
+        testFilter(tryPushDown("substr(city.Name, 1, 5) = 'he'", sessionHolder), sessionHolder, Optional.empty(), Optional.of("substr(city.Name, 1, 5) = 'he'"));
+        testFilter(tryPushDown("substr(city.Name, -5) = 'he'", sessionHolder), sessionHolder, Optional.empty(), Optional.of("substr(city.Name, -5) = 'he'"));
     }
 
     @Test
@@ -92,20 +124,20 @@ public class TestClpFilterToKql
     {
         SessionHolder sessionHolder = new SessionHolder();
 
-        testFilter("fare > 0", Optional.of("fare > 0"), Optional.empty(), sessionHolder);
-        testFilter("fare >= 0", Optional.of("fare >= 0"), Optional.empty(), sessionHolder);
-        testFilter("fare < 0", Optional.of("fare < 0"), Optional.empty(), sessionHolder);
-        testFilter("fare <= 0", Optional.of("fare <= 0"), Optional.empty(), sessionHolder);
-        testFilter("fare = 0", Optional.of("fare: 0"), Optional.empty(), sessionHolder);
-        testFilter("fare != 0", Optional.of("NOT fare: 0"), Optional.empty(), sessionHolder);
-        testFilter("fare <> 0", Optional.of("NOT fare: 0"), Optional.empty(), sessionHolder);
-        testFilter("0 < fare", Optional.of("fare > 0"), Optional.empty(), sessionHolder);
-        testFilter("0 <= fare", Optional.of("fare >= 0"), Optional.empty(), sessionHolder);
-        testFilter("0 > fare", Optional.of("fare < 0"), Optional.empty(), sessionHolder);
-        testFilter("0 >= fare", Optional.of("fare <= 0"), Optional.empty(), sessionHolder);
-        testFilter("0 = fare", Optional.of("fare: 0"), Optional.empty(), sessionHolder);
-        testFilter("0 != fare", Optional.of("NOT fare: 0"), Optional.empty(), sessionHolder);
-        testFilter("0 <> fare", Optional.of("NOT fare: 0"), Optional.empty(), sessionHolder);
+        testFilter(tryPushDown("fare > 0", sessionHolder), sessionHolder, Optional.of("fare > 0"), Optional.empty());
+        testFilter(tryPushDown("fare >= 0", sessionHolder), sessionHolder, Optional.of("fare >= 0"), Optional.empty());
+        testFilter(tryPushDown("fare < 0", sessionHolder), sessionHolder, Optional.of("fare < 0"), Optional.empty());
+        testFilter(tryPushDown("fare <= 0", sessionHolder), sessionHolder, Optional.of("fare <= 0"), Optional.empty());
+        testFilter(tryPushDown("fare = 0", sessionHolder), sessionHolder, Optional.of("fare: 0"), Optional.empty());
+        testFilter(tryPushDown("fare != 0", sessionHolder), sessionHolder, Optional.of("NOT fare: 0"), Optional.empty());
+        testFilter(tryPushDown("fare <> 0", sessionHolder), sessionHolder, Optional.of("NOT fare: 0"), Optional.empty());
+        testFilter(tryPushDown("0 < fare", sessionHolder), sessionHolder, Optional.of("fare > 0"), Optional.empty());
+        testFilter(tryPushDown("0 <= fare", sessionHolder), sessionHolder, Optional.of("fare >= 0"), Optional.empty());
+        testFilter(tryPushDown("0 > fare", sessionHolder), sessionHolder, Optional.of("fare < 0"), Optional.empty());
+        testFilter(tryPushDown("0 >= fare", sessionHolder), sessionHolder, Optional.of("fare <= 0"), Optional.empty());
+        testFilter(tryPushDown("0 = fare", sessionHolder), sessionHolder, Optional.of("fare: 0"), Optional.empty());
+        testFilter(tryPushDown("0 != fare", sessionHolder), sessionHolder, Optional.of("NOT fare: 0"), Optional.empty());
+        testFilter(tryPushDown("0 <> fare", sessionHolder), sessionHolder, Optional.of("NOT fare: 0"), Optional.empty());
     }
 
     @Test
@@ -113,24 +145,16 @@ public class TestClpFilterToKql
     {
         SessionHolder sessionHolder = new SessionHolder();
 
-        testFilter("fare > 0 OR city.Name like 'b%'", Optional.of("(fare > 0 OR city.Name: \"b*\")"), Optional.empty(), sessionHolder);
-        testFilter(
-                "lower(city.Region.Name) = 'hello world' OR city.Region.Id != 1",
-                Optional.empty(),
-                Optional.of("(lower(city.Region.Name) = 'hello world' OR city.Region.Id != 1)"),
-                sessionHolder);
+        testFilter(tryPushDown("fare > 0 OR city.Name like 'b%'", sessionHolder), sessionHolder, Optional.of("(fare > 0 OR city.Name: \"b*\")"), Optional.empty());
+        testFilter(tryPushDown("lower(city.Region.Name) = 'hello world' OR city.Region.Id != 1", sessionHolder), sessionHolder, Optional.empty(), Optional.of("(lower(city.Region.Name) = 'hello world' OR city.Region.Id != 1)"));
 
         // Multiple ORs
-        testFilter(
-                "fare > 0 OR city.Name like 'b%' OR lower(city.Region.Name) = 'hello world' OR city.Region.Id != 1",
-                Optional.empty(),
-                Optional.of("fare > 0 OR city.Name like 'b%' OR lower(city.Region.Name) = 'hello world' OR city.Region.Id != 1"),
-                sessionHolder);
-        testFilter(
-                "fare > 0 OR city.Name like 'b%' OR city.Region.Id != 1",
-                Optional.of("((fare > 0 OR city.Name: \"b*\") OR NOT city.Region.Id: 1)"),
-                Optional.empty(),
-                sessionHolder);
+        testFilter(tryPushDown("fare > 0 OR city.Name like 'b%' OR lower(city.Region.Name) = 'hello world' OR city.Region.Id != 1",
+                        sessionHolder), sessionHolder, Optional.empty(),
+                Optional.of("fare > 0 OR city.Name like 'b%' OR lower(city.Region.Name) = 'hello world' OR city.Region.Id != 1"));
+        testFilter(tryPushDown("fare > 0 OR city.Name like 'b%' OR city.Region.Id != 1",
+                        sessionHolder), sessionHolder, Optional.of("((fare > 0 OR city.Name: \"b*\") OR NOT city.Region.Id: 1)"),
+                Optional.empty());
     }
 
     @Test
@@ -138,24 +162,16 @@ public class TestClpFilterToKql
     {
         SessionHolder sessionHolder = new SessionHolder();
 
-        testFilter("fare > 0 AND city.Name like 'b%'", Optional.of("(fare > 0 AND city.Name: \"b*\")"), Optional.empty(), sessionHolder);
-        testFilter(
-                "lower(city.Region.Name) = 'hello world' AND city.Region.Id != 1",
-                Optional.of("(NOT city.Region.Id: 1)"),
-                Optional.of("lower(city.Region.Name) = 'hello world'"),
-                sessionHolder);
+        testFilter(tryPushDown("fare > 0 AND city.Name like 'b%'", sessionHolder), sessionHolder, Optional.of("(fare > 0 AND city.Name: \"b*\")"), Optional.empty());
+        testFilter(tryPushDown("lower(city.Region.Name) = 'hello world' AND city.Region.Id != 1", sessionHolder), sessionHolder, Optional.of("(NOT city.Region.Id: 1)"), Optional.of("lower(city.Region.Name) = 'hello world'"));
 
         // Multiple ANDs
-        testFilter(
-                "fare > 0 AND city.Name like 'b%' AND lower(city.Region.Name) = 'hello world' AND city.Region.Id != 1",
-                Optional.of("(((fare > 0 AND city.Name: \"b*\")) AND NOT city.Region.Id: 1)"),
-                Optional.of("(lower(city.Region.Name) = 'hello world')"),
-                sessionHolder);
-        testFilter(
-                "fare > 0 AND city.Name like '%b%' AND lower(city.Region.Name) = 'hello world' AND city.Region.Id != 1",
-                Optional.of("(((fare > 0)) AND NOT city.Region.Id: 1)"),
-                Optional.of("city.Name like '%b%' AND lower(city.Region.Name) = 'hello world'"),
-                sessionHolder);
+        testFilter(tryPushDown("fare > 0 AND city.Name like 'b%' AND lower(city.Region.Name) = 'hello world' AND city.Region.Id != 1",
+                        sessionHolder), sessionHolder, Optional.of("(((fare > 0 AND city.Name: \"b*\")) AND NOT city.Region.Id: 1)"),
+                Optional.of("(lower(city.Region.Name) = 'hello world')"));
+        testFilter(tryPushDown("fare > 0 AND city.Name like '%b%' AND lower(city.Region.Name) = 'hello world' AND city.Region.Id != 1",
+                        sessionHolder), sessionHolder, Optional.of("(((fare > 0)) AND NOT city.Region.Id: 1)"),
+                Optional.of("city.Name like '%b%' AND lower(city.Region.Name) = 'hello world'"));
     }
 
     @Test
@@ -163,19 +179,19 @@ public class TestClpFilterToKql
     {
         SessionHolder sessionHolder = new SessionHolder();
 
-        testFilter("city.Region.Name NOT LIKE 'hello%'", Optional.of("NOT city.Region.Name: \"hello*\""), Optional.empty(), sessionHolder);
-        testFilter("NOT (city.Region.Name LIKE 'hello%')", Optional.of("NOT city.Region.Name: \"hello*\""), Optional.empty(), sessionHolder);
-        testFilter("city.Name != 'hello world'", Optional.of("NOT city.Name: \"hello world\""), Optional.empty(), sessionHolder);
-        testFilter("city.Name <> 'hello world'", Optional.of("NOT city.Name: \"hello world\""), Optional.empty(), sessionHolder);
-        testFilter("NOT (city.Name = 'hello world')", Optional.of("NOT city.Name: \"hello world\""), Optional.empty(), sessionHolder);
-        testFilter("fare != 0", Optional.of("NOT fare: 0"), Optional.empty(), sessionHolder);
-        testFilter("fare <> 0", Optional.of("NOT fare: 0"), Optional.empty(), sessionHolder);
-        testFilter("NOT (fare = 0)", Optional.of("NOT fare: 0"), Optional.empty(), sessionHolder);
+        testFilter(tryPushDown("city.Region.Name NOT LIKE 'hello%'", sessionHolder), sessionHolder, Optional.of("NOT city.Region.Name: \"hello*\""), Optional.empty());
+        testFilter(tryPushDown("NOT (city.Region.Name LIKE 'hello%')", sessionHolder), sessionHolder, Optional.of("NOT city.Region.Name: \"hello*\""), Optional.empty());
+        testFilter(tryPushDown("city.Name != 'hello world'", sessionHolder), sessionHolder, Optional.of("NOT city.Name: \"hello world\""), Optional.empty());
+        testFilter(tryPushDown("city.Name <> 'hello world'", sessionHolder), sessionHolder, Optional.of("NOT city.Name: \"hello world\""), Optional.empty());
+        testFilter(tryPushDown("NOT (city.Name = 'hello world')", sessionHolder), sessionHolder, Optional.of("NOT city.Name: \"hello world\""), Optional.empty());
+        testFilter(tryPushDown("fare != 0", sessionHolder), sessionHolder, Optional.of("NOT fare: 0"), Optional.empty());
+        testFilter(tryPushDown("fare <> 0", sessionHolder), sessionHolder, Optional.of("NOT fare: 0"), Optional.empty());
+        testFilter(tryPushDown("NOT (fare = 0)", sessionHolder), sessionHolder, Optional.of("NOT fare: 0"), Optional.empty());
 
         // Multiple NOTs
-        testFilter("NOT (NOT fare = 0)", Optional.of("NOT NOT fare: 0"), Optional.empty(), sessionHolder);
-        testFilter("NOT (fare = 0 AND city.Name = 'hello world')", Optional.of("NOT (fare: 0 AND city.Name: \"hello world\")"), Optional.empty(), sessionHolder);
-        testFilter("NOT (fare = 0 OR city.Name = 'hello world')", Optional.of("NOT (fare: 0 OR city.Name: \"hello world\")"), Optional.empty(), sessionHolder);
+        testFilter(tryPushDown("NOT (NOT fare = 0)", sessionHolder), sessionHolder, Optional.of("NOT NOT fare: 0"), Optional.empty());
+        testFilter(tryPushDown("NOT (fare = 0 AND city.Name = 'hello world')", sessionHolder), sessionHolder, Optional.of("NOT (fare: 0 AND city.Name: \"hello world\")"), Optional.empty());
+        testFilter(tryPushDown("NOT (fare = 0 OR city.Name = 'hello world')", sessionHolder), sessionHolder, Optional.of("NOT (fare: 0 OR city.Name: \"hello world\")"), Optional.empty());
     }
 
     @Test
@@ -183,7 +199,7 @@ public class TestClpFilterToKql
     {
         SessionHolder sessionHolder = new SessionHolder();
 
-        testFilter("city.Name IN ('hello world', 'hello world 2')", Optional.of("(city.Name: \"hello world\" OR city.Name: \"hello world 2\")"), Optional.empty(), sessionHolder);
+        testFilter(tryPushDown("city.Name IN ('hello world', 'hello world 2')", sessionHolder), sessionHolder, Optional.of("(city.Name: \"hello world\" OR city.Name: \"hello world 2\")"), Optional.empty());
     }
 
     @Test
@@ -191,9 +207,9 @@ public class TestClpFilterToKql
     {
         SessionHolder sessionHolder = new SessionHolder();
 
-        testFilter("city.Name IS NULL", Optional.of("NOT city.Name: *"), Optional.empty(), sessionHolder);
-        testFilter("city.Name IS NOT NULL", Optional.of("NOT NOT city.Name: *"), Optional.empty(), sessionHolder);
-        testFilter("NOT (city.Name IS NULL)", Optional.of("NOT NOT city.Name: *"), Optional.empty(), sessionHolder);
+        testFilter(tryPushDown("city.Name IS NULL", sessionHolder), sessionHolder, Optional.of("NOT city.Name: *"), Optional.empty());
+        testFilter(tryPushDown("city.Name IS NOT NULL", sessionHolder), sessionHolder, Optional.of("NOT NOT city.Name: *"), Optional.empty());
+        testFilter(tryPushDown("NOT (city.Name IS NULL)", sessionHolder), sessionHolder, Optional.of("NOT NOT city.Name: *"), Optional.empty());
     }
 
     @Test
@@ -201,15 +217,44 @@ public class TestClpFilterToKql
     {
         SessionHolder sessionHolder = new SessionHolder();
 
-        testFilter(
-                "(fare > 0 OR city.Name like 'b%') AND (lower(city.Region.Name) = 'hello world' OR city.Name IS NULL)",
-                Optional.of("((fare > 0 OR city.Name: \"b*\"))"),
-                Optional.of("(lower(city.Region.Name) = 'hello world' OR city.Name IS NULL)"),
-                sessionHolder);
-        testFilter(
-                "city.Region.Id = 1 AND (fare > 0 OR city.Name NOT like 'b%') AND (lower(city.Region.Name) = 'hello world' OR city.Name IS NULL)",
-                Optional.of("((city.Region.Id: 1 AND (fare > 0 OR NOT city.Name: \"b*\")))"),
-                Optional.of("lower(city.Region.Name) = 'hello world' OR city.Name IS NULL"),
-                sessionHolder);
+        testFilter(tryPushDown("(fare > 0 OR city.Name like 'b%') AND (lower(city.Region.Name) = 'hello world' OR city.Name IS NULL)",
+                        sessionHolder), sessionHolder, Optional.of("((fare > 0 OR city.Name: \"b*\"))"),
+                Optional.of("(lower(city.Region.Name) = 'hello world' OR city.Name IS NULL)"));
+        testFilter(tryPushDown("city.Region.Id = 1 AND (fare > 0 OR city.Name NOT like 'b%') AND (lower(city.Region.Name) = 'hello world' OR city.Name IS NULL)",
+                        sessionHolder), sessionHolder, Optional.of("((city.Region.Id: 1 AND (fare > 0 OR NOT city.Name: \"b*\")))"),
+                Optional.of("lower(city.Region.Name) = 'hello world' OR city.Name IS NULL"));
+    }
+
+    public void testMetadataSqlGeneration()
+    {
+        SessionHolder sessionHolder = new SessionHolder();
+        testFilterWithMetadataSql(
+                tryPushDown("(fare > 0 AND city.Name like 'b%')",
+                        sessionHolder),
+                sessionHolder,
+                Optional.of("(fare > 0 AND city.Name: \"b*\")"),
+                Optional.of("(\"fare\" > 0)"),
+                Optional.empty());
+        testFilterWithMetadataSql(
+                tryPushDown("(fare > 0 OR city.Name like 'b%')",
+                        sessionHolder),
+                sessionHolder,
+                Optional.of("(fare > 0 OR city.Name: \"b*\")"),
+                Optional.empty(),
+                Optional.empty());
+        testFilterWithMetadataSql(
+                tryPushDown("(fare > 0 AND city.Name like 'b%') OR city.Region.Id = 1",
+                        sessionHolder),
+                sessionHolder,
+                Optional.of("((fare > 0 AND city.Name: \"b*\") OR city.Region.Id: 1)"),
+                Optional.empty(),
+                Optional.empty());
+        testFilterWithMetadataSql(
+                tryPushDown("fare = 0 AND (city.Name like 'b%' OR city.Region.Id = 1)",
+                        sessionHolder),
+                sessionHolder,
+                Optional.of("(fare: 0 AND (city.Name: \"b*\" OR city.Region.Id: 1))"),
+                Optional.of("(\"fare\" = 0)"),
+                Optional.empty());
     }
 }

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/TestClpMetadataFilter.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/TestClpMetadataFilter.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.clp;
+
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.Set;
+
+import static org.testng.Assert.assertEquals;
+
+@Test(singleThreaded = true)
+public class TestClpMetadataFilter
+{
+    private String filterConfigPath;
+    private File tempFile;
+
+    @BeforeMethod
+    public void setUp() throws IOException
+    {
+        tempFile = File.createTempFile("metadata-filter", ".json");
+        tempFile.deleteOnExit();
+        filterConfigPath = tempFile.getAbsolutePath();
+
+        String json =
+                "{\n" +
+                        "  \"clp\": {\n" +
+                        "    \"filters\": [\n" +
+                        "      {\n" +
+                        "        \"filterName\": \"level\"\n" +
+                        "      }\n" +
+                        "    ]\n" +
+                        "  },\n" +
+                        "  \"clp.default\": {\n" +
+                        "    \"filters\": [\n" +
+                        "      {\n" +
+                        "        \"filterName\": \"author\"\n" +
+                        "      }\n" +
+                        "    ]\n" +
+                        "  },\n" +
+                        "  \"clp.default.table_1\": {\n" +
+                        "    \"filters\": [\n" +
+                        "      {\n" +
+                        "        \"filterName\": \"msg.timestamp\",\n" +
+                        "        \"rangeMapping\": {\n" +
+                        "          \"lowerBound\": \"begin_timestamp\",\n" +
+                        "          \"upperBound\": \"end_timestamp\"\n" +
+                        "        }\n" +
+                        "      },\n" +
+                        "      {\n" +
+                        "        \"filterName\": \"file_name\"\n" +
+                        "      }\n" +
+                        "    ]\n" +
+                        "  }\n" +
+                        "}";
+
+        try (FileWriter writer = new FileWriter(tempFile)) {
+            writer.write(json);
+        }
+    }
+
+    @Test
+    public void getFilterNames()
+    {
+        ClpConfig config = new ClpConfig();
+        config.setMetadataFilterConfig(filterConfigPath);
+        ClpMetadataFilterProvider filterProvider = new ClpMetadataFilterProvider(config);
+        Set<String> catalogFilterNames = filterProvider.getFilterNames("clp");
+        assertEquals(ImmutableSet.of("level"), catalogFilterNames);
+        Set<String> schemaFilterNames = filterProvider.getFilterNames("clp.default");
+        assertEquals(ImmutableSet.of("level", "author"), schemaFilterNames);
+        Set<String> tableFilterNames = filterProvider.getFilterNames("clp.default.table_1");
+        assertEquals(ImmutableSet.of("level", "author", "msg.timestamp", "file_name"), tableFilterNames);
+    }
+
+    @Test
+    public void remapSql()
+    {
+        ClpConfig config = new ClpConfig();
+        config.setMetadataFilterConfig(filterConfigPath);
+        ClpMetadataFilterProvider filterProvider = new ClpMetadataFilterProvider(config);
+
+        String metadataFilterSql1 = "(\"msg.timestamp\" > 1234 AND \"msg.timestamp\" < 5678)";
+        String remappedSql1 = filterProvider.remapFilterSql("clp.default.table_1", metadataFilterSql1);
+        assertEquals(remappedSql1, "(end_timestamp > 1234 AND begin_timestamp < 5678)");
+
+        String metadataFilterSql2 = "(\"msg.timestamp\" >= 1234 AND \"msg.timestamp\" <= 5678)";
+        String remappedSql2 = filterProvider.remapFilterSql("clp.default.table_1", metadataFilterSql2);
+        assertEquals(remappedSql2, "(end_timestamp >= 1234 AND begin_timestamp <= 5678)");
+
+        String metadataFilterSql3 = "(\"msg.timestamp\" > 1234 AND \"msg.timestamp\" <= 5678)";
+        String remappedSql3 = filterProvider.remapFilterSql("clp.default.table_1", metadataFilterSql3);
+        assertEquals(remappedSql3, "(end_timestamp > 1234 AND begin_timestamp <= 5678)");
+
+        String metadataFilterSql4 = "(\"msg.timestamp\" >= 1234 AND \"msg.timestamp\" < 5678)";
+        String remappedSql4 = filterProvider.remapFilterSql("clp.default.table_1", metadataFilterSql4);
+        assertEquals(remappedSql4, "(end_timestamp >= 1234 AND begin_timestamp < 5678)");
+
+        String metadataFilterSql5 = "(\"msg.timestamp\" = 1234)";
+        String remappedSql5 = filterProvider.remapFilterSql("clp.default.table_1", metadataFilterSql5);
+        assertEquals(remappedSql5, "((begin_timestamp <= 1234 AND end_timestamp >= 1234))");
+    }
+
+    @AfterMethod
+    public void tearDown()
+    {
+        if (null != tempFile && tempFile.exists()) {
+            tempFile.delete();
+        }
+    }
+}

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/TestClpQueryBase.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/TestClpQueryBase.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.clp;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.SystemSessionProperties;
+import com.facebook.presto.common.block.BlockEncodingManager;
+import com.facebook.presto.common.type.RowType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.metadata.AnalyzePropertyManager;
+import com.facebook.presto.metadata.CatalogManager;
+import com.facebook.presto.metadata.ColumnPropertyManager;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.metadata.SchemaPropertyManager;
+import com.facebook.presto.metadata.TablePropertyManager;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.function.StandardFunctionResolution;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.ExpressionUtils;
+import com.facebook.presto.sql.parser.ParsingOptions;
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.planner.TypeProvider;
+import com.facebook.presto.sql.relational.FunctionResolution;
+import com.facebook.presto.sql.relational.SqlToRowExpressionTranslator;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.NodeRef;
+import com.facebook.presto.testing.TestingSession;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.metadata.FunctionAndTypeManager.createTestFunctionAndTypeManager;
+import static com.facebook.presto.metadata.SessionPropertyManager.createTestingSessionPropertyManager;
+import static com.facebook.presto.sql.analyzer.ExpressionAnalyzer.getExpressionTypes;
+import static com.facebook.presto.testing.TestingConnectorSession.SESSION;
+import static com.facebook.presto.transaction.InMemoryTransactionManager.createTestTransactionManager;
+import static java.util.stream.Collectors.toMap;
+
+public class TestClpQueryBase
+{
+    protected static final FunctionAndTypeManager functionAndTypeManager = createTestFunctionAndTypeManager();
+    protected static final StandardFunctionResolution standardFunctionResolution = new FunctionResolution(functionAndTypeManager.getFunctionAndTypeResolver());
+    protected static final Metadata metadata = new MetadataManager(
+            functionAndTypeManager,
+            new BlockEncodingManager(),
+            createTestingSessionPropertyManager(),
+            new SchemaPropertyManager(),
+            new TablePropertyManager(),
+            new ColumnPropertyManager(),
+            new AnalyzePropertyManager(),
+            createTestTransactionManager(new CatalogManager()));
+
+    protected static final ClpTableHandle table = new ClpTableHandle(new SchemaTableName("default", "test"), "", ClpTableHandle.StorageType.FS);
+    protected static final ClpColumnHandle city = new ClpColumnHandle(
+            "city",
+            RowType.from(ImmutableList.of(
+                    RowType.field("Region", RowType.from(ImmutableList.of(
+                            RowType.field("Id", BIGINT),
+                            RowType.field("Name", VARCHAR)))),
+                    RowType.field("Name", VARCHAR))),
+            true);
+    protected static final ClpColumnHandle fare = new ClpColumnHandle("fare", DOUBLE, true);
+    protected static final ClpColumnHandle isHoliday = new ClpColumnHandle("isHoliday", BOOLEAN, true);
+    protected static final Map<VariableReferenceExpression, ColumnHandle> variableToColumnHandleMap =
+            Stream.of(city, fare, isHoliday)
+                    .collect(toMap(
+                            ch -> new VariableReferenceExpression(Optional.empty(), ch.getColumnName(), ch.getColumnType()),
+                            ch -> ch));
+    protected final TypeProvider typeProvider = TypeProvider.fromVariables(variableToColumnHandleMap.keySet());
+
+    public static Expression expression(String sql)
+    {
+        return ExpressionUtils.rewriteIdentifiersToSymbolReferences(
+                new SqlParser().createExpression(sql, new ParsingOptions(ParsingOptions.DecimalLiteralTreatment.AS_DECIMAL)));
+    }
+
+    protected RowExpression toRowExpression(Expression expression, TypeProvider typeProvider, Session session)
+    {
+        Map<NodeRef<Expression>, Type> expressionTypes = getExpressionTypes(
+                session,
+                metadata,
+                new SqlParser(),
+                typeProvider,
+                expression,
+                ImmutableMap.of(),
+                WarningCollector.NOOP);
+        return SqlToRowExpressionTranslator.translate(expression, expressionTypes, ImmutableMap.of(), functionAndTypeManager, session);
+    }
+
+    protected RowExpression getRowExpression(String sqlExpression, SessionHolder sessionHolder)
+    {
+        return toRowExpression(expression(sqlExpression), typeProvider, sessionHolder.getSession());
+    }
+
+    protected RowExpression getRowExpression(String sqlExpression, TypeProvider typeProvider, SessionHolder sessionHolder)
+    {
+        return toRowExpression(expression(sqlExpression), typeProvider, sessionHolder.getSession());
+    }
+
+    protected static class SessionHolder
+    {
+        private final ConnectorSession connectorSession;
+        private final Session session;
+
+        public SessionHolder()
+        {
+            connectorSession = SESSION;
+            session = TestingSession.testSessionBuilder(createTestingSessionPropertyManager(new SystemSessionProperties().getSessionProperties())).build();
+        }
+
+        public ConnectorSession getConnectorSession()
+        {
+            return connectorSession;
+        }
+
+        public Session getSession()
+        {
+            return session;
+        }
+    }
+}

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/TestClpSplit.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/TestClpSplit.java
@@ -79,6 +79,7 @@ public class TestClpSplit
             ClpTableLayoutHandle layoutHandle = new ClpTableLayoutHandle(
                     new ClpTableHandle(new SchemaTableName(DEFAULT_SCHEMA_NAME, tableName),
                             tablePath, FS),
+                    Optional.empty(),
                     Optional.empty());
             List<ClpSplit> splits = clpSplitProvider.listSplits(layoutHandle);
             assertEquals(splits.size(), expectedSplits.size());


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

See [ERD](https://docs.google.com/document/d/15SE4806RR1LJHwAN0g12Lju8nFxYHWURUNuwN1Tek9M/edit?tab=t.0).

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [ ] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [ ] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [ ] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

E2E test with sample log with format like:
```
"msg": {
    "timestamp": "1234",
    "message":"hahaha",
    "logLevel": "INFO"   
}
```
Then test with the query that (note that `query_begin_ts < query_end_ts`):
1. `query_begin_ts < archive_min_ts && query_end_ts > archive_min_ts`
2. `query_begin_ts < archive_min_ts && query_end_ts > archive_max_ts`
3. `query_begin_ts > archive_min_ts && query_end_ts < archive_max_ts`
4. `query_begin_ts > archive_min_ts && query_begin_ts < archive_max_ts && query_end_ts > archive_max_ts`
5. `query_begin_ts > archive_max_ts`
6. `query_ts = archive_min_ts`
7. `query_ts = archive_max_ts`
8. `query_ts = x && x > archive_min_ts && x < archive_max_ts`

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
