### PR TITLE
fix: Remove StorageType from ClpTableHandle since it will now be a cluster-level property.

### DIFF
--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpTableHandle.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpTableHandle.java
@@ -27,17 +27,12 @@ public class ClpTableHandle
 {
     private final SchemaTableName schemaTableName;
     private final String tablePath;
-    private final StorageType storageType;
 
     @JsonCreator
-    public ClpTableHandle(
-            @JsonProperty("schemaTableName") SchemaTableName schemaTableName,
-            @JsonProperty("tablePath") String tablePath,
-            @JsonProperty("storageType") StorageType storageType)
+    public ClpTableHandle(@JsonProperty("schemaTableName") SchemaTableName schemaTableName, @JsonProperty("tablePath") String tablePath)
     {
         this.schemaTableName = schemaTableName;
         this.tablePath = tablePath;
-        this.storageType = storageType;
     }
 
     @JsonProperty
@@ -52,16 +47,10 @@ public class ClpTableHandle
         return tablePath;
     }
 
-    @JsonProperty
-    public StorageType getStorageType()
-    {
-        return storageType;
-    }
-
     @Override
     public int hashCode()
     {
-        return Objects.hash(schemaTableName, tablePath, storageType);
+        return Objects.hash(schemaTableName, tablePath);
     }
 
     @Override
@@ -74,9 +63,7 @@ public class ClpTableHandle
             return false;
         }
         ClpTableHandle other = (ClpTableHandle) obj;
-        return this.schemaTableName.equals(other.schemaTableName) &&
-                this.tablePath.equals(other.tablePath) &&
-                this.storageType == other.storageType;
+        return this.schemaTableName.equals(other.schemaTableName) && this.tablePath.equals(other.tablePath);
     }
 
     @Override
@@ -85,13 +72,6 @@ public class ClpTableHandle
         return toStringHelper(this)
                 .add("schemaTableName", schemaTableName)
                 .add("tablePath", tablePath)
-                .add("storageType", storageType)
                 .toString();
-    }
-
-    public enum StorageType
-    {
-        FS, // Local File System
-        S3
     }
 }

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/metadata/ClpMySqlMetadataProvider.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/metadata/ClpMySqlMetadataProvider.java
@@ -39,7 +39,6 @@ public class ClpMySqlMetadataProvider
     public static final String COLUMN_METADATA_TABLE_COLUMN_NAME = "name";
     public static final String COLUMN_METADATA_TABLE_COLUMN_TYPE = "type";
     public static final String DATASETS_TABLE_COLUMN_NAME = "name";
-    public static final String DATASETS_TABLE_COLUMN_ARCHIVE_STORAGE_TYPE = "archive_storage_type";
     public static final String DATASETS_TABLE_COLUMN_ARCHIVE_STORAGE_DIRECTORY = "archive_storage_directory";
 
     // Table suffixes
@@ -49,9 +48,8 @@ public class ClpMySqlMetadataProvider
     // SQL templates
     private static final String SQL_SELECT_COLUMN_METADATA_TEMPLATE = "SELECT * FROM `%s%s" + COLUMN_METADATA_TABLE_SUFFIX + "`";
     private static final String SQL_SELECT_DATASETS_TEMPLATE = format(
-            "SELECT `%s`, `%s`, `%s` FROM `%%s%s`",
+            "SELECT `%s`, `%s` FROM `%%s%s`",
             DATASETS_TABLE_COLUMN_NAME,
-            DATASETS_TABLE_COLUMN_ARCHIVE_STORAGE_TYPE,
             DATASETS_TABLE_COLUMN_ARCHIVE_STORAGE_DIRECTORY,
             DATASETS_TABLE_SUFFIX);
 
@@ -102,14 +100,9 @@ public class ClpMySqlMetadataProvider
                 ResultSet resultSet = statement.executeQuery(query)) {
             while (resultSet.next()) {
                 String tableName = resultSet.getString(DATASETS_TABLE_COLUMN_NAME);
-                String archiveStorageType = resultSet.getString(DATASETS_TABLE_COLUMN_ARCHIVE_STORAGE_TYPE);
                 String archiveStorageDirectory = resultSet.getString(DATASETS_TABLE_COLUMN_ARCHIVE_STORAGE_DIRECTORY);
                 if (isValidIdentifier(tableName) && archiveStorageDirectory != null && !archiveStorageDirectory.isEmpty()) {
-                    tableHandles.add(
-                            new ClpTableHandle(
-                                    new SchemaTableName(schemaName, tableName),
-                                    archiveStorageDirectory,
-                                    ClpTableHandle.StorageType.valueOf(archiveStorageType.toUpperCase())));
+                    tableHandles.add(new ClpTableHandle(new SchemaTableName(schemaName, tableName), archiveStorageDirectory));
                 }
                 else {
                     log.warn("Ignoring invalid table name found in metadata: %s", tableName);

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/ClpMetadataDbSetUp.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/ClpMetadataDbSetUp.java
@@ -34,7 +34,6 @@ import java.util.Map;
 import static com.facebook.presto.plugin.clp.metadata.ClpMySqlMetadataProvider.COLUMN_METADATA_TABLE_COLUMN_NAME;
 import static com.facebook.presto.plugin.clp.metadata.ClpMySqlMetadataProvider.COLUMN_METADATA_TABLE_COLUMN_TYPE;
 import static com.facebook.presto.plugin.clp.metadata.ClpMySqlMetadataProvider.DATASETS_TABLE_COLUMN_ARCHIVE_STORAGE_DIRECTORY;
-import static com.facebook.presto.plugin.clp.metadata.ClpMySqlMetadataProvider.DATASETS_TABLE_COLUMN_ARCHIVE_STORAGE_TYPE;
 import static com.facebook.presto.plugin.clp.metadata.ClpMySqlMetadataProvider.DATASETS_TABLE_COLUMN_NAME;
 import static com.facebook.presto.plugin.clp.metadata.ClpMySqlMetadataProvider.DATASETS_TABLE_SUFFIX;
 import static com.facebook.presto.plugin.clp.split.ClpMySqlSplitProvider.ARCHIVES_TABLE_COLUMN_ID;
@@ -184,13 +183,9 @@ public final class ClpMetadataDbSetUp
             throws SQLException
     {
         final String createDatasetsTableSql = format(
-                "CREATE TABLE IF NOT EXISTS %s (" +
-                        " %s VARCHAR(255) PRIMARY KEY," +
-                        " %s VARCHAR(64) NOT NULL," +
-                        " %s VARCHAR(4096) NOT NULL)",
+                "CREATE TABLE IF NOT EXISTS %s (%s VARCHAR(255) PRIMARY KEY, %s VARCHAR(4096) NOT NULL)",
                 DATASETS_TABLE_NAME,
                 DATASETS_TABLE_COLUMN_NAME,
-                DATASETS_TABLE_COLUMN_ARCHIVE_STORAGE_TYPE,
                 DATASETS_TABLE_COLUMN_ARCHIVE_STORAGE_DIRECTORY);
         stmt.execute(createDatasetsTableSql);
     }
@@ -199,15 +194,13 @@ public final class ClpMetadataDbSetUp
             throws SQLException
     {
         final String insertDatasetsTableSql = format(
-                "INSERT INTO %s (%s, %s, %s) VALUES (?, ?, ?)",
+                "INSERT INTO %s (%s, %s) VALUES (?, ?)",
                 DATASETS_TABLE_NAME,
                 DATASETS_TABLE_COLUMN_NAME,
-                DATASETS_TABLE_COLUMN_ARCHIVE_STORAGE_TYPE,
                 DATASETS_TABLE_COLUMN_ARCHIVE_STORAGE_DIRECTORY);
         try (PreparedStatement pstmt = conn.prepareStatement(insertDatasetsTableSql)) {
             pstmt.setString(1, tableName);
-            pstmt.setString(2, "fs");
-            pstmt.setString(3, ARCHIVE_STORAGE_DIRECTORY_BASE + tableName);
+            pstmt.setString(2, ARCHIVE_STORAGE_DIRECTORY_BASE + tableName);
             pstmt.executeUpdate();
         }
     }

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/TestClpSplit.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/TestClpSplit.java
@@ -31,7 +31,6 @@ import static com.facebook.presto.plugin.clp.ClpMetadataDbSetUp.ARCHIVE_STORAGE_
 import static com.facebook.presto.plugin.clp.ClpMetadataDbSetUp.DbHandle;
 import static com.facebook.presto.plugin.clp.ClpMetadataDbSetUp.getDbHandle;
 import static com.facebook.presto.plugin.clp.ClpMetadataDbSetUp.setupSplit;
-import static com.facebook.presto.plugin.clp.ClpTableHandle.StorageType.FS;
 import static org.testng.Assert.assertEquals;
 
 @Test(singleThreaded = true)
@@ -77,9 +76,7 @@ public class TestClpSplit
             String tablePath = ARCHIVE_STORAGE_DIRECTORY_BASE + tableName;
             List<String> expectedSplits = entry.getValue();
             ClpTableLayoutHandle layoutHandle = new ClpTableLayoutHandle(
-                    new ClpTableHandle(new SchemaTableName(DEFAULT_SCHEMA_NAME, tableName),
-                            tablePath, FS),
-                    Optional.empty());
+                    new ClpTableHandle(new SchemaTableName(DEFAULT_SCHEMA_NAME, tableName), tablePath), Optional.empty());
             List<ClpSplit> splits = clpSplitProvider.listSplits(layoutHandle);
             assertEquals(splits.size(), expectedSplits.size());
 


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
Since `storage_type` will be removed from the dataset table in the CLP package and promoted to a cluster-level configuration, this PR removes `StorageType` from `ClpTableHandle`. A corresponding configuration option will be introduced on the worker side (Velox).


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed
Unit tests passed

<!-- Describe what tests and validation you performed on the change. -->



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified table handle creation and metadata management by removing the storage type field and related logic from dataset handling and metadata queries.
- **Tests**
	- Updated test setup and test cases to align with the removal of the storage type, ensuring consistency with the new schema and object construction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->