### PR TITLE
feat: Add CLP UDFs with query rewriting support

### DIFF
--- a/presto-clp/pom.xml
+++ b/presto-clp/pom.xml
@@ -140,5 +140,22 @@
             <artifactId>commons-io</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-tests</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-main-base</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-expressions</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpFunctions.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpFunctions.java
@@ -102,12 +102,4 @@ public final class ClpFunctions
     {
         return false;
     }
-
-    @ScalarFunction(value = "CLP_GET_JSON_STRING", deterministic = false)
-    @Description("Converts an entire log record into a JSON string.")
-    @SqlType(StandardTypes.VARCHAR)
-    public static Slice clpGetJSONString()
-    {
-        return Slices.EMPTY_SLICE;
-    }
 }

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpFunctions.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpFunctions.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.clp;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.spi.function.Description;
+import com.facebook.presto.spi.function.ScalarFunction;
+import com.facebook.presto.spi.function.SqlType;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+
+public final class ClpFunctions
+{
+    private ClpFunctions()
+    {
+    }
+
+    @ScalarFunction(value = "CLP_GET_INT", deterministic = false)
+    @Description("Retrieves an integer value corresponding to the given JSON path.")
+    @SqlType(StandardTypes.BIGINT)
+    public static long clpGetInt(@SqlType(StandardTypes.VARCHAR) Slice jsonPath)
+    {
+        return 0;
+    }
+
+    @ScalarFunction(value = "CLP_GET_FLOAT", deterministic = false)
+    @Description("Retrieves a floating point value corresponding to the given JSON path.")
+    @SqlType(StandardTypes.DOUBLE)
+    public static double clpGetFloat(@SqlType(StandardTypes.VARCHAR) Slice jsonPath)
+    {
+        return 0.0;
+    }
+
+    @ScalarFunction(value = "CLP_GET_BOOL", deterministic = false)
+    @Description("Retrieves a boolean value corresponding to the given JSON path.")
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean clpGetBool(@SqlType(StandardTypes.VARCHAR) Slice jsonPath)
+    {
+        return false;
+    }
+
+    @ScalarFunction(value = "CLP_GET_STRING", deterministic = false)
+    @Description("Retrieves a string value corresponding to the given JSON path.")
+    @SqlType(StandardTypes.VARCHAR)
+    public static Slice clpGetString(@SqlType(StandardTypes.VARCHAR) Slice jsonPath)
+    {
+        return Slices.EMPTY_SLICE;
+    }
+
+    @ScalarFunction(value = "CLP_GET_STRING_ARRAY", deterministic = false)
+    @Description("Retrieves an array value corresponding to the given JSON path and converts each element into a string.")
+    @SqlType("ARRAY(VARCHAR)")
+    public static Block clpGetStringArray(@SqlType(StandardTypes.VARCHAR) Slice jsonPath)
+    {
+        BlockBuilder blockBuilder = VARCHAR.createBlockBuilder(null, 0);
+        return blockBuilder.build();
+    }
+
+    @ScalarFunction(value = "CLP_WILDCARD_STRING_COLUMN", deterministic = false)
+    @Description("Used in filter expressions to allow comparisons with any string column in the log record.")
+    @SqlType(StandardTypes.VARCHAR)
+    public static Slice clpWildcardStringColumn()
+    {
+        return Slices.EMPTY_SLICE;
+    }
+
+    @ScalarFunction(value = "CLP_WILDCARD_INT_COLUMN", deterministic = false)
+    @Description("Used in filter expressions to allow comparisons with any integer column in the log record.")
+    @SqlType(StandardTypes.BIGINT)
+    public static long clpWildcardIntColumn()
+    {
+        return 0;
+    }
+
+    @ScalarFunction(value = "CLP_WILDCARD_FLOAT_COLUMN", deterministic = false)
+    @Description("Used in filter expressions to allow comparisons with any floating point column in the log record.")
+    @SqlType(StandardTypes.DOUBLE)
+    public static double clpWildcardFloatColumn()
+    {
+        return 0.0;
+    }
+
+    @ScalarFunction(value = "CLP_WILDCARD_BOOL_COLUMN", deterministic = false)
+    @Description("Used in filter expressions to allow comparisons with any boolean column in the log record.")
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean clpWildcardBoolColumn()
+    {
+        return false;
+    }
+
+    @ScalarFunction(value = "CLP_GET_JSON_STRING", deterministic = false)
+    @Description("Converts an entire log record into a JSON string.")
+    @SqlType(StandardTypes.VARCHAR)
+    public static Slice clpGetJSONString()
+    {
+        return Slices.EMPTY_SLICE;
+    }
+}

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpMetadataFilterProvider.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpMetadataFilterProvider.java
@@ -84,11 +84,16 @@ public class ClpMetadataFilterProvider
     public ClpMetadataFilterProvider(ClpConfig config)
     {
         requireNonNull(config, "config is null");
+        String configPath = config.getMetadataFilterConfig();
+        if (configPath == null || configPath.isEmpty()) {
+            filterMap = ImmutableMap.of();
+            return;
+        }
 
         ObjectMapper mapper = new ObjectMapper();
         try {
             filterMap = mapper.readValue(
-                    new File(config.getMetadataFilterConfig()),
+                    new File(configPath),
                     new TypeReference<Map<String, List<Filter>>>() {});
         }
         catch (IOException e) {

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpPlanOptimizer.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpPlanOptimizer.java
@@ -14,25 +14,39 @@
 package com.facebook.presto.plugin.clp;
 
 import com.facebook.airlift.log.Logger;
+import com.facebook.presto.expressions.DefaultRowExpressionTraversalVisitor;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorPlanOptimizer;
 import com.facebook.presto.spi.ConnectorPlanRewriter;
 import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.function.FunctionMetadataManager;
 import com.facebook.presto.spi.function.StandardFunctionResolution;
+import com.facebook.presto.spi.plan.Assignments;
 import com.facebook.presto.spi.plan.FilterNode;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
+import com.facebook.presto.spi.plan.ProjectNode;
 import com.facebook.presto.spi.plan.TableScanNode;
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.ConstantExpression;
 import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.RowExpressionVisitor;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import io.airlift.slice.Slice;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static com.facebook.presto.plugin.clp.ClpConnectorFactory.CONNECTOR_NAME;
+import static com.facebook.presto.plugin.clp.ClpErrorCode.CLP_PUSHDOWN_UNSUPPORTED_EXPRESSION;
 import static com.facebook.presto.spi.ConnectorPlanRewriter.rewriteWith;
 import static java.util.Objects.requireNonNull;
 
@@ -68,63 +82,198 @@ public class ClpPlanOptimizer
         }
 
         @Override
+        public PlanNode visitProject(ProjectNode node, RewriteContext<Void> context)
+        {
+            Assignments.Builder assignmentsBuilder = new Assignments.Builder();
+            Set<VariableReferenceExpression> clpUdfVariablesInProjectNode = new HashSet<>();
+            for (Map.Entry<VariableReferenceExpression, RowExpression> entry : node.getAssignments().getMap().entrySet()) {
+                VariableReferenceExpression oldKey = entry.getKey();
+                RowExpression oldValue = entry.getValue();
+
+                if (!(oldValue instanceof CallExpression)) {
+                    assignmentsBuilder.put(oldKey, oldValue);
+                    continue;
+                }
+
+                CallExpression callExpression = (CallExpression) oldValue;
+                String functionName = functionManager.getFunctionMetadata((callExpression).getFunctionHandle())
+                        .getName().getObjectName().toUpperCase();
+
+                if (!functionName.startsWith("CLP_GET")) {
+                    assignmentsBuilder.put(oldKey, oldValue);
+                    continue;
+                }
+
+                if (!callExpression.getArguments().isEmpty()) {
+                    RowExpression argument = callExpression.getArguments().get(0);
+                    if (!(argument instanceof ConstantExpression)) {
+                        throw new PrestoException(
+                                CLP_PUSHDOWN_UNSUPPORTED_EXPRESSION,
+                                "The argument of " + functionName + " must be a ConstantExpression");
+                    }
+                    String jsonPath = ((Slice) ((ConstantExpression) argument).getValue()).toStringUtf8();
+
+                    VariableReferenceExpression newValue = new VariableReferenceExpression(
+                            oldValue.getSourceLocation(), jsonPath, oldValue.getType());
+                    assignmentsBuilder.put(oldKey, newValue);
+                    clpUdfVariablesInProjectNode.add(newValue);
+                }
+            }
+
+            PlanNode childNode = node.getSource();
+
+            // Handle Project -> TableScan
+            if (childNode instanceof TableScanNode) {
+                TableScanNode newTableScanNode = buildNewTableScanNode((TableScanNode) childNode, clpUdfVariablesInProjectNode);
+                return new ProjectNode(
+                        newTableScanNode.getSourceLocation(),
+                        idAllocator.getNextId(),
+                        newTableScanNode,
+                        assignmentsBuilder.build(),
+                        node.getLocality());
+            }
+
+            // Handle Project -> Filter -> TableScan
+            if (childNode instanceof FilterNode && ((FilterNode) childNode).getSource() instanceof TableScanNode) {
+                FilterNode filterNode = (FilterNode) childNode;
+                TableScanNode tableScanNode = (TableScanNode) filterNode.getSource();
+
+                // Build new TableScanNode with CLP_GET projection pushes (even if empty)
+                TableScanNode newTableScanNode = buildNewTableScanNode(tableScanNode, clpUdfVariablesInProjectNode);
+
+                // Apply KQL pushdown for the FilterNode
+                PlanNode newSourceNode = processFilter(filterNode, newTableScanNode);
+                return new ProjectNode(
+                        newSourceNode.getSourceLocation(),
+                        idAllocator.getNextId(),
+                        newSourceNode,
+                        assignmentsBuilder.build(),
+                        node.getLocality());
+            }
+            if (clpUdfVariablesInProjectNode.isEmpty()) {
+                return node;
+            }
+            throw new PrestoException(CLP_PUSHDOWN_UNSUPPORTED_EXPRESSION,
+                    "Unsupported plan shape for CLP pushdown: " + childNode.getClass().getSimpleName());
+        }
+
+        @Override
         public PlanNode visitFilter(FilterNode node, RewriteContext<Void> context)
         {
             if (!(node.getSource() instanceof TableScanNode)) {
                 return node;
             }
 
-            TableScanNode tableScanNode = (TableScanNode) node.getSource();
-            Map<VariableReferenceExpression, ColumnHandle> assignments = tableScanNode.getAssignments();
-            TableHandle tableHandle = tableScanNode.getTable();
-            ClpTableHandle clpTableHandle = (ClpTableHandle) tableHandle.getConnectorHandle();
-            String scope = CONNECTOR_NAME + "." + clpTableHandle.getSchemaTableName().toString();
-            ClpExpression clpExpression = node.getPredicate().accept(
-                    new ClpFilterToKqlConverter(
-                            functionResolution,
-                            functionManager,
-                            assignments,
-                            metadataFilterProvider.getColumnNames(scope)), null);
-            Optional<String> kqlQuery = clpExpression.getPushDownExpression();
-            Optional<String> metadataSqlQuery = clpExpression.getMetadataSqlQuery();
-            Optional<RowExpression> remainingPredicate = clpExpression.getRemainingExpression();
+            return processFilter(node, (TableScanNode) node.getSource());
+        }
 
-            // Perform required metadata filter checks before handling the KQL query (if kqlQuery
-            // isn't present, we'll return early, skipping subsequent checks).
-            metadataFilterProvider.checkContainsRequiredFilters(clpTableHandle.getSchemaTableName(), metadataSqlQuery.orElse(""));
-            if (metadataSqlQuery.isPresent()) {
-                metadataSqlQuery = Optional.of(metadataFilterProvider.remapFilterSql(scope, metadataSqlQuery.get()));
-                log.debug("Metadata SQL query: %s", metadataSqlQuery);
+        private TableScanNode buildNewTableScanNode(
+                TableScanNode tableScanNode,
+                Set<VariableReferenceExpression> clpUdfVariables)
+        {
+            List<VariableReferenceExpression> newOutputVariables = new ArrayList<>(tableScanNode.getOutputVariables());
+            Map<VariableReferenceExpression, ColumnHandle> newAssignments = new HashMap<>(tableScanNode.getAssignments());
+            for (VariableReferenceExpression var : clpUdfVariables) {
+                newOutputVariables.add(var);
+                newAssignments.put(var, new ClpColumnHandle(var.getName(), var.getType(), true));
             }
 
-            if (!kqlQuery.isPresent()) {
-                return node;
-            }
-            log.debug("KQL query: %s", kqlQuery);
-
-            ClpTableLayoutHandle clpTableLayoutHandle = new ClpTableLayoutHandle(clpTableHandle, kqlQuery, metadataSqlQuery);
-            TableScanNode newTableScanNode = new TableScanNode(
+            return new TableScanNode(
                     tableScanNode.getSourceLocation(),
                     idAllocator.getNextId(),
-                    new TableHandle(
-                            tableHandle.getConnectorId(),
-                            clpTableHandle,
-                            tableHandle.getTransaction(),
-                            Optional.of(clpTableLayoutHandle)),
-                    tableScanNode.getOutputVariables(),
-                    tableScanNode.getAssignments(),
+                    tableScanNode.getTable(),
+                    newOutputVariables,
+                    newAssignments,
                     tableScanNode.getTableConstraints(),
                     tableScanNode.getCurrentConstraint(),
                     tableScanNode.getEnforcedConstraint(),
                     tableScanNode.getCteMaterializationInfo());
-            if (!remainingPredicate.isPresent()) {
-                return newTableScanNode;
+        }
+
+        private PlanNode processFilter(FilterNode filterNode, TableScanNode tableScanNode)
+        {
+            Map<VariableReferenceExpression, ColumnHandle> assignments = tableScanNode.getAssignments();
+            TableHandle tableHandle = tableScanNode.getTable();
+            ClpTableHandle clpTableHandle = (ClpTableHandle) tableHandle.getConnectorHandle();
+
+            Set<VariableReferenceExpression> clpUdfVariablesInFilterNode = new HashSet<>();
+            String scope = CONNECTOR_NAME + "." + clpTableHandle.getSchemaTableName().toString();
+            ClpExpression clpExpression = filterNode.getPredicate().accept(
+                    new ClpFilterToKqlConverter(
+                            functionResolution,
+                            functionManager,
+                            assignments,
+                            metadataFilterProvider.getColumnNames(scope)),
+                    clpUdfVariablesInFilterNode);
+
+            Optional<String> kqlQuery = clpExpression.getPushDownExpression();
+            Optional<String> metadataSqlQuery = clpExpression.getMetadataSqlQuery();
+            Optional<RowExpression> remainingPredicate = clpExpression.getRemainingExpression();
+
+            if (remainingPredicate.isPresent()) {
+                // Collect all variables actually present in the remainingPredicate
+                Set<VariableReferenceExpression> variablesInPredicate = new HashSet<>();
+
+                RowExpressionVisitor<Void, Void> visitor = new DefaultRowExpressionTraversalVisitor<Void>() {
+                    @Override
+                    public Void visitVariableReference(VariableReferenceExpression variable, Void context)
+                    {
+                        variablesInPredicate.add(variable);
+                        return null;
+                    }
+                };
+
+                remainingPredicate.get().accept(visitor, null);
+                // Retain only the variables that also exist in the remainingPredicate
+                clpUdfVariablesInFilterNode.retainAll(variablesInPredicate);
+                if (!clpUdfVariablesInFilterNode.isEmpty()) {
+                    tableScanNode = buildNewTableScanNode(tableScanNode, clpUdfVariablesInFilterNode);
+                }
             }
 
-            return new FilterNode(node.getSourceLocation(),
-                    idAllocator.getNextId(),
-                    newTableScanNode,
-                    remainingPredicate.get());
+            // Perform required metadata filter checks
+            metadataFilterProvider.checkContainsRequiredFilters(clpTableHandle.getSchemaTableName(), metadataSqlQuery.orElse(""));
+            boolean hasMetadataFilter = metadataSqlQuery.isPresent() && !metadataSqlQuery.get().isEmpty();
+            if (hasMetadataFilter) {
+                metadataSqlQuery = Optional.of(metadataFilterProvider.remapFilterSql(scope, metadataSqlQuery.get()));
+                log.debug("Metadata SQL query: %s", metadataSqlQuery);
+            }
+
+            if (kqlQuery.isPresent() || hasMetadataFilter) {
+                if (kqlQuery.isPresent()) {
+                    log.debug("KQL query: %s", kqlQuery);
+                }
+
+                ClpTableLayoutHandle layoutHandle = new ClpTableLayoutHandle(clpTableHandle, kqlQuery, metadataSqlQuery);
+                TableHandle newTableHandle = new TableHandle(
+                        tableHandle.getConnectorId(),
+                        clpTableHandle,
+                        tableHandle.getTransaction(),
+                        Optional.of(layoutHandle));
+
+                tableScanNode = new TableScanNode(
+                        tableScanNode.getSourceLocation(),
+                        idAllocator.getNextId(),
+                        newTableHandle,
+                        tableScanNode.getOutputVariables(),
+                        tableScanNode.getAssignments(),
+                        tableScanNode.getTableConstraints(),
+                        tableScanNode.getCurrentConstraint(),
+                        tableScanNode.getEnforcedConstraint(),
+                        tableScanNode.getCteMaterializationInfo());
+            }
+
+            if (remainingPredicate.isPresent()) {
+                // Not all predicate pushed down, need new FilterNode
+                return new FilterNode(
+                        filterNode.getSourceLocation(),
+                        idAllocator.getNextId(),
+                        tableScanNode,
+                        remainingPredicate.get());
+            }
+            else {
+                return tableScanNode;
+            }
         }
     }
 }

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpPlugin.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpPlugin.java
@@ -16,10 +16,19 @@ package com.facebook.presto.plugin.clp;
 import com.facebook.presto.spi.Plugin;
 import com.facebook.presto.spi.connector.ConnectorFactory;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Set;
 
 public class ClpPlugin
         implements Plugin
 {
+    @Override
+    public Set<Class<?>> getFunctions()
+    {
+        return ImmutableSet.of(ClpFunctions.class);
+    }
+
     @Override
     public Iterable<ConnectorFactory> getConnectorFactories()
     {

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/ClpMetadataDbSetUp.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/ClpMetadataDbSetUp.java
@@ -226,6 +226,11 @@ public final class ClpMetadataDbSetUp
         {
             this.dbPath = dbPath;
         }
+
+        public String getDbPath()
+        {
+            return dbPath;
+        }
     }
 
     static final class ArchivesTableRow

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/TestClpQueryBase.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/TestClpQueryBase.java
@@ -22,13 +22,13 @@ import com.facebook.presto.metadata.AnalyzePropertyManager;
 import com.facebook.presto.metadata.CatalogManager;
 import com.facebook.presto.metadata.ColumnPropertyManager;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.metadata.FunctionExtractor;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.metadata.SchemaPropertyManager;
 import com.facebook.presto.metadata.TablePropertyManager;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorSession;
-import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.function.StandardFunctionResolution;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
@@ -64,6 +64,9 @@ import static java.util.stream.Collectors.toMap;
 public class TestClpQueryBase
 {
     protected static final FunctionAndTypeManager functionAndTypeManager = createTestFunctionAndTypeManager();
+    static {
+        functionAndTypeManager.registerBuiltInFunctions(FunctionExtractor.extractFunctions(ClpFunctions.class));
+    }
     protected static final StandardFunctionResolution standardFunctionResolution = new FunctionResolution(functionAndTypeManager.getFunctionAndTypeResolver());
     protected static final Metadata metadata = new MetadataManager(
             functionAndTypeManager,
@@ -75,14 +78,13 @@ public class TestClpQueryBase
             new AnalyzePropertyManager(),
             createTestTransactionManager(new CatalogManager()));
 
-    protected static final ClpTableHandle table = new ClpTableHandle(new SchemaTableName("default", "test"), "");
     protected static final ClpColumnHandle city = new ClpColumnHandle(
             "city",
             RowType.from(ImmutableList.of(
+                    RowType.field("Name", VARCHAR),
                     RowType.field("Region", RowType.from(ImmutableList.of(
                             RowType.field("Id", BIGINT),
-                            RowType.field("Name", VARCHAR)))),
-                    RowType.field("Name", VARCHAR))),
+                            RowType.field("Name", VARCHAR)))))),
             true);
     protected static final ClpColumnHandle fare = new ClpColumnHandle("fare", DOUBLE, true);
     protected static final ClpColumnHandle isHoliday = new ClpColumnHandle("isHoliday", BOOLEAN, true);


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
This PR introduces new user-defined functions (UDFs) for the CLP connector to improve querying of semi-structured logs:

- **CLP_GET_*** functions for retrieving values from JSON paths, targeting specific CLP column types (`ClpString`, `Integer`, `Float`, etc.). These UDFs enable direct access to dynamic fields and return corresponding Presto native types.  
- **CLP_WILDCARD_*** functions that represent wildcard filters over all columns of a given CLP type. These take no arguments and are designed to be used in filter predicates to simplify querying across dynamic schemas.

Both sets of UDFs are integrated with the query rewriting layer. During query optimization, calls to these functions are rewritten into normal column references or KQL query column symbols, ensuring efficient execution with no additional parsing overhead.

The PR also updates the documentation to clearly describe the semantics and usage of these UDFs, along with examples demonstrating their use.

This PR fixes #29.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
All unit tests passed. End-to-end testing worked. 

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

**New Features**
  * Introduced new CLP functions for querying semi-structured logs, including path-based and wildcard column functions.
  * Enhanced support for pushdown of filter and projection expressions involving CLP user-defined functions (UDFs).
  * Added support for context-aware processing of expressions and improved handling of dynamic or wide schemas.
  * Extended query plan optimization to handle CLP_GET functions in projections and filters.

**Bug Fixes**
  * Improved robustness when handling missing or empty metadata filter configuration paths.

**Documentation**
  * Added comprehensive documentation for new CLP functions, including usage notes and SQL examples.

**Tests**
  * Introduced new and updated tests to cover CLP UDFs, wildcard functions, and plan optimization scenarios.

**Chores**
  * Updated dependencies and internal configuration to support new features and testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->