### PR TITLE
feat: Set context to Set<VariableReferenceExpression> in ClpFilterToKqlConverter

### DIFF
--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpFilterToKqlConverter.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpFilterToKqlConverter.java
@@ -95,7 +95,7 @@ import static java.util.Objects.requireNonNull;
  * </ul>
  */
 public class ClpFilterToKqlConverter
-        implements RowExpressionVisitor<ClpExpression, Void>
+        implements RowExpressionVisitor<ClpExpression, Set<VariableReferenceExpression>>
 {
     private static final Set<OperatorType> LOGICAL_BINARY_OPS_FILTER =
             ImmutableSet.of(EQUAL, NOT_EQUAL, LESS_THAN, LESS_THAN_OR_EQUAL, GREATER_THAN, GREATER_THAN_OR_EQUAL);
@@ -118,15 +118,15 @@ public class ClpFilterToKqlConverter
     }
 
     @Override
-    public ClpExpression visitCall(CallExpression node, Void context)
+    public ClpExpression visitCall(CallExpression node, Set<VariableReferenceExpression> context)
     {
         FunctionHandle functionHandle = node.getFunctionHandle();
         if (standardFunctionResolution.isNotFunction(functionHandle)) {
-            return handleNot(node);
+            return handleNot(node, context);
         }
 
         if (standardFunctionResolution.isLikeFunction(functionHandle)) {
-            return handleLike(node);
+            return handleLike(node, context);
         }
 
         FunctionMetadata functionMetadata = functionMetadataManager.getFunctionMetadata(node.getFunctionHandle());
@@ -134,10 +134,10 @@ public class ClpFilterToKqlConverter
         if (operatorTypeOptional.isPresent()) {
             OperatorType operatorType = operatorTypeOptional.get();
             if (operatorType.isComparisonOperator() && operatorType != IS_DISTINCT_FROM) {
-                return handleLogicalBinary(operatorType, node);
+                return handleLogicalBinary(operatorType, node, context);
             }
             if (BETWEEN == operatorType) {
-                return handleBetween(node);
+                return handleBetween(node, context);
             }
         }
 
@@ -145,38 +145,38 @@ public class ClpFilterToKqlConverter
     }
 
     @Override
-    public ClpExpression visitConstant(ConstantExpression node, Void context)
+    public ClpExpression visitConstant(ConstantExpression node, Set<VariableReferenceExpression> context)
     {
         return new ClpExpression(getLiteralString(node));
     }
 
     @Override
-    public ClpExpression visitVariableReference(VariableReferenceExpression node, Void context)
+    public ClpExpression visitVariableReference(VariableReferenceExpression node, Set<VariableReferenceExpression> context)
     {
         return new ClpExpression(getVariableName(node));
     }
 
     @Override
-    public ClpExpression visitSpecialForm(SpecialFormExpression node, Void context)
+    public ClpExpression visitSpecialForm(SpecialFormExpression node, Set<VariableReferenceExpression> context)
     {
         switch (node.getForm()) {
             case AND:
-                return handleAnd(node);
+                return handleAnd(node, context);
             case OR:
-                return handleOr(node);
+                return handleOr(node, context);
             case IN:
-                return handleIn(node);
+                return handleIn(node, context);
             case IS_NULL:
-                return handleIsNull(node);
+                return handleIsNull(node, context);
             case DEREFERENCE:
-                return handleDereference(node);
+                return handleDereference(node, context);
             default:
                 return new ClpExpression(node);
         }
     }
 
     @Override
-    public ClpExpression visitExpression(RowExpression node, Void context)
+    public ClpExpression visitExpression(RowExpression node, Set<VariableReferenceExpression> context)
     {
         // For all other expressions, return the original expression
         return new ClpExpression(node);
@@ -219,11 +219,12 @@ public class ClpFilterToKqlConverter
      * <p></p>
      * Example: <code>col1 BETWEEN 0 AND 5</code> → <code>col1 >= 0 AND col1 <= 5</code>
      *
-     * @param node the {@code BETWEEN} call expression
+     * @param node the <code>BETWEEN</code> call expression
+     * @param context a set of VariableReferenceExpressions used for pushdown;
      * @return a ClpExpression containing either the equivalent KQL query, or the original
      * expression if it couldn't be translated
      */
-    private ClpExpression handleBetween(CallExpression node)
+    private ClpExpression handleBetween(CallExpression node, Set<VariableReferenceExpression> context)
     {
         List<RowExpression> arguments = node.getArguments();
         if (arguments.size() != 3) {
@@ -243,7 +244,7 @@ public class ClpFilterToKqlConverter
                 || !isClpCompatibleNumericType(third.getType())) {
             return new ClpExpression(node);
         }
-        Optional<String> variableOpt = first.accept(this, null).getPushDownExpression();
+        Optional<String> variableOpt = first.accept(this, context).getPushDownExpression();
         if (!variableOpt.isPresent()) {
             return new ClpExpression(node);
         }
@@ -263,10 +264,11 @@ public class ClpFilterToKqlConverter
      * Example: <code>NOT (col1 = 5)</code> → <code>NOT col1: 5</code>
      *
      * @param node the NOT call expression
+     * @param context a set of VariableReferenceExpressions used for pushdown;
      * @return a ClpExpression containing either the equivalent KQL query, or the original
      * expression if it couldn't be translated
      */
-    private ClpExpression handleNot(CallExpression node)
+    private ClpExpression handleNot(CallExpression node, Set<VariableReferenceExpression> context)
     {
         if (node.getArguments().size() != 1) {
             throw new PrestoException(CLP_PUSHDOWN_UNSUPPORTED_EXPRESSION,
@@ -274,7 +276,7 @@ public class ClpFilterToKqlConverter
         }
 
         RowExpression input = node.getArguments().get(0);
-        ClpExpression expression = input.accept(this, null);
+        ClpExpression expression = input.accept(this, context);
         if (expression.getRemainingExpression().isPresent() || !expression.getPushDownExpression().isPresent()) {
             return new ClpExpression(node);
         }
@@ -297,15 +299,16 @@ public class ClpFilterToKqlConverter
      * Example: <code>col1 LIKE 'a_bc%'</code> → <code>col1: "a?bc*"</code>
      *
      * @param node the LIKE call expression
+     * @param context a set of VariableReferenceExpressions used for pushdown;
      * @return a ClpExpression containing either the equivalent KQL query, or the original
      * expression if it couldn't be translated
      */
-    private ClpExpression handleLike(CallExpression node)
+    private ClpExpression handleLike(CallExpression node, Set<VariableReferenceExpression> context)
     {
         if (node.getArguments().size() != 2) {
             throw new PrestoException(CLP_PUSHDOWN_UNSUPPORTED_EXPRESSION, "LIKE operator must have exactly two arguments. Received: " + node);
         }
-        ClpExpression variable = node.getArguments().get(0).accept(this, null);
+        ClpExpression variable = node.getArguments().get(0).accept(this, context);
         if (!variable.getPushDownExpression().isPresent()) {
             return new ClpExpression(node);
         }
@@ -346,10 +349,11 @@ public class ClpFilterToKqlConverter
      *
      * @param operator the binary operator (e.g., EQUAL, NOT_EQUAL)
      * @param node the call expression representing the binary operation
+     * @param context a set of VariableReferenceExpressions used for pushdown;
      * @return a ClpExpression containing either the equivalent KQL query, or the original
      * expression if it couldn't be translated
      */
-    private ClpExpression handleLogicalBinary(OperatorType operator, CallExpression node)
+    private ClpExpression handleLogicalBinary(OperatorType operator, CallExpression node, Set<VariableReferenceExpression> context)
     {
         if (node.getArguments().size() != 2) {
             throw new PrestoException(CLP_PUSHDOWN_UNSUPPORTED_EXPRESSION,
@@ -358,21 +362,21 @@ public class ClpFilterToKqlConverter
         RowExpression left = node.getArguments().get(0);
         RowExpression right = node.getArguments().get(1);
 
-        ClpExpression maybeLeftSubstring = tryInterpretSubstringEquality(operator, left, right);
-        if (maybeLeftSubstring.getPushDownExpression().isPresent()) {
-            return maybeLeftSubstring;
+        Optional<ClpExpression> maybeLeftSubstring = tryInterpretSubstringEquality(operator, left, right, context);
+        if (maybeLeftSubstring.isPresent()) {
+            return maybeLeftSubstring.get();
         }
 
-        ClpExpression maybeRightSubstring = tryInterpretSubstringEquality(operator, right, left);
-        if (maybeRightSubstring.getPushDownExpression().isPresent()) {
-            return maybeRightSubstring;
+        Optional<ClpExpression> maybeRightSubstring = tryInterpretSubstringEquality(operator, right, left, context);
+        if (maybeRightSubstring.isPresent()) {
+            return maybeRightSubstring.get();
         }
 
-        ClpExpression leftExpression = left.accept(this, null);
-        ClpExpression rightExpression = right.accept(this, null);
-        Optional<String> leftDefinition = leftExpression.getPushDownExpression();
-        Optional<String> rightDefinition = rightExpression.getPushDownExpression();
-        if (!leftDefinition.isPresent() || !rightDefinition.isPresent()) {
+        ClpExpression leftExpression = left.accept(this, context);
+        ClpExpression rightExpression = right.accept(this, context);
+        Optional<String> leftPushDownExpression = leftExpression.getPushDownExpression();
+        Optional<String> rightPushDownExpression = rightExpression.getPushDownExpression();
+        if (!leftPushDownExpression.isPresent() || !rightPushDownExpression.isPresent()) {
             return new ClpExpression(node);
         }
 
@@ -384,8 +388,8 @@ public class ClpFilterToKqlConverter
 
         if (rightIsConstant) {
             return buildClpExpression(
-                    leftDefinition.get(),    // variable
-                    rightDefinition.get(),   // literal
+                    leftPushDownExpression.get(),    // variable
+                    rightPushDownExpression.get(),   // literal
                     operator,
                     rightType,
                     node);
@@ -393,8 +397,8 @@ public class ClpFilterToKqlConverter
         else if (leftIsConstant) {
             OperatorType newOperator = flip(operator);
             return buildClpExpression(
-                    rightDefinition.get(),   // variable
-                    leftDefinition.get(),    // literal
+                    rightPushDownExpression.get(),   // variable
+                    leftPushDownExpression.get(),    // literal
                     newOperator,
                     leftType,
                     node);
@@ -471,26 +475,27 @@ public class ClpFilterToKqlConverter
      * @param operator the comparison operator (should be EQUAL)
      * @param possibleSubstring the left or right expression, possibly a SUBSTR call
      * @param possibleLiteral the opposite expression, possibly a string constant
-     * @return a ClpExpression containing either the equivalent KQL query, or nothing if it couldn't
-     * be translated
+     * @param context a set of VariableReferenceExpressions used for pushdown;
+     * @return an Optional containing a ClpExpression with the equivalent KQL query
      */
-    private ClpExpression tryInterpretSubstringEquality(
+    private Optional<ClpExpression> tryInterpretSubstringEquality(
             OperatorType operator,
             RowExpression possibleSubstring,
-            RowExpression possibleLiteral)
+            RowExpression possibleLiteral,
+            Set<VariableReferenceExpression> context)
     {
         if (!operator.equals(EQUAL)) {
-            return new ClpExpression();
+            return Optional.empty();
         }
 
         if (!(possibleSubstring instanceof CallExpression) ||
                 !(possibleLiteral instanceof ConstantExpression)) {
-            return new ClpExpression();
+            return Optional.empty();
         }
 
-        Optional<SubstrInfo> maybeSubstringCall = parseSubstringCall((CallExpression) possibleSubstring);
+        Optional<SubstrInfo> maybeSubstringCall = parseSubstringCall((CallExpression) possibleSubstring, context);
         if (!maybeSubstringCall.isPresent()) {
-            return new ClpExpression();
+            return Optional.empty();
         }
 
         String targetString = getLiteralString((ConstantExpression) possibleLiteral);
@@ -501,9 +506,10 @@ public class ClpFilterToKqlConverter
      * Parses a <code>SUBSTR(x, start [, length])</code> call into a SubstrInfo object if valid.
      *
      * @param callExpression the call expression to inspect
+     * @param context a set of VariableReferenceExpressions used for pushdown;
      * @return an Optional containing SubstrInfo if the expression is a valid SUBSTR call
      */
-    private Optional<SubstrInfo> parseSubstringCall(CallExpression callExpression)
+    private Optional<SubstrInfo> parseSubstringCall(CallExpression callExpression, Set<VariableReferenceExpression> context)
     {
         FunctionMetadata functionMetadata = functionMetadataManager.getFunctionMetadata(callExpression.getFunctionHandle());
         String functionName = functionMetadata.getName().getObjectName();
@@ -516,7 +522,7 @@ public class ClpFilterToKqlConverter
             return Optional.empty();
         }
 
-        ClpExpression variable = callExpression.getArguments().get(0).accept(this, null);
+        ClpExpression variable = callExpression.getArguments().get(0).accept(this, context);
         if (!variable.getPushDownExpression().isPresent()) {
             return Optional.empty();
         }
@@ -545,10 +551,9 @@ public class ClpFilterToKqlConverter
      *
      * @param info parsed SUBSTR call info
      * @param targetString the literal string being compared to
-     * @return a ClpExpression containing either the equivalent KQL query, or nothing if it couldn't
-     * be translated
+     * @return an Optional containing either a ClpExpression with the equivalent KQL query
      */
-    private ClpExpression interpretSubstringEquality(SubstrInfo info, String targetString)
+    private Optional<ClpExpression> interpretSubstringEquality(SubstrInfo info, String targetString)
     {
         if (info.lengthExpression != null) {
             Optional<Integer> maybeStart = parseIntValue(info.startExpression);
@@ -564,7 +569,7 @@ public class ClpFilterToKqlConverter
                         result.append("?");
                     }
                     result.append(targetString).append("*\"");
-                    return new ClpExpression(result.toString());
+                    return Optional.of(new ClpExpression(result.toString()));
                 }
             }
         }
@@ -579,15 +584,15 @@ public class ClpFilterToKqlConverter
                         result.append("?");
                     }
                     result.append(targetString).append("\"");
-                    return new ClpExpression(result.toString());
+                    return Optional.of(new ClpExpression(result.toString()));
                 }
                 if (start == -targetString.length()) {
-                    return new ClpExpression(format("%s: \"*%s\"", info.variableName, targetString));
+                    return Optional.of(new ClpExpression(format("%s: \"*%s\"", info.variableName, targetString)));
                 }
             }
         }
 
-        return new ClpExpression();
+        return Optional.empty();
     }
 
     /**
@@ -655,9 +660,10 @@ public class ClpFilterToKqlConverter
      * Example: <code>col1 = 5 AND col2 = 'abc'</code> → <code>(col1: 5 AND col2: "abc")</code>
      *
      * @param node the <code>AND</code> special form expression
+     * @param context a set of VariableReferenceExpressions used for pushdown;
      * @return a ClpExpression containing the KQL query and any remaining sub-expressions
      */
-    private ClpExpression handleAnd(SpecialFormExpression node)
+    private ClpExpression handleAnd(SpecialFormExpression node, Set<VariableReferenceExpression> context)
     {
         StringBuilder metadataQueryBuilder = new StringBuilder();
         metadataQueryBuilder.append("(");
@@ -667,7 +673,7 @@ public class ClpFilterToKqlConverter
         boolean hasMetadataSql = false;
         boolean hasPushDownExpression = false;
         for (RowExpression argument : node.getArguments()) {
-            ClpExpression expression = argument.accept(this, null);
+            ClpExpression expression = argument.accept(this, context);
             if (expression.getPushDownExpression().isPresent()) {
                 hasPushDownExpression = true;
                 queryBuilder.append(expression.getPushDownExpression().get());
@@ -713,20 +719,25 @@ public class ClpFilterToKqlConverter
      * Example: <code>col1 = 5 OR col1 = 10</code> → <code>(col1: 5 OR col1: 10)</code>
      *
      * @param node the <code>OR</code> special form expression
+     * @param context a set of VariableReferenceExpressions used for pushdown;
      * @return a ClpExpression containing either the equivalent KQL query, or the original
      * expression if it couldn't be fully translated
      */
-    private ClpExpression handleOr(SpecialFormExpression node)
+    private ClpExpression handleOr(SpecialFormExpression node, Set<VariableReferenceExpression> context)
     {
         StringBuilder metadataQueryBuilder = new StringBuilder();
         metadataQueryBuilder.append("(");
         StringBuilder queryBuilder = new StringBuilder();
         queryBuilder.append("(");
+        boolean allPushedDown = true;
         boolean hasAllMetadataSql = true;
         for (RowExpression argument : node.getArguments()) {
-            ClpExpression expression = argument.accept(this, null);
+            ClpExpression expression = argument.accept(this, context);
+            // Note: It is possible in the future that an expression cannot be pushed down as a KQL query, but can be
+            // pushed down as a metadata SQL query.
             if (expression.getRemainingExpression().isPresent() || !expression.getPushDownExpression().isPresent()) {
-                return new ClpExpression(node);
+                allPushedDown = false;
+                continue;
             }
             queryBuilder.append(expression.getPushDownExpression().get());
             queryBuilder.append(" OR ");
@@ -738,10 +749,13 @@ public class ClpFilterToKqlConverter
                 hasAllMetadataSql = false;
             }
         }
-        // Remove the last " OR " from the query
-        return new ClpExpression(
-                queryBuilder.substring(0, queryBuilder.length() - 4) + ")",
-                hasAllMetadataSql ? metadataQueryBuilder.substring(0, metadataQueryBuilder.length() - 4) + ")" : null);
+        if (allPushedDown) {
+            // Remove the last " OR " from the query
+            return new ClpExpression(
+                    queryBuilder.substring(0, queryBuilder.length() - 4) + ")",
+                    hasAllMetadataSql ? metadataQueryBuilder.substring(0, metadataQueryBuilder.length() - 4) + ")" : null);
+        }
+        return new ClpExpression(node);
     }
 
     /**
@@ -750,12 +764,13 @@ public class ClpFilterToKqlConverter
      * Example: <code>col1 IN (1, 2, 3)</code> → <code>(col1: 1 OR col1: 2 OR col1: 3)</code>
      *
      * @param node the <code>IN</code> special form expression
+     * @param context a set of VariableReferenceExpressions used for pushdown;
      * @return a ClpExpression containing either the equivalent KQL query, or the original
      * expression if it couldn't be translated
      */
-    private ClpExpression handleIn(SpecialFormExpression node)
+    private ClpExpression handleIn(SpecialFormExpression node, Set<VariableReferenceExpression> context)
     {
-        ClpExpression variable = node.getArguments().get(0).accept(this, null);
+        ClpExpression variable = node.getArguments().get(0).accept(this, context);
         if (!variable.getPushDownExpression().isPresent()) {
             return new ClpExpression(node);
         }
@@ -788,17 +803,18 @@ public class ClpFilterToKqlConverter
      * Example: <code>col1 IS NULL</code> → <code>NOT col1: *</code>
      *
      * @param node the <code>IS_NULL</code> special form expression
+     * @param context a set of VariableReferenceExpressions used for pushdown;
      * @return a ClpExpression containing either the equivalent KQL query, or the original
      * expression if it couldn't be translated
      */
-    private ClpExpression handleIsNull(SpecialFormExpression node)
+    private ClpExpression handleIsNull(SpecialFormExpression node, Set<VariableReferenceExpression> context)
     {
         if (node.getArguments().size() != 1) {
             throw new PrestoException(CLP_PUSHDOWN_UNSUPPORTED_EXPRESSION,
                     "IS NULL operator must have exactly one argument. Received: " + node);
         }
 
-        ClpExpression expression = node.getArguments().get(0).accept(this, null);
+        ClpExpression expression = node.getArguments().get(0).accept(this, context);
         if (!expression.getPushDownExpression().isPresent()) {
             return new ClpExpression(node);
         }
@@ -816,13 +832,14 @@ public class ClpFilterToKqlConverter
      *
      * @param expression the dereference expression ({@link SpecialFormExpression} or
      * {@link VariableReferenceExpression})
+     * @param context a set of VariableReferenceExpressions used for pushdown;
      * @return a ClpExpression containing either the dot-separated field name, or the original
      * expression if it couldn't be translated
      */
-    private ClpExpression handleDereference(RowExpression expression)
+    private ClpExpression handleDereference(RowExpression expression, Set<VariableReferenceExpression> context)
     {
         if (expression instanceof VariableReferenceExpression) {
-            return expression.accept(this, null);
+            return expression.accept(this, context);
         }
 
         if (!(expression instanceof SpecialFormExpression)) {
@@ -862,7 +879,7 @@ public class ClpFilterToKqlConverter
         RowType.Field field = rowType.getFields().get(fieldIndex);
         String fieldName = field.getName().orElse("field" + fieldIndex);
 
-        ClpExpression baseString = handleDereference(base);
+        ClpExpression baseString = handleDereference(base, context);
         if (!baseString.getPushDownExpression().isPresent()) {
             return new ClpExpression(expression);
         }

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpPlanOptimizer.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpPlanOptimizer.java
@@ -29,8 +29,10 @@ import com.facebook.presto.spi.plan.TableScanNode;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static com.facebook.presto.plugin.clp.ClpConnectorFactory.CONNECTOR_NAME;
 import static com.facebook.presto.spi.ConnectorPlanRewriter.rewriteWith;
@@ -79,12 +81,14 @@ public class ClpPlanOptimizer
             TableHandle tableHandle = tableScanNode.getTable();
             ClpTableHandle clpTableHandle = (ClpTableHandle) tableHandle.getConnectorHandle();
             String scope = CONNECTOR_NAME + "." + clpTableHandle.getSchemaTableName().toString();
+            Set<VariableReferenceExpression> clpUdfVariablesInFilterNode = new HashSet<>();
             ClpExpression clpExpression = node.getPredicate().accept(
                     new ClpFilterToKqlConverter(
                             functionResolution,
                             functionManager,
                             assignments,
-                            metadataFilterProvider.getColumnNames(scope)), null);
+                            metadataFilterProvider.getColumnNames(scope)),
+                    clpUdfVariablesInFilterNode);
             Optional<String> kqlQuery = clpExpression.getPushDownExpression();
             Optional<String> metadataSqlQuery = clpExpression.getMetadataSqlQuery();
             Optional<RowExpression> remainingPredicate = clpExpression.getRemainingExpression();


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
When implementing CLP UDFs, we need to transform each `CLP_GET_*` function into a `VariableReferenceExpression`. During this transformation, it's important to track all variables derived from `CLP_GET_*` so that they can later be included as outputs in the corresponding TableScanNode.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [ ] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [ ] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [ ] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
All unit tests passed


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
