### PR TITLE
fix: Update the velox submodule's URL and commit to the latest from y-scope/velox:presto-0.293-clp-connector.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "presto-native-execution/velox"]
 	path = presto-native-execution/velox
-	url = https://github.com/facebookincubator/velox.git
+	url = https://github.com/y-scope/velox.git


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

When PR https://github.com/y-scope/velox/pull/18 merged, it generated a new squash commit that I forgot to sync in the Presto repo. This PR is to sync the Velox submodule commit hash to make sure it is of the latest.

We also forgot to update the `.gitmodules` to replace facebook's main repo with our fork.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

Clone the repo and checkout the branch, then run `make submodules -C presto-native-exeuction` and `make velox-submodule -C presto-native-execution` to check if the Velox is of correct version.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the source and version of a key submodule dependency to ensure continued access and compatibility. No changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->