### PR TITLE
feat: Add split type to `ClpSplit` to prepare to support searching CLP IR files; Update to the latest commit of y-scope/velox:presto-0.293-clp-connector.

### DIFF
--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpSplit.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpSplit.java
@@ -80,7 +80,7 @@ public class ClpSplit
     @Override
     public Map<String, String> getInfo()
     {
-        return ImmutableMap.of("path", path, "kqlQuery", kqlQuery.orElse("<null>"), "type", type.toString());
+        return ImmutableMap.of("path", path, "type", type.toString(), "kqlQuery", kqlQuery.orElse("<null>"));
     }
 
     public enum SplitType

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpSplit.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpSplit.java
@@ -80,7 +80,7 @@ public class ClpSplit
     @Override
     public Map<String, String> getInfo()
     {
-        return ImmutableMap.of("path", path, "kqlQuery", kqlQuery.orElse("<null>"));
+        return ImmutableMap.of("path", path, "kqlQuery", kqlQuery.orElse("<null>"), "type", type.toString());
     }
 
     public enum SplitType

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpSplit.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpSplit.java
@@ -34,13 +34,13 @@ public class ClpSplit
 {
     private final String path;
     private final Optional<String> kqlQuery;
-    private final Type type;
+    private final SplitType type;
 
     @JsonCreator
     public ClpSplit(
             @JsonProperty("path") String path,
             @JsonProperty("kqlQuery") Optional<String> kqlQuery,
-            @JsonProperty("type") Type type)
+            @JsonProperty("type") SplitType type)
     {
         this.path = requireNonNull(path, "Split path is null");
         this.kqlQuery = kqlQuery;
@@ -60,7 +60,7 @@ public class ClpSplit
     }
 
     @JsonProperty
-    public Type getType()
+    public SplitType getType()
     {
         return type;
     }
@@ -83,7 +83,8 @@ public class ClpSplit
         return ImmutableMap.of("path", path, "kqlQuery", kqlQuery.orElse("<null>"));
     }
 
-    public enum Type {
+    public enum SplitType
+    {
         ARCHIVE,
         IR,
     }

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpSplit.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpSplit.java
@@ -33,18 +33,18 @@ public class ClpSplit
         implements ConnectorSplit
 {
     private final String path;
-    private final Optional<String> kqlQuery;
     private final SplitType type;
+    private final Optional<String> kqlQuery;
 
     @JsonCreator
     public ClpSplit(
             @JsonProperty("path") String path,
-            @JsonProperty("kqlQuery") Optional<String> kqlQuery,
-            @JsonProperty("type") SplitType type)
+            @JsonProperty("type") SplitType type,
+            @JsonProperty("kqlQuery") Optional<String> kqlQuery)
     {
         this.path = requireNonNull(path, "Split path is null");
-        this.kqlQuery = kqlQuery;
         this.type = requireNonNull(type, "Split type is null");
+        this.kqlQuery = kqlQuery;
     }
 
     @JsonProperty
@@ -54,15 +54,15 @@ public class ClpSplit
     }
 
     @JsonProperty
-    public Optional<String> getKqlQuery()
-    {
-        return kqlQuery;
-    }
-
-    @JsonProperty
     public SplitType getType()
     {
         return type;
+    }
+
+    @JsonProperty
+    public Optional<String> getKqlQuery()
+    {
+        return kqlQuery;
     }
 
     @Override

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpSplit.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpSplit.java
@@ -34,14 +34,17 @@ public class ClpSplit
 {
     private final String path;
     private final Optional<String> kqlQuery;
+    private final Type type;
 
     @JsonCreator
     public ClpSplit(
             @JsonProperty("path") String path,
-            @JsonProperty("kqlQuery") Optional<String> kqlQuery)
+            @JsonProperty("kqlQuery") Optional<String> kqlQuery,
+            @JsonProperty("type") Type type)
     {
         this.path = requireNonNull(path, "Split path is null");
         this.kqlQuery = kqlQuery;
+        this.type = requireNonNull(type, "Split type is null");
     }
 
     @JsonProperty
@@ -54,6 +57,12 @@ public class ClpSplit
     public Optional<String> getKqlQuery()
     {
         return kqlQuery;
+    }
+
+    @JsonProperty
+    public Type getType()
+    {
+        return type;
     }
 
     @Override
@@ -72,5 +81,10 @@ public class ClpSplit
     public Map<String, String> getInfo()
     {
         return ImmutableMap.of("path", path, "kqlQuery", kqlQuery.orElse("<null>"));
+    }
+
+    public enum Type {
+        ARCHIVE,
+        IR,
     }
 }

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpMySqlSplitProvider.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpMySqlSplitProvider.java
@@ -29,8 +29,8 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
 
+import static com.facebook.presto.plugin.clp.ClpSplit.SplitType.ARCHIVE;
 import static java.lang.String.format;
-import static com.facebook.presto.plugin.clp.ClpSplit.Type.ARCHIVE;
 
 public class ClpMySqlSplitProvider
         implements ClpSplitProvider

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpMySqlSplitProvider.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpMySqlSplitProvider.java
@@ -30,6 +30,7 @@ import java.sql.SQLException;
 import java.util.List;
 
 import static java.lang.String.format;
+import static com.facebook.presto.plugin.clp.ClpSplit.Type.ARCHIVE;
 
 public class ClpMySqlSplitProvider
         implements ClpSplitProvider
@@ -81,7 +82,7 @@ public class ClpMySqlSplitProvider
                 while (resultSet.next()) {
                     final String archiveId = resultSet.getString(ARCHIVES_TABLE_COLUMN_ID);
                     final String archivePath = tablePath + "/" + archiveId;
-                    splits.add(new ClpSplit(archivePath, clpTableLayoutHandle.getKqlQuery()));
+                    splits.add(new ClpSplit(archivePath, clpTableLayoutHandle.getKqlQuery(), ARCHIVE));
                 }
             }
         }

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpMySqlSplitProvider.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpMySqlSplitProvider.java
@@ -82,7 +82,7 @@ public class ClpMySqlSplitProvider
                 while (resultSet.next()) {
                     final String archiveId = resultSet.getString(ARCHIVES_TABLE_COLUMN_ID);
                     final String archivePath = tablePath + "/" + archiveId;
-                    splits.add(new ClpSplit(archivePath, clpTableLayoutHandle.getKqlQuery(), ARCHIVE));
+                    splits.add(new ClpSplit(archivePath, ARCHIVE, clpTableLayoutHandle.getKqlQuery()));
                 }
             }
         }

--- a/presto-native-execution/presto_cpp/main/connectors/PrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/PrestoToVeloxConnector.cpp
@@ -1566,8 +1566,8 @@ ClpPrestoToVeloxConnector::toVeloxSplit(
   return std::make_unique<connector::clp::ClpConnectorSplit>(
       catalogId,
       clpSplit->path,
-      clpSplit->kqlQuery,
-      static_cast<int>(clpSplit->type));
+      static_cast<int>(clpSplit->type),
+      clpSplit->kqlQuery);
 }
 
 std::unique_ptr<velox::connector::ColumnHandle>

--- a/presto-native-execution/presto_cpp/main/connectors/PrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/PrestoToVeloxConnector.cpp
@@ -1564,7 +1564,10 @@ ClpPrestoToVeloxConnector::toVeloxSplit(
   VELOX_CHECK_NOT_NULL(
       clpSplit, "Unexpected split type {}", connectorSplit->_type);
   return std::make_unique<connector::clp::ClpConnectorSplit>(
-      catalogId, clpSplit->path, clpSplit->kqlQuery);
+      catalogId,
+      clpSplit->path,
+      clpSplit->kqlQuery,
+      static_cast<int>(clpSplit->type));
 }
 
 std::unique_ptr<velox::connector::ColumnHandle>

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/clp/presto_protocol-json-cpp.mustache
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/clp/presto_protocol-json-cpp.mustache
@@ -72,7 +72,7 @@ namespace facebook::presto::protocol::clp {
 {{/struct}}
 {{#enum}}
 namespace facebook::presto::protocol::clp {
-    //Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+    //Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
     // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
     static const std::pair<{{&class_name}}, json>

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/clp/presto_protocol_clp.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/clp/presto_protocol_clp.cpp
@@ -70,7 +70,7 @@ void from_json(const json& j, ClpColumnHandle& p) {
 }
 } // namespace facebook::presto::protocol::clp
 namespace facebook::presto::protocol::clp {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+// Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<SplitType, json> SplitType_enum_table[] =

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/clp/presto_protocol_clp.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/clp/presto_protocol_clp.cpp
@@ -34,6 +34,37 @@ void from_json(const json& j, ClpTransactionHandle& p) {
 }
 } // namespace facebook::presto::protocol::clp
 namespace facebook::presto::protocol::clp {
+// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+
+// NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
+static const std::pair<Type, json> Type_enum_table[] =
+    { // NOLINT: cert-err58-cpp
+        {Type::ARCHIVE, "ARCHIVE"},
+        {Type::IR, "IR"}};
+void to_json(json& j, const Type& e) {
+  static_assert(std::is_enum<Type>::value, "Type must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(Type_enum_table),
+      std::end(Type_enum_table),
+      [e](const std::pair<Type, json>& ej_pair) -> bool {
+        return ej_pair.first == e;
+      });
+  j = ((it != std::end(Type_enum_table)) ? it : std::begin(Type_enum_table))
+          ->second;
+}
+void from_json(const json& j, Type& e) {
+  static_assert(std::is_enum<Type>::value, "Type must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(Type_enum_table),
+      std::end(Type_enum_table),
+      [&j](const std::pair<Type, json>& ej_pair) -> bool {
+        return ej_pair.second == j;
+      });
+  e = ((it != std::end(Type_enum_table)) ? it : std::begin(Type_enum_table))
+          ->first;
+}
+} // namespace facebook::presto::protocol::clp
+namespace facebook::presto::protocol::clp {
 ClpColumnHandle::ClpColumnHandle() noexcept {
   _type = "clp";
 }
@@ -79,12 +110,14 @@ void to_json(json& j, const ClpSplit& p) {
   j["@type"] = "clp";
   to_json_key(j, "path", p.path, "ClpSplit", "String", "path");
   to_json_key(j, "kqlQuery", p.kqlQuery, "ClpSplit", "String", "kqlQuery");
+  to_json_key(j, "type", p.type, "ClpSplit", "Type", "type");
 }
 
 void from_json(const json& j, ClpSplit& p) {
   p._type = j["@type"];
   from_json_key(j, "path", p.path, "ClpSplit", "String", "path");
   from_json_key(j, "kqlQuery", p.kqlQuery, "ClpSplit", "String", "kqlQuery");
+  from_json_key(j, "type", p.type, "ClpSplit", "Type", "type");
 }
 } // namespace facebook::presto::protocol::clp
 namespace facebook::presto::protocol::clp {

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/clp/presto_protocol_clp.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/clp/presto_protocol_clp.cpp
@@ -34,37 +34,6 @@ void from_json(const json& j, ClpTransactionHandle& p) {
 }
 } // namespace facebook::presto::protocol::clp
 namespace facebook::presto::protocol::clp {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
-
-// NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
-static const std::pair<Type, json> Type_enum_table[] =
-    { // NOLINT: cert-err58-cpp
-        {Type::ARCHIVE, "ARCHIVE"},
-        {Type::IR, "IR"}};
-void to_json(json& j, const Type& e) {
-  static_assert(std::is_enum<Type>::value, "Type must be an enum!");
-  const auto* it = std::find_if(
-      std::begin(Type_enum_table),
-      std::end(Type_enum_table),
-      [e](const std::pair<Type, json>& ej_pair) -> bool {
-        return ej_pair.first == e;
-      });
-  j = ((it != std::end(Type_enum_table)) ? it : std::begin(Type_enum_table))
-          ->second;
-}
-void from_json(const json& j, Type& e) {
-  static_assert(std::is_enum<Type>::value, "Type must be an enum!");
-  const auto* it = std::find_if(
-      std::begin(Type_enum_table),
-      std::end(Type_enum_table),
-      [&j](const std::pair<Type, json>& ej_pair) -> bool {
-        return ej_pair.second == j;
-      });
-  e = ((it != std::end(Type_enum_table)) ? it : std::begin(Type_enum_table))
-          ->first;
-}
-} // namespace facebook::presto::protocol::clp
-namespace facebook::presto::protocol::clp {
 ClpColumnHandle::ClpColumnHandle() noexcept {
   _type = "clp";
 }
@@ -101,6 +70,41 @@ void from_json(const json& j, ClpColumnHandle& p) {
 }
 } // namespace facebook::presto::protocol::clp
 namespace facebook::presto::protocol::clp {
+// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+
+// NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
+static const std::pair<SplitType, json> SplitType_enum_table[] =
+    { // NOLINT: cert-err58-cpp
+        {SplitType::ARCHIVE, "ARCHIVE"},
+        {SplitType::IR, "IR"}};
+void to_json(json& j, const SplitType& e) {
+  static_assert(std::is_enum<SplitType>::value, "SplitType must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(SplitType_enum_table),
+      std::end(SplitType_enum_table),
+      [e](const std::pair<SplitType, json>& ej_pair) -> bool {
+        return ej_pair.first == e;
+      });
+  j = ((it != std::end(SplitType_enum_table))
+           ? it
+           : std::begin(SplitType_enum_table))
+          ->second;
+}
+void from_json(const json& j, SplitType& e) {
+  static_assert(std::is_enum<SplitType>::value, "SplitType must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(SplitType_enum_table),
+      std::end(SplitType_enum_table),
+      [&j](const std::pair<SplitType, json>& ej_pair) -> bool {
+        return ej_pair.second == j;
+      });
+  e = ((it != std::end(SplitType_enum_table))
+           ? it
+           : std::begin(SplitType_enum_table))
+          ->first;
+}
+} // namespace facebook::presto::protocol::clp
+namespace facebook::presto::protocol::clp {
 ClpSplit::ClpSplit() noexcept {
   _type = "clp";
 }
@@ -110,14 +114,14 @@ void to_json(json& j, const ClpSplit& p) {
   j["@type"] = "clp";
   to_json_key(j, "path", p.path, "ClpSplit", "String", "path");
   to_json_key(j, "kqlQuery", p.kqlQuery, "ClpSplit", "String", "kqlQuery");
-  to_json_key(j, "type", p.type, "ClpSplit", "Type", "type");
+  to_json_key(j, "type", p.type, "ClpSplit", "SplitType", "type");
 }
 
 void from_json(const json& j, ClpSplit& p) {
   p._type = j["@type"];
   from_json_key(j, "path", p.path, "ClpSplit", "String", "path");
   from_json_key(j, "kqlQuery", p.kqlQuery, "ClpSplit", "String", "kqlQuery");
-  from_json_key(j, "type", p.type, "ClpSplit", "Type", "type");
+  from_json_key(j, "type", p.type, "ClpSplit", "SplitType", "type");
 }
 } // namespace facebook::presto::protocol::clp
 namespace facebook::presto::protocol::clp {

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/clp/presto_protocol_clp.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/clp/presto_protocol_clp.cpp
@@ -113,15 +113,15 @@ void to_json(json& j, const ClpSplit& p) {
   j = json::object();
   j["@type"] = "clp";
   to_json_key(j, "path", p.path, "ClpSplit", "String", "path");
-  to_json_key(j, "kqlQuery", p.kqlQuery, "ClpSplit", "String", "kqlQuery");
   to_json_key(j, "type", p.type, "ClpSplit", "SplitType", "type");
+  to_json_key(j, "kqlQuery", p.kqlQuery, "ClpSplit", "String", "kqlQuery");
 }
 
 void from_json(const json& j, ClpSplit& p) {
   p._type = j["@type"];
   from_json_key(j, "path", p.path, "ClpSplit", "String", "path");
-  from_json_key(j, "kqlQuery", p.kqlQuery, "ClpSplit", "String", "kqlQuery");
   from_json_key(j, "type", p.type, "ClpSplit", "SplitType", "type");
+  from_json_key(j, "kqlQuery", p.kqlQuery, "ClpSplit", "String", "kqlQuery");
 }
 } // namespace facebook::presto::protocol::clp
 namespace facebook::presto::protocol::clp {

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/clp/presto_protocol_clp.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/clp/presto_protocol_clp.h
@@ -30,11 +30,6 @@ void to_json(json& j, const ClpTransactionHandle& p);
 
 void from_json(const json& j, ClpTransactionHandle& p);
 } // namespace facebook::presto::protocol::clp
-namespace facebook::presto::protocol::clp {
-enum class Type { ARCHIVE, IR };
-extern void to_json(json& j, const Type& e);
-extern void from_json(const json& j, Type& e);
-} // namespace facebook::presto::protocol::clp
 // ClpColumnHandle is special since it needs an implementation of
 // operator<().
 
@@ -54,10 +49,15 @@ void to_json(json& j, const ClpColumnHandle& p);
 void from_json(const json& j, ClpColumnHandle& p);
 } // namespace facebook::presto::protocol::clp
 namespace facebook::presto::protocol::clp {
+enum class SplitType { ARCHIVE, IR };
+extern void to_json(json& j, const SplitType& e);
+extern void from_json(const json& j, SplitType& e);
+} // namespace facebook::presto::protocol::clp
+namespace facebook::presto::protocol::clp {
 struct ClpSplit : public ConnectorSplit {
   String path = {};
   std::shared_ptr<String> kqlQuery = {};
-  Type type = {};
+  SplitType type = {};
 
   ClpSplit() noexcept;
 };

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/clp/presto_protocol_clp.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/clp/presto_protocol_clp.h
@@ -30,6 +30,11 @@ void to_json(json& j, const ClpTransactionHandle& p);
 
 void from_json(const json& j, ClpTransactionHandle& p);
 } // namespace facebook::presto::protocol::clp
+namespace facebook::presto::protocol::clp {
+enum class Type { ARCHIVE, IR };
+extern void to_json(json& j, const Type& e);
+extern void from_json(const json& j, Type& e);
+} // namespace facebook::presto::protocol::clp
 // ClpColumnHandle is special since it needs an implementation of
 // operator<().
 
@@ -52,6 +57,7 @@ namespace facebook::presto::protocol::clp {
 struct ClpSplit : public ConnectorSplit {
   String path = {};
   std::shared_ptr<String> kqlQuery = {};
+  Type type = {};
 
   ClpSplit() noexcept;
 };

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/clp/presto_protocol_clp.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/clp/presto_protocol_clp.h
@@ -56,8 +56,8 @@ extern void from_json(const json& j, SplitType& e);
 namespace facebook::presto::protocol::clp {
 struct ClpSplit : public ConnectorSplit {
   String path = {};
-  std::shared_ptr<String> kqlQuery = {};
   SplitType type = {};
+  std::shared_ptr<String> kqlQuery = {};
 
   ClpSplit() noexcept;
 };


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

We added `type` property stored in the `ClpSplit` and nested enum class `SplitType` (We cannot name it `Type` because it will conflict with `ColumnHandle`'s `Type` because there is no way to config this remapping in protocol's YAML according to the [doc](https://github.com/y-scope/presto/blob/release-0.293-clp-connector/presto-native-execution/presto_cpp/presto_protocol/README.md#presto_protocolyml)). This property is to discern whether the dataset we want to conduct search is IR files or archives. We can refer to this [commit](https://github.com/y-scope/velox/pull/4/commits/7c0f91eca5946c60935e7f5976e01f150838cee8).

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

Set a breakpoint at `ClpDataSource.cpp:addSplit()` to check if the type was passed and parsed correctly.
<img width="1491" height="977" alt="image" src="https://github.com/user-attachments/assets/ed6a234a-d950-4d65-87a4-e058de25a655" />

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a split type field with values "ARCHIVE" and "IR" to improve split identification.
  * Enhanced JSON serialization and deserialization to include the split type field.
* **Bug Fixes**
  * Ensured consistent handling and passing of split type information across components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->