### PR TITLE
feat: Update to the latest Velox submodule to add support for searching archives from S3; Globally ignore `stringop-overflow` warnings to mitigate GCC bug which is triggered in 3rd-party code.

### DIFF
--- a/presto-native-execution/CMakeLists.txt
+++ b/presto-native-execution/CMakeLists.txt
@@ -38,19 +38,21 @@ set(DISABLED_WARNINGS
      -Wno-deprecated-declarations \
      -Wno-restrict")
 
-# Disable -Wstringop-overflow to avoid a false positive in the following compiler versions. See
-# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=117983
+# Disable -Wstringop-overflow to avoid a false positive in the following
+# compiler versions. See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=117983
 #
-# NOTE: Typically, this is disabled using a VELOX_SUPPRESS_STRINGOP guard within the code; but that
-# doesn't apply to 3rd-party libraries, so we need to disable it globally for now.
+# NOTE: Typically, this is disabled using a VELOX_SUPPRESS_STRINGOP guard within
+# the code; but that doesn't apply to 3rd-party libraries, so we need to disable
+# it globally for now.
 if("GNU" STREQUAL "${CMAKE_CXX_COMPILER_ID}"
-    AND ((CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 12
+   AND ((CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 12
          AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 12.5)
-         OR (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 13
-             AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 13.4)
-         OR (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 14
-             AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 14.3)))
-    set(DISABLED_WARNINGS "${DISABLED_WARNINGS} -Wno-stringop-overflow")
+        OR (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 13
+            AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 13.4)
+        OR (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 14
+            AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 14.3)
+       ))
+  set(DISABLED_WARNINGS "${DISABLED_WARNINGS} -Wno-stringop-overflow")
 endif()
 
 # Important warnings that must be explicitly enabled.

--- a/presto-native-execution/CMakeLists.txt
+++ b/presto-native-execution/CMakeLists.txt
@@ -29,6 +29,15 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 message("Appending CMAKE_CXX_FLAGS with ${SCRIPT_CXX_FLAGS}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SCRIPT_CXX_FLAGS}")
 
+# Known warnings that are benign can be disabled:
+#
+# * `restrict` since it triggers a bug in gcc 12. See
+#   https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105651
+set(DISABLED_WARNINGS
+    "-Wno-nullability-completeness \
+     -Wno-deprecated-declarations \
+     -Wno-restrict")
+
 # Disable -Wstringop-overflow to avoid a false positive in the following compiler versions. See
 # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=117983
 #
@@ -41,17 +50,8 @@ if("GNU" STREQUAL "${CMAKE_CXX_COMPILER_ID}"
              AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 13.4)
          OR (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 14
              AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 14.3)))
-    target_compile_options(log_surgeon PRIVATE "-Wno-stringop-overflow")
+    set(DISABLED_WARNINGS "${DISABLED_WARNINGS} -Wno-stringop-overflow")
 endif()
-
-# Known warnings that are benign can be disabled:
-#
-# * `restrict` since it triggers a bug in gcc 12. See
-#   https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105651
-set(DISABLED_WARNINGS
-    "-Wno-nullability-completeness \
-     -Wno-deprecated-declarations \
-     -Wno-restrict")
 
 # Important warnings that must be explicitly enabled.
 set(ENABLE_WARNINGS "-Wreorder")

--- a/presto-native-execution/CMakeLists.txt
+++ b/presto-native-execution/CMakeLists.txt
@@ -29,6 +29,21 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 message("Appending CMAKE_CXX_FLAGS with ${SCRIPT_CXX_FLAGS}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SCRIPT_CXX_FLAGS}")
 
+# Disable -Wstringop-overflow to avoid a false positive in the following compiler versions. See
+# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=117983
+#
+# NOTE: Typically, this is disabled using a VELOX_SUPPRESS_STRINGOP guard within the code; but that
+# doesn't apply to 3rd-party libraries, so we need to disable it globally for now.
+if("GNU" STREQUAL "${CMAKE_CXX_COMPILER_ID}"
+    AND ((CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 12
+         AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 12.5)
+         OR (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 13
+             AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 13.4)
+         OR (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 14
+             AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 14.3)))
+    target_compile_options(log_surgeon PRIVATE "-Wno-stringop-overflow")
+endif()
+
 # Known warnings that are benign can be disabled:
 #
 # * `restrict` since it triggers a bug in gcc 12. See


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR is to update the Velox submodule to sync the merged PR https://github.com/y-scope/velox/pull/21

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

Passed the CI.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Updated the underlying execution-engine submodule to a newer upstream revision to keep dependencies current.
  - Added a targeted build adjustment to suppress a specific GCC compiler warning for affected toolchain versions to reduce build noise.

- Impact
  - No user-facing changes; features, performance and behaviour remain unchanged.
  - Routine maintenance to preserve compatibility and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->