### PR TITLE
chore: Add `ca-certificates` to the worker's runtime image to support reading signed S3 URLs in the CLP connector (fixes #56).

### DIFF
--- a/presto-native-execution/scripts/dockerfiles/prestissimo-runtime.dockerfile
+++ b/presto-native-execution/scripts/dockerfiles/prestissimo-runtime.dockerfile
@@ -41,7 +41,7 @@ ENV BUILD_DIR=""
 
 # NOTE:
 # - We need `ca-certificates` to support reads from signed S3 URLs.
-# - We need `tzdata` as a workaround temporary for https://github.com/prestodb/presto/issues/25531
+# - We need `tzdata` as a temporary workaround for https://github.com/prestodb/presto/issues/25531
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     ca-certificates \

--- a/presto-native-execution/scripts/dockerfiles/prestissimo-runtime.dockerfile
+++ b/presto-native-execution/scripts/dockerfiles/prestissimo-runtime.dockerfile
@@ -46,6 +46,12 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+# CLP S3 support currently needs ca-certificates package to access the presigned URL
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
 COPY --chmod=0775 --from=prestissimo-image /prestissimo/${BUILD_BASE_DIR}/${BUILD_DIR}/presto_cpp/main/presto_server /usr/bin/
 COPY --chmod=0775 --from=prestissimo-image /runtime-libraries/* /usr/lib64/prestissimo-libs/
 COPY --chmod=0755 ./etc /opt/presto-server/etc

--- a/presto-native-execution/scripts/dockerfiles/prestissimo-runtime.dockerfile
+++ b/presto-native-execution/scripts/dockerfiles/prestissimo-runtime.dockerfile
@@ -39,18 +39,15 @@ FROM ${BASE_IMAGE}
 ENV BUILD_BASE_DIR=_build
 ENV BUILD_DIR=""
 
-# Temporary fix for https://github.com/prestodb/presto/issues/25531
-# TODO: Update this code when there's a proper fix
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
-# CLP S3 support currently needs ca-certificates package to access the presigned URL
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+# NOTE:
+# - We need `ca-certificates` to support reads from signed S3 URLs.
+# - We need `tzdata` as a workaround temporary for https://github.com/prestodb/presto/issues/25531
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    ca-certificates \
+    tzdata \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY --chmod=0775 --from=prestissimo-image /prestissimo/${BUILD_BASE_DIR}/${BUILD_DIR}/presto_cpp/main/presto_server /usr/bin/
 COPY --chmod=0775 --from=prestissimo-image /runtime-libraries/* /usr/lib64/prestissimo-libs/


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

CLP S3 support needs this to access the presign URL.

Change the source image in CLP's `tools/deployment/presto-clp/docker-compose.yml` from `y-scope` to `anlowee` and it works.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

Download the image and E2E test w/ and w/o S3 CLP package.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Restored reliable access to HTTPS resources (including presigned S3 URLs) by bundling system CA certificates in the runtime image, preventing TLS verification failures.

- **Chores**
  - Streamlined runtime image setup with non-interactive package installation (including timezone data) and cleanup to keep the image lean and predictable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->