### PR TITLE
refactor: Replace `ClpMetadataDbSetUp` with `ClpMockMetadataDatabase` in `TestClpMetadata` and `TestClpSplit` to improve code maintainability.

### DIFF
--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/TestClpSplit.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/TestClpSplit.java
@@ -13,75 +13,88 @@
  */
 package com.facebook.presto.plugin.clp;
 
+import com.facebook.presto.plugin.clp.mockdb.ClpMockMetadataDatabase;
+import com.facebook.presto.plugin.clp.mockdb.table.ArchivesTableRows;
+import com.facebook.presto.plugin.clp.split.ClpMySqlSplitProvider;
 import com.facebook.presto.plugin.clp.split.ClpSplitProvider;
 import com.facebook.presto.spi.SchemaTableName;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 import static com.facebook.presto.plugin.clp.ClpMetadata.DEFAULT_SCHEMA_NAME;
 import static com.facebook.presto.plugin.clp.ClpMetadataDbSetUp.ARCHIVES_STORAGE_DIRECTORY_BASE;
-import static com.facebook.presto.plugin.clp.ClpMetadataDbSetUp.ArchivesTableRow;
-import static com.facebook.presto.plugin.clp.ClpMetadataDbSetUp.DbHandle;
-import static com.facebook.presto.plugin.clp.ClpMetadataDbSetUp.getDbHandle;
-import static com.facebook.presto.plugin.clp.ClpMetadataDbSetUp.setupSplit;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static java.lang.String.format;
 import static org.testng.Assert.assertEquals;
 
 @Test(singleThreaded = true)
 public class TestClpSplit
 {
-    private DbHandle dbHandle;
+    private ClpMockMetadataDatabase mockMetadataDatabase;
     private ClpSplitProvider clpSplitProvider;
-    private Map<String, List<ArchivesTableRow>> tableSplits;
+    private Map<String, ArchivesTableRows> tableSplits;
 
     @BeforeMethod
     public void setUp()
     {
-        dbHandle = getDbHandle("split_testdb");
-        tableSplits = new HashMap<>();
+        mockMetadataDatabase = ClpMockMetadataDatabase
+                .builder()
+                .build();
+        ImmutableList.Builder<String> tableNamesBuilder = ImmutableList.builder();
+        ImmutableMap.Builder<String, ArchivesTableRows> splitsMapBuilder = ImmutableMap.builder();
 
-        int numKeys = 3;
-        int numValuesPerKey = 10;
+        int numTables = 3;
+        int numSplitsPerTable = 10;
 
-        for (int i = 0; i < numKeys; i++) {
-            String key = "test_" + i;
-            List<ArchivesTableRow> values = new ArrayList<>();
+        for (int i = 0; i < numTables; i++) {
+            String tableName = "test_" + i;
+            tableNamesBuilder.add(tableName);
 
-            for (int j = 0; j < numValuesPerKey; j++) {
+            ImmutableList.Builder<String> idsBuilder = ImmutableList.builder();
+            ImmutableList.Builder<Long> beginTimestampsBuilder = ImmutableList.builder();
+            ImmutableList.Builder<Long> endTimestampsBuilder = ImmutableList.builder();
+            for (int j = 0; j < numSplitsPerTable; j++) {
                 // We generate synthetic begin_timestamp and end_timestamp values for each split
                 // by offsetting two base timestamps (1700000000000L and 1705000000000L) with a
                 // fixed increment per split (10^10 * j).
-                values.add(new ArchivesTableRow(
-                        "id_" + j,
-                        1700000000000L + 10000000000L * j,
-                        1705000000000L + 10000000000L * j));
+                idsBuilder.add(format("id_%s", j));
+                beginTimestampsBuilder.add(1700000000000L + 10000000000L * j);
+                endTimestampsBuilder.add(1705000000000L + 10000000000L * j);
             }
-
-            tableSplits.put(key, values);
+            splitsMapBuilder.put(tableName, new ArchivesTableRows(idsBuilder.build(), beginTimestampsBuilder.build(), endTimestampsBuilder.build()));
         }
-        clpSplitProvider = setupSplit(dbHandle, tableSplits);
+
+        mockMetadataDatabase.addTableToDatasetsTableIfNotExist(tableNamesBuilder.build());
+        tableSplits = splitsMapBuilder.build();
+        mockMetadataDatabase.addSplits(tableSplits);
+        ClpConfig config = new ClpConfig()
+                .setPolymorphicTypeEnabled(true)
+                .setMetadataDbUrl(mockMetadataDatabase.getUrl())
+                .setMetadataDbUser(mockMetadataDatabase.getUsername())
+                .setMetadataDbPassword(mockMetadataDatabase.getPassword())
+                .setMetadataTablePrefix(mockMetadataDatabase.getTablePrefix());
+        clpSplitProvider = new ClpMySqlSplitProvider(config);
     }
 
     @AfterMethod
     public void tearDown()
     {
-        ClpMetadataDbSetUp.tearDown(dbHandle);
+        if (null != mockMetadataDatabase) {
+            mockMetadataDatabase.teardown();
+        }
     }
 
     @Test
     public void testListSplits()
     {
-        for (Map.Entry<String, List<ArchivesTableRow>> entry : tableSplits.entrySet()) {
+        for (Map.Entry<String, ArchivesTableRows> entry : tableSplits.entrySet()) {
             // Without metadata filters
             compareListSplitsResult(entry, Optional.empty(), ImmutableList.of(0, 1, 2, 3, 4, 5, 6, 7, 8, 9));
 
@@ -118,9 +131,9 @@ public class TestClpSplit
     }
 
     private void compareListSplitsResult(
-            Map.Entry<String, List<ArchivesTableRow>> entry,
+            Map.Entry<String, ArchivesTableRows> entry,
             Optional<String> metadataSql,
-            List<Integer> expectedSplitIds)
+            List<Integer> expectedSplitIndexes)
     {
         String tableName = entry.getKey();
         String tablePath = ARCHIVES_STORAGE_DIRECTORY_BASE + tableName;
@@ -128,19 +141,15 @@ public class TestClpSplit
                 new ClpTableHandle(new SchemaTableName(DEFAULT_SCHEMA_NAME, tableName), tablePath),
                 Optional.empty(),
                 metadataSql);
-        List<ArchivesTableRow> expectedSplits = expectedSplitIds.stream()
-                .map(expectedSplitId -> entry.getValue().get(expectedSplitId))
+        List<String> expectedSplitPaths = expectedSplitIndexes.stream()
+                .map(expectedSplitIndex -> format("%s/%s", tablePath, entry.getValue().getIds().get(expectedSplitIndex)))
                 .collect(toImmutableList());
         List<ClpSplit> actualSplits = clpSplitProvider.listSplits(layoutHandle);
-        assertEquals(actualSplits.size(), expectedSplits.size());
+        assertEquals(actualSplits.size(), expectedSplitPaths.size());
 
-        ImmutableSet<String> actualSplitPaths = actualSplits.stream()
+        ImmutableList<String> actualSplitPaths = actualSplits.stream()
                 .map(ClpSplit::getPath)
-                .collect(toImmutableSet());
-
-        ImmutableSet<String> expectedSplitPaths = expectedSplits.stream()
-                .map(split -> tablePath + "/" + split.getId())
-                .collect(toImmutableSet());
+                .collect(toImmutableList());
 
         assertEquals(actualSplitPaths, expectedSplitPaths);
     }

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/TestClpSplit.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/TestClpSplit.java
@@ -54,7 +54,7 @@ public class TestClpSplit
         int numSplitsPerTable = 10;
 
         for (int i = 0; i < numTables; i++) {
-            String tableName = "test_" + i;
+            String tableName = "test_split_" + i;
             tableNamesBuilder.add(tableName);
 
             ImmutableList.Builder<String> idsBuilder = ImmutableList.builder();

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/mockdb/ClpMockMetadataDatabase.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/mockdb/ClpMockMetadataDatabase.java
@@ -217,6 +217,7 @@ public class ClpMockMetadataDatabase
         private Builder()
         {
             setDatabaseUrl(format("/tmp/%s", UUID.randomUUID()));
+            setArchiveStorageDirectory("");
             setUsername(MOCK_METADATA_DB_DEFAULT_USERNAME);
             setPassword(MOCK_METADATA_DB_DEFAULT_PASSWORD);
             setTablePrefix(MOCK_METADATA_DB_DEFAULT_TABLE_PREFIX);

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/mockdb/table/ArchivesTableRows.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/mockdb/table/ArchivesTableRows.java
@@ -69,4 +69,19 @@ public class ArchivesTableRows
         this.endTimestamps = endTimestamps;
         this.numberOfRows = ids.size();
     }
+
+    public List<String> getIds()
+    {
+        return ids;
+    }
+
+    public List<Long> getBeginTimestamps()
+    {
+        return beginTimestamps;
+    }
+
+    public List<Long> getEndTimestamps()
+    {
+        return endTimestamps;
+    }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR refactored`TestClpMetadata` and `TestClpSplit` to use `ClpMockMetadataDatabase` instead of `ClpMetadataDbSetUp` to improve the code maintainability.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

Passed the CI.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Migrated metadata and split tests to a mock database for faster, more reliable runs.
  - Expanded coverage for listing tables and splits, including multiple filter scenarios.
  - Improved determinism and cleanup to reduce flakiness.

- Bug Fixes
  - Added a safe default for archive storage directory in test infrastructure to prevent null-related failures.

- Refactor
  - Streamlined test data modelling and expectations for clearer assertions.
  - Exposed helper accessors to simplify test setup and comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->