### PR TITLE
feat: Add `CLP_WILDCARD_*` functions.

### DIFF
--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpFunctions.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpFunctions.java
@@ -19,7 +19,6 @@ import com.facebook.presto.spi.function.Description;
 import com.facebook.presto.spi.function.ScalarFunction;
 import com.facebook.presto.spi.function.SqlType;
 import io.airlift.slice.Slice;
-import io.airlift.slice.Slices;
 
 public final class ClpFunctions
 {
@@ -72,7 +71,7 @@ public final class ClpFunctions
     @SqlType(StandardTypes.VARCHAR)
     public static Slice clpWildcardStringColumn()
     {
-        return Slices.EMPTY_SLICE;
+        throw new UnsupportedOperationException("CLP_WILDCARD_STRING_COLUMN is a placeholder function without implementation.");
     }
 
     @ScalarFunction(value = "CLP_WILDCARD_INT_COLUMN", deterministic = false)
@@ -80,7 +79,7 @@ public final class ClpFunctions
     @SqlType(StandardTypes.BIGINT)
     public static long clpWildcardIntColumn()
     {
-        return 0;
+        throw new UnsupportedOperationException("CLP_WILDCARD_INT_COLUMN is a placeholder function without implementation.");
     }
 
     @ScalarFunction(value = "CLP_WILDCARD_FLOAT_COLUMN", deterministic = false)
@@ -88,7 +87,7 @@ public final class ClpFunctions
     @SqlType(StandardTypes.DOUBLE)
     public static double clpWildcardFloatColumn()
     {
-        return 0.0;
+        throw new UnsupportedOperationException("CLP_WILDCARD_FLOAT_COLUMN is a placeholder function without implementation.");
     }
 
     @ScalarFunction(value = "CLP_WILDCARD_BOOL_COLUMN", deterministic = false)
@@ -96,6 +95,6 @@ public final class ClpFunctions
     @SqlType(StandardTypes.BOOLEAN)
     public static boolean clpWildcardBoolColumn()
     {
-        return false;
+        throw new UnsupportedOperationException("CLP_WILDCARD_BOOL_COLUMN is a placeholder function without implementation.");
     }
 }

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpFunctions.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpFunctions.java
@@ -19,6 +19,7 @@ import com.facebook.presto.spi.function.Description;
 import com.facebook.presto.spi.function.ScalarFunction;
 import com.facebook.presto.spi.function.SqlType;
 import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
 
 public final class ClpFunctions
 {
@@ -64,5 +65,37 @@ public final class ClpFunctions
     public static Block clpGetStringArray(@SqlType(StandardTypes.VARCHAR) Slice jsonPath)
     {
         throw new UnsupportedOperationException("CLP_GET_STRING_ARRAY is a placeholder function without implementation.");
+    }
+
+    @ScalarFunction(value = "CLP_WILDCARD_STRING_COLUMN", deterministic = false)
+    @Description("Used in filter expressions to allow comparisons with any string column in the log record.")
+    @SqlType(StandardTypes.VARCHAR)
+    public static Slice clpWildcardStringColumn()
+    {
+        return Slices.EMPTY_SLICE;
+    }
+
+    @ScalarFunction(value = "CLP_WILDCARD_INT_COLUMN", deterministic = false)
+    @Description("Used in filter expressions to allow comparisons with any integer column in the log record.")
+    @SqlType(StandardTypes.BIGINT)
+    public static long clpWildcardIntColumn()
+    {
+        return 0;
+    }
+
+    @ScalarFunction(value = "CLP_WILDCARD_FLOAT_COLUMN", deterministic = false)
+    @Description("Used in filter expressions to allow comparisons with any floating point column in the log record.")
+    @SqlType(StandardTypes.DOUBLE)
+    public static double clpWildcardFloatColumn()
+    {
+        return 0.0;
+    }
+
+    @ScalarFunction(value = "CLP_WILDCARD_BOOL_COLUMN", deterministic = false)
+    @Description("Used in filter expressions to allow comparisons with any boolean column in the log record.")
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean clpWildcardBoolColumn()
+    {
+        return false;
     }
 }

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpFilterToKqlConverter.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpFilterToKqlConverter.java
@@ -371,6 +371,16 @@ public class ClpFilterToKqlConverter
             return maybeRightSubstring.get();
         }
 
+        Optional<ClpExpression> clpWildcardLeft = tryInterpretClpWildcard(left, right, operator, node);
+        if (clpWildcardLeft.isPresent()) {
+            return clpWildcardLeft.get();
+        }
+
+        Optional<ClpExpression> clpWildcardRight = tryInterpretClpWildcard(right, left, operator, node);
+        if (clpWildcardRight.isPresent()) {
+            return clpWildcardRight.get();
+        }
+
         ClpExpression leftExpression = left.accept(this, null);
         ClpExpression rightExpression = right.accept(this, null);
         Optional<String> leftPushDownExpression = leftExpression.getPushDownExpression();
@@ -404,6 +414,59 @@ public class ClpFilterToKqlConverter
         }
         // fallback
         return new ClpExpression(node);
+    }
+
+    /**
+     * Attempts to interpret a <code>CLP_WILDCARD_*</code> function call in a logical binary
+     * expression.
+     * <p></p>
+     * This method checks if the <code>possibleCall</code> is a CLP_WILDCARD function and the
+     * <code>possibleConst</code> is a constant expression. If so, it builds a corresponding
+     * {@link ClpExpression}. Otherwise, returns {@link Optional#empty()}.
+     * <p></p>
+     * Example: <code>CLP_WILDCARD_STRING_COLUMN() = 'abc'</code>
+     *
+     * @param possibleCall  the operand that may be a <code>CLP_WILDCARD_*</code> function call
+     * @param possibleConst the opposite operand which must be a literal/constant at planning time
+     * @param operator      the comparison operator from the parent binary expression
+     * @param parentNode    the enclosing call (binary comparison) node
+     * @return an Optional with the built {@link ClpExpression} if recognized; otherwise empty
+     */
+    private Optional<ClpExpression> tryInterpretClpWildcard(
+            RowExpression possibleCall,
+            RowExpression possibleConst,
+            OperatorType operator,
+            CallExpression parentNode)
+    {
+        if (!(possibleCall instanceof CallExpression)) {
+            return Optional.empty();
+        }
+
+        FunctionMetadata metadata = functionMetadataManager.getFunctionMetadata(
+                ((CallExpression) possibleCall).getFunctionHandle());
+        String functionName = metadata.getName().getObjectName().toUpperCase();
+
+        if (!functionName.startsWith("CLP_WILDCARD")) {
+            return Optional.empty();
+        }
+
+        if (!(possibleConst instanceof ConstantExpression)) {
+            throw new PrestoException(CLP_PUSHDOWN_UNSUPPORTED_EXPRESSION,
+                    "CLP_WILDCARD_COLUMN can only be used in a filter against a constant value");
+        }
+
+        ClpExpression constExpression = possibleConst.accept(this, null);
+        if (!constExpression.getPushDownExpression().isPresent()) {
+            throw new PrestoException(CLP_PUSHDOWN_UNSUPPORTED_EXPRESSION,
+                    possibleConst + " is not supported in CLP_WILDCARD UDFs");
+        }
+
+        return Optional.of(buildClpExpression(
+                "*",
+                constExpression.getPushDownExpression().get(),
+                operator,
+                possibleCall.getType(),
+                parentNode));
     }
 
     /**

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpFilterToKqlConverter.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpFilterToKqlConverter.java
@@ -446,26 +446,39 @@ public class ClpFilterToKqlConverter
                 ((CallExpression) possibleCall).getFunctionHandle());
         String functionName = metadata.getName().getObjectName().toUpperCase();
 
-        if (!functionName.startsWith("CLP_WILDCARD")) {
+        if (!functionName.startsWith("CLP_WILDCARD_")) {
             return Optional.empty();
         }
 
-        if (!(possibleConst instanceof ConstantExpression)) {
-            throw new PrestoException(CLP_PUSHDOWN_UNSUPPORTED_EXPRESSION,
-                    "CLP_WILDCARD_COLUMN can only be used in a filter against a constant value");
+        String literalString;
+        Type literalType;
+        if (possibleConst instanceof ConstantExpression) {
+            literalString = getLiteralString((ConstantExpression) possibleConst);
+            literalType = possibleConst.getType();
         }
-
-        ClpExpression constExpression = possibleConst.accept(this, null);
-        if (!constExpression.getPushDownExpression().isPresent()) {
+        else if (possibleConst instanceof CallExpression) {
+            CallExpression call = (CallExpression) possibleConst;
+            if (standardFunctionResolution.isCastFunction(call.getFunctionHandle())
+                    && call.getArguments().size() == 1
+                    && call.getArguments().get(0) instanceof ConstantExpression) {
+                literalString = getLiteralString((ConstantExpression) call.getArguments().get(0));
+                literalType = possibleConst.getType(); // post-cast type
+            }
+            else {
+                throw new PrestoException(CLP_PUSHDOWN_UNSUPPORTED_EXPRESSION,
+                        "CLP_WILDCARD_* functions can only be used in a filter against a constant value");
+            }
+        }
+        else {
             throw new PrestoException(CLP_PUSHDOWN_UNSUPPORTED_EXPRESSION,
-                    possibleConst + " is not supported in CLP_WILDCARD UDFs");
+                    "CLP_WILDCARD_* functions can only be used in a filter against a constant value");
         }
 
         return Optional.of(buildClpExpression(
                 "*",
-                constExpression.getPushDownExpression().get(),
+                literalString,
                 operator,
-                possibleCall.getType(),
+                literalType,
                 parentNode));
     }
 

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpFilterToKqlConverter.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpFilterToKqlConverter.java
@@ -238,23 +238,23 @@ public class ClpFilterToKqlConverter
             throw new PrestoException(CLP_PUSHDOWN_UNSUPPORTED_EXPRESSION,
                     "BETWEEN operator must have exactly three arguments. Received: " + node);
         }
+
         RowExpression first = arguments.get(0);
         RowExpression second = arguments.get(1);
         RowExpression third = arguments.get(2);
-        if (!(first instanceof VariableReferenceExpression)
-                || !(second instanceof ConstantExpression)
-                || !(third instanceof ConstantExpression)) {
-            return new ClpExpression(node);
-        }
         if (!isClpCompatibleNumericType(first.getType())
                 || !isClpCompatibleNumericType(second.getType())
                 || !isClpCompatibleNumericType(third.getType())) {
             return new ClpExpression(node);
         }
+
         Optional<String> variableOpt = first.accept(this, null).getPushDownExpression();
-        if (!variableOpt.isPresent()) {
+        if (!variableOpt.isPresent()
+                || !(second instanceof ConstantExpression)
+                || !(third instanceof ConstantExpression)) {
             return new ClpExpression(node);
         }
+
         String variable = variableOpt.get();
         String lowerBound = getLiteralString((ConstantExpression) second);
         String upperBound = getLiteralString((ConstantExpression) third);

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpFilterToKqlConverter.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpFilterToKqlConverter.java
@@ -376,7 +376,7 @@ public class ClpFilterToKqlConverter
             return clpWildcardLeft.get();
         }
 
-        Optional<ClpExpression> clpWildcardRight = tryInterpretClpWildcard(right, left, operator, node);
+        Optional<ClpExpression> clpWildcardRight = tryInterpretClpWildcard(right, left, flip(operator), node);
         if (clpWildcardRight.isPresent()) {
             return clpWildcardRight.get();
         }

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpFilterToKqlConverter.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpFilterToKqlConverter.java
@@ -144,6 +144,11 @@ public class ClpFilterToKqlConverter
             }
         }
 
+        String functionName = functionMetadata.getName().getObjectName().toUpperCase();
+        if (functionName.startsWith("CLP_WILDCARD_")) {
+            return new ClpExpression("*");
+        }
+
         return new ClpExpression(node);
     }
 
@@ -371,16 +376,6 @@ public class ClpFilterToKqlConverter
             return maybeRightSubstring.get();
         }
 
-        Optional<ClpExpression> clpWildcardLeft = tryInterpretClpWildcard(left, right, operator, node);
-        if (clpWildcardLeft.isPresent()) {
-            return clpWildcardLeft.get();
-        }
-
-        Optional<ClpExpression> clpWildcardRight = tryInterpretClpWildcard(right, left, flip(operator), node);
-        if (clpWildcardRight.isPresent()) {
-            return clpWildcardRight.get();
-        }
-
         ClpExpression leftExpression = left.accept(this, null);
         ClpExpression rightExpression = right.accept(this, null);
         Optional<String> leftPushDownExpression = leftExpression.getPushDownExpression();
@@ -414,72 +409,6 @@ public class ClpFilterToKqlConverter
         }
         // fallback
         return new ClpExpression(node);
-    }
-
-    /**
-     * Attempts to interpret a <code>CLP_WILDCARD_*</code> function call in a logical binary
-     * expression.
-     * <p></p>
-     * This method checks if the <code>possibleCall</code> is a CLP_WILDCARD function and the
-     * <code>possibleConst</code> is a constant expression. If so, it builds a corresponding
-     * {@link ClpExpression}. Otherwise, returns {@link Optional#empty()}.
-     * <p></p>
-     * Example: <code>CLP_WILDCARD_STRING_COLUMN() = 'abc'</code>
-     *
-     * @param possibleCall  the operand that may be a <code>CLP_WILDCARD_*</code> function call
-     * @param possibleConst the opposite operand which must be a literal/constant at planning time
-     * @param operator      the comparison operator from the parent binary expression
-     * @param parentNode    the enclosing call (binary comparison) node
-     * @return an Optional with the built {@link ClpExpression} if recognized; otherwise empty
-     */
-    private Optional<ClpExpression> tryInterpretClpWildcard(
-            RowExpression possibleCall,
-            RowExpression possibleConst,
-            OperatorType operator,
-            CallExpression parentNode)
-    {
-        if (!(possibleCall instanceof CallExpression)) {
-            return Optional.empty();
-        }
-
-        FunctionMetadata metadata = functionMetadataManager.getFunctionMetadata(
-                ((CallExpression) possibleCall).getFunctionHandle());
-        String functionName = metadata.getName().getObjectName().toUpperCase();
-
-        if (!functionName.startsWith("CLP_WILDCARD_")) {
-            return Optional.empty();
-        }
-
-        String literalString;
-        Type literalType;
-        if (possibleConst instanceof ConstantExpression) {
-            literalString = getLiteralString((ConstantExpression) possibleConst);
-            literalType = possibleConst.getType();
-        }
-        else if (possibleConst instanceof CallExpression) {
-            CallExpression call = (CallExpression) possibleConst;
-            if (standardFunctionResolution.isCastFunction(call.getFunctionHandle())
-                    && call.getArguments().size() == 1
-                    && call.getArguments().get(0) instanceof ConstantExpression) {
-                literalString = getLiteralString((ConstantExpression) call.getArguments().get(0));
-                literalType = possibleConst.getType(); // post-cast type
-            }
-            else {
-                throw new PrestoException(CLP_PUSHDOWN_UNSUPPORTED_EXPRESSION,
-                        "CLP_WILDCARD_* functions can only be used in a filter against a constant value");
-            }
-        }
-        else {
-            throw new PrestoException(CLP_PUSHDOWN_UNSUPPORTED_EXPRESSION,
-                    "CLP_WILDCARD_* functions can only be used in a filter against a constant value");
-        }
-
-        return Optional.of(buildClpExpression(
-                "*",
-                literalString,
-                operator,
-                literalType,
-                parentNode));
     }
 
     /**

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/TestClpFilterToKql.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/TestClpFilterToKql.java
@@ -286,6 +286,16 @@ public class TestClpFilterToKql
                 "CLP_WILDCARD_STRING_COLUMN() = 'Beijing' AND CLP_WILDCARD_INT_COLUMN() = 1 AND city.Region.Id = 1",
                 "((*: \"Beijing\" AND *: 1) AND city.Region.Id: 1)",
                 null);
+        testPushDown(
+                sessionHolder,
+                "CLP_WILDCARD_STRING_COLUMN() = 'Toronto' OR CLP_WILDCARD_INT_COLUMN() = 2",
+                "(*: \"Toronto\" OR *: 2)",
+                null);
+        testPushDown(
+                sessionHolder,
+                "CLP_WILDCARD_STRING_COLUMN() = 'Shanghai' AND (CLP_WILDCARD_INT_COLUMN() = 3 OR city.Region.Id = 5)",
+                "(*: \"Shanghai\" AND (*: 3 OR city.Region.Id: 5))",
+                null);
     }
 
     private void testPushDown(SessionHolder sessionHolder, String sql, String expectedKql, String expectedRemaining)

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/TestClpFilterToKql.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/TestClpFilterToKql.java
@@ -271,6 +271,23 @@ public class TestClpFilterToKql
                 testMetadataFilterColumns);
     }
 
+    @Test
+    public void testClpWildcardUdf()
+    {
+        SessionHolder sessionHolder = new SessionHolder();
+
+        testPushDown(sessionHolder, "CLP_WILDCARD_STRING_COLUMN() = 'Beijing'", "*: \"Beijing\"", null);
+        testPushDown(sessionHolder, "CLP_WILDCARD_INT_COLUMN() = 1", "*: 1", null);
+        testPushDown(sessionHolder, "CLP_WILDCARD_FLOAT_COLUMN() > 0", "* > 0", null);
+        testPushDown(sessionHolder, "CLP_WILDCARD_BOOL_COLUMN() = true", "*: true", null);
+
+        testPushDown(
+                sessionHolder,
+                "CLP_WILDCARD_STRING_COLUMN() = 'Beijing' AND CLP_WILDCARD_INT_COLUMN() = 1 AND city.Region.Id = 1",
+                "((*: \"Beijing\" AND *: 1) AND city.Region.Id: 1)",
+                null);
+    }
+
     private void testPushDown(SessionHolder sessionHolder, String sql, String expectedKql, String expectedRemaining)
     {
         ClpExpression clpExpression = tryPushDown(sql, sessionHolder, ImmutableSet.of());

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/TestClpFilterToKql.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/TestClpFilterToKql.java
@@ -281,6 +281,12 @@ public class TestClpFilterToKql
         testPushDown(sessionHolder, "CLP_WILDCARD_FLOAT_COLUMN() > 0", "* > 0", null);
         testPushDown(sessionHolder, "CLP_WILDCARD_BOOL_COLUMN() = true", "*: true", null);
 
+        testPushDown(sessionHolder, "CLP_WILDCARD_STRING_COLUMN() like 'hello%'", "*: \"hello*\"", null);
+        testPushDown(sessionHolder, "substr(CLP_WILDCARD_STRING_COLUMN(), 1, 2) = 'he'", "*: \"he*\"", null);
+        testPushDown(sessionHolder, "CLP_WILDCARD_INT_COLUMN() BETWEEN 0 AND 5", "* >= 0 AND * <= 5", null);
+        testPushDown(sessionHolder, "CLP_WILDCARD_STRING_COLUMN() IN ('hello world', 'hello world 2')", "(*: \"hello world\" OR *: \"hello world 2\")", null);
+
+        testPushDown(sessionHolder, "NOT CLP_WILDCARD_FLOAT_COLUMN() > 0", "NOT * > 0", null);
         testPushDown(
                 sessionHolder,
                 "CLP_WILDCARD_STRING_COLUMN() = 'Beijing' AND CLP_WILDCARD_INT_COLUMN() = 1 AND city.Region.Id = 1",


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
This PR introduces new `CLP_WILDCARD_*` functions for the CLP connector to compare values against any CLP columns for a specific type in the where clause.

The PR doesn't update the documentation and will leave it for a future PR.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

+ Unit tests have been passed
+ Verified via end-to-end testing using the queries below, covering a variety of patterns:
```sql
select * from default where clp_wildcard_string_column() in ('profile_update', 'logout');
select * from default where clp_wildcard_string_column() like 'profile_update%';
select * from default where clp_wildcard_string_column() like '%profile_update';
select * from default where clp_wildcard_string_column() like '%profile_update%';
select * from default where clp_wildcard_string_column() = 'profile_update';
select * from default where clp_wildcard_int_column() > 0;
```

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added placeholder wildcard predicates for string, integer, float and boolean columns to enable wildcard comparisons in filter expressions.
  * Filter translation now recognises these wildcard predicates and emits wildcard clauses for push-down, affecting how filters are translated for query push-down.

* **Tests**
  * Added unit tests validating wildcard predicate push-down across types and within combined expressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->