### PR TITLE
feat: Upgrade velox submodule to y-scope/velox@7ae5119.

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeClpGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeClpGeneralQueries.java
@@ -126,6 +126,51 @@ public class TestPrestoNativeClpGeneralQueries
                         "    ARRAY[ARRAY[NULL]]" +
                         "  ]," +
                         "  NULL");
+        assertQuery(
+                format("SELECT" +
+                        " msg," +
+                        " format_datetime(t.dollar_sign_date, 'yyyy-MM-dd HH:mm:ss.SSS')," +
+                        " id," +
+                        " attr," +
+                        " tags" +
+                        " FROM %s" +
+                        " WHERE t.dollar_sign_date > from_unixtime(1679441694.576)" +
+                        " ORDER BY id" +
+                        " LIMIT 1", DEFAULT_TABLE_NAME),
+                "SELECT" +
+                        "  'There were no users to pin, not starting tracker thread'," +
+                        "  TIMESTAMP '2023-03-22 12:34:55.821'," +
+                        "  20227," +
+                        "  ARRAY[" +
+                        "    NULL," +
+                        "    ARRAY[ARRAY[ARRAY[ARRAY[ARRAY[NULL]]]]]," +
+                        "    NULL," +
+                        "    ARRAY[ARRAY[NULL]]" +
+                        "  ]," +
+                        "  NULL");
+        assertQuery(
+                format("SELECT" +
+                        " msg," +
+                        " format_datetime(t.dollar_sign_date, 'yyyy-MM-dd HH:mm:ss.SSS')," +
+                        " id," +
+                        " attr," +
+                        " tags" +
+                        " FROM %s" +
+                        " WHERE t.dollar_sign_date > from_unixtime(1679441694.576)" +
+                        " AND msg like '%%user%%'" +
+                        " ORDER BY id" +
+                        " LIMIT 1", DEFAULT_TABLE_NAME),
+                "SELECT" +
+                        "  'There were no users to pin, not starting tracker thread'," +
+                        "  TIMESTAMP '2023-03-22 12:34:55.821'," +
+                        "  20227," +
+                        "  ARRAY[" +
+                        "    NULL," +
+                        "    ARRAY[ARRAY[ARRAY[ARRAY[ARRAY[NULL]]]]]," +
+                        "    NULL," +
+                        "    ARRAY[ARRAY[NULL]]" +
+                        "  ]," +
+                        "  NULL");
     }
 
     @AfterTest

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeClpGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeClpGeneralQueries.java
@@ -108,7 +108,7 @@ public class TestPrestoNativeClpGeneralQueries
         assertQuery(
                 format("SELECT" +
                         " msg," +
-                        " format_datetime(t.dollar_sign_date, 'yyyy-MM-dd HH:mm:ss.SSS')," +
+                        " FORMAT_DATETIME(t.dollar_sign_date, 'yyyy-MM-dd HH:mm:ss.SSS')," +
                         " id," +
                         " attr," +
                         " tags" +
@@ -129,12 +129,12 @@ public class TestPrestoNativeClpGeneralQueries
         assertQuery(
                 format("SELECT" +
                         " msg," +
-                        " format_datetime(t.dollar_sign_date, 'yyyy-MM-dd HH:mm:ss.SSS')," +
+                        " FORMAT_DATETIME(t.dollar_sign_date, 'yyyy-MM-dd HH:mm:ss.SSS')," +
                         " id," +
                         " attr," +
                         " tags" +
                         " FROM %s" +
-                        " WHERE t.dollar_sign_date > from_unixtime(1679441694.576)" +
+                        " WHERE t.dollar_sign_date > FROM_UNIXTIME(1679441694.576)" +
                         " ORDER BY id" +
                         " LIMIT 1", DEFAULT_TABLE_NAME),
                 "SELECT" +
@@ -151,13 +151,13 @@ public class TestPrestoNativeClpGeneralQueries
         assertQuery(
                 format("SELECT" +
                         " msg," +
-                        " format_datetime(t.dollar_sign_date, 'yyyy-MM-dd HH:mm:ss.SSS')," +
+                        " FORMAT_DATETIME(t.dollar_sign_date, 'yyyy-MM-dd HH:mm:ss.SSS')," +
                         " id," +
                         " attr," +
                         " tags" +
                         " FROM %s" +
-                        " WHERE t.dollar_sign_date > from_unixtime(1679441694.576)" +
-                        " AND msg like '%%user%%'" +
+                        " WHERE t.dollar_sign_date > FROM_UNIXTIME(1679441694.576)" +
+                        " AND msg LIKE '%%user%%'" +
                         " ORDER BY id" +
                         " LIMIT 1", DEFAULT_TABLE_NAME),
                 "SELECT" +

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeClpGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeClpGeneralQueries.java
@@ -108,7 +108,7 @@ public class TestPrestoNativeClpGeneralQueries
         assertQuery(
                 format("SELECT" +
                         " msg," +
-                        " FORMAT_DATETIME(t.dollar_sign_date, 'yyyy-MM-dd HH:mm:ss.SSS')," +
+                        " format_datetime(t.dollar_sign_date, 'yyyy-MM-dd HH:mm:ss.SSS')," +
                         " id," +
                         " attr," +
                         " tags" +
@@ -119,51 +119,6 @@ public class TestPrestoNativeClpGeneralQueries
                         "  'Initialized wire specification'," +
                         "  TIMESTAMP '2023-03-22 12:34:54.576'," +
                         "  4915701," +
-                        "  ARRAY[" +
-                        "    NULL," +
-                        "    ARRAY[ARRAY[ARRAY[ARRAY[ARRAY[NULL]]]]]," +
-                        "    NULL," +
-                        "    ARRAY[ARRAY[NULL]]" +
-                        "  ]," +
-                        "  NULL");
-        assertQuery(
-                format("SELECT" +
-                        " msg," +
-                        " FORMAT_DATETIME(t.dollar_sign_date, 'yyyy-MM-dd HH:mm:ss.SSS')," +
-                        " id," +
-                        " attr," +
-                        " tags" +
-                        " FROM %s" +
-                        " WHERE t.dollar_sign_date > FROM_UNIXTIME(1679441694.576)" +
-                        " ORDER BY id" +
-                        " LIMIT 1", DEFAULT_TABLE_NAME),
-                "SELECT" +
-                        "  'There were no users to pin, not starting tracker thread'," +
-                        "  TIMESTAMP '2023-03-22 12:34:55.821'," +
-                        "  20227," +
-                        "  ARRAY[" +
-                        "    NULL," +
-                        "    ARRAY[ARRAY[ARRAY[ARRAY[ARRAY[NULL]]]]]," +
-                        "    NULL," +
-                        "    ARRAY[ARRAY[NULL]]" +
-                        "  ]," +
-                        "  NULL");
-        assertQuery(
-                format("SELECT" +
-                        " msg," +
-                        " FORMAT_DATETIME(t.dollar_sign_date, 'yyyy-MM-dd HH:mm:ss.SSS')," +
-                        " id," +
-                        " attr," +
-                        " tags" +
-                        " FROM %s" +
-                        " WHERE t.dollar_sign_date > FROM_UNIXTIME(1679441694.576)" +
-                        " AND msg LIKE '%%user%%'" +
-                        " ORDER BY id" +
-                        " LIMIT 1", DEFAULT_TABLE_NAME),
-                "SELECT" +
-                        "  'There were no users to pin, not starting tracker thread'," +
-                        "  TIMESTAMP '2023-03-22 12:34:55.821'," +
-                        "  20227," +
                         "  ARRAY[" +
                         "    NULL," +
                         "    ARRAY[ARRAY[ARRAY[ARRAY[ARRAY[NULL]]]]]," +


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR is to update the Velox submodule to sync the merged PR https://github.com/y-scope/velox/pull/29 to have the refactored `Clp*Cursor` in Velox codebase.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

Passed the CI.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Added two new query tests to expand coverage for timestamp-based filtering and message-text matching, ensuring consistent results under additional filter conditions; also applied a minor formatting normalization in test assertions.

- Chores
  - Updated the Velox submodule reference to the latest commit to stay aligned with upstream changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->