### PR TITLE
test: Add general end-to-end test cases to test `WHERE` clause.

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeClpGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeClpGeneralQueries.java
@@ -105,10 +105,12 @@ public class TestPrestoNativeClpGeneralQueries
         // H2QueryRunner currently can't change the timestamp format, and the default timestamp
         // format of Presto is different, so for now we have to manually format the timestamp
         // field.
+
+        // Test SELECT all
         assertQuery(
                 format("SELECT" +
                         " msg," +
-                        " format_datetime(t.dollar_sign_date, 'yyyy-MM-dd HH:mm:ss.SSS')," +
+                        " FORMAT_DATETIME(t.dollar_sign_date, 'yyyy-MM-dd HH:mm:ss.SSS')," +
                         " id," +
                         " attr," +
                         " tags" +
@@ -119,6 +121,53 @@ public class TestPrestoNativeClpGeneralQueries
                         "  'Initialized wire specification'," +
                         "  TIMESTAMP '2023-03-22 12:34:54.576'," +
                         "  4915701," +
+                        "  ARRAY[" +
+                        "    NULL," +
+                        "    ARRAY[ARRAY[ARRAY[ARRAY[ARRAY[NULL]]]]]," +
+                        "    NULL," +
+                        "    ARRAY[ARRAY[NULL]]" +
+                        "  ]," +
+                        "  NULL");
+        // Test WHERE clause with numeric comparison
+        assertQuery(
+                format("SELECT" +
+                        " msg," +
+                        " FORMAT_DATETIME(t.dollar_sign_date, 'yyyy-MM-dd HH:mm:ss.SSS')," +
+                        " id," +
+                        " attr," +
+                        " tags" +
+                        " FROM %s" +
+                        " WHERE t.dollar_sign_date > FROM_UNIXTIME(1679441694.576)" +
+                        " ORDER BY id" +
+                        " LIMIT 1", DEFAULT_TABLE_NAME),
+                "SELECT" +
+                        "  'There were no users to pin, not starting tracker thread'," +
+                        "  TIMESTAMP '2023-03-22 12:34:55.821'," +
+                        "  20227," +
+                        "  ARRAY[" +
+                        "    NULL," +
+                        "    ARRAY[ARRAY[ARRAY[ARRAY[ARRAY[NULL]]]]]," +
+                        "    NULL," +
+                        "    ARRAY[ARRAY[NULL]]" +
+                        "  ]," +
+                        "  NULL");
+        // Test WHERE clause with string matching
+        assertQuery(
+                format("SELECT" +
+                        " msg," +
+                        " FORMAT_DATETIME(t.dollar_sign_date, 'yyyy-MM-dd HH:mm:ss.SSS')," +
+                        " id," +
+                        " attr," +
+                        " tags" +
+                        " FROM %s" +
+                        " WHERE t.dollar_sign_date > FROM_UNIXTIME(1679441694.576)" +
+                        " AND msg LIKE '%%user%%'" +
+                        " ORDER BY id" +
+                        " LIMIT 1", DEFAULT_TABLE_NAME),
+                "SELECT" +
+                        "  'There were no users to pin, not starting tracker thread'," +
+                        "  TIMESTAMP '2023-03-22 12:34:55.821'," +
+                        "  20227," +
                         "  ARRAY[" +
                         "    NULL," +
                         "    ARRAY[ARRAY[ARRAY[ARRAY[ARRAY[NULL]]]]]," +

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeClpGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeClpGeneralQueries.java
@@ -128,6 +128,7 @@ public class TestPrestoNativeClpGeneralQueries
                         "    ARRAY[ARRAY[NULL]]" +
                         "  ]," +
                         "  NULL");
+
         // Test WHERE clause with numeric comparison
         assertQuery(
                 format("SELECT" +
@@ -151,6 +152,7 @@ public class TestPrestoNativeClpGeneralQueries
                         "    ARRAY[ARRAY[NULL]]" +
                         "  ]," +
                         "  NULL");
+
         // Test WHERE clause with string matching
         assertQuery(
                 format("SELECT" +


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR added two more general end-to-end test cases to test `WHERE` clause as a suplementry for sanity check. Previously there was only a select-all query.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

Passed the CI.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Added/updated tests covering SELECT all, numeric timestamp filtering, and string-matching WHERE clauses with explicit expected results.
  - Standardized use of FORMAT_DATETIME across projections for consistent date formatting.
  - Ensured deterministic ordering and limits for stable expectations.
  - Improved readability with clear section labels; no changes to production behaviour or public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->