### PR TITLE
feat: Implement CLP type parser to support special chars besides `_` in field name (addresses yscope/velox#13).

### DIFF
--- a/presto-native-execution/presto_cpp/main/connectors/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/connectors/CMakeLists.txt
@@ -17,5 +17,6 @@ if(PRESTO_ENABLE_ARROW_FLIGHT_CONNECTOR)
   target_link_libraries(presto_connectors presto_flight_connector)
 endif()
 
-target_link_libraries(presto_connectors presto_velox_expr_conversion
-                      velox_clp_connector velox_type_fbhive)
+target_link_libraries(
+  presto_connectors presto_velox_expr_conversion velox_clp_connector
+  velox_type_fbhive velox_type_fbclp_parser)

--- a/presto-native-execution/presto_cpp/main/connectors/PrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/PrestoToVeloxConnector.cpp
@@ -20,6 +20,7 @@
 #include "presto_cpp/presto_protocol/connector/iceberg/IcebergConnectorProtocol.h"
 #include "presto_cpp/presto_protocol/connector/tpch/TpchConnectorProtocol.h"
 
+#include <velox/type/fbclp/ClpTypeParser.h>
 #include <velox/type/fbhive/HiveTypeParser.h>
 #include "velox/connectors/clp/ClpColumnHandle.h"
 #include "velox/connectors/clp/ClpConnectorSplit.h"
@@ -1580,7 +1581,7 @@ ClpPrestoToVeloxConnector::toVeloxColumnHandle(
   return std::make_unique<connector::clp::ClpColumnHandle>(
       clpColumn->columnName,
       clpColumn->originalColumnName,
-      typeParser.parse(clpColumn->columnType));
+      facebook::velox::type::fbclp::parseClpType(clpColumn->columnType));
 }
 
 std::unique_ptr<velox::connector::ConnectorTableHandle>


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR used the new type parser to parse the type, to catch those special chars.

This PR need to be merged after https://github.com/y-scope/velox/pull/31 gets merged, and also sync the submodule version.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

Passed the CI.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Improved handling of CLP column types in the Presto-to-Velox connector via a dedicated parser, improving type-parsing accuracy.

- Chores
  - Updated the Velox dependency to a newer commit for stability and improvements.
  - Adjusted connector link configuration to include an additional required component to ensure runtime completeness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->