### PR TITLE
feat: Upgrade velox submodule to y-scope/velox@1604a4d to add support for CLP's `FormattedFloat` and `DictionaryFloat` types.

### DIFF
--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/metadata/ClpSchemaTree.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/metadata/ClpSchemaTree.java
@@ -117,6 +117,8 @@ public class ClpSchemaTree
             case Integer:
                 return BIGINT;
             case Float:
+            case FormattedFloat:
+            case DictionaryFloat:
                 return DOUBLE;
             case ClpString:
             case VarString:

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/metadata/ClpSchemaTreeNodeType.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/metadata/ClpSchemaTreeNodeType.java
@@ -27,7 +27,9 @@ public enum ClpSchemaTreeNodeType
     UnstructuredArray((byte) 6),
     NullValue((byte) 7),
     DateString((byte) 8),
-    StructuredArray((byte) 9);
+    StructuredArray((byte) 9),
+    FormattedFloat((byte) 12),
+    DictionaryFloat((byte) 13);
 
     private static final ClpSchemaTreeNodeType[] LOOKUP_TABLE;
     private final byte type;

--- a/presto-docs/src/main/sphinx/connector/clp.rst
+++ b/presto-docs/src/main/sphinx/connector/clp.rst
@@ -252,10 +252,14 @@ CLP Type               Presto Type
 Double Types
 ============
 
-CLP uses three distinct double types: ``Float`` (a standard IEEE-754 double-precision value), ``FormattedFloat`` (a
-double-precision value stored together with its original formatting details), and ``DictionaryFloat`` (a
-double-precision value whose full string representation is stored in the variable dictionary, with values encoded by
-their corresponding dictionary IDs). At present, all three are mapped to Presto's ``DOUBLE`` type.
+CLP uses three distinct double types:
+
+- ``Float`` is a standard IEEE-754 double-precision value.
+- ``FormattedFloat`` is a double-precision value stored together with its original formatting details.
+- ``DictionaryFloat`` is a double-precision value whose full string representation is stored in the variable dictionary,
+  with values encoded by their corresponding dictionary IDs.
+
+At present, all three are mapped to Presto's ``DOUBLE`` type.
 
 String Types
 ============

--- a/presto-docs/src/main/sphinx/connector/clp.rst
+++ b/presto-docs/src/main/sphinx/connector/clp.rst
@@ -238,6 +238,8 @@ CLP Type               Presto Type
 ====================== ====================
 ``Integer``            ``BIGINT``
 ``Float``              ``DOUBLE``
+``FormattedFloat``     ``DOUBLE``
+``DictionaryFloat``    ``DOUBLE``
 ``ClpString``          ``VARCHAR``
 ``VarString``          ``VARCHAR``
 ``DateString``         ``VARCHAR``
@@ -246,6 +248,14 @@ CLP Type               Presto Type
 ``Object``             ``ROW``
 (others)               (unsupported)
 ====================== ====================
+
+Double Types
+============
+
+CLP uses three distinct double types: ``Float`` (a standard IEEE-754 double-precision value), ``FormattedFloat`` (a
+double-precision value stored together with its original formatting details), and ``DictionaryFloat`` (a
+double-precision value whose full string representation is stored in the variable dictionary, with values encoded by
+their corresponding dictionary IDs). At present, all three are mapped to Presto's ``DOUBLE`` type.
 
 String Types
 ============


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR adds support for `FormattedFloat` and `DictionaryFloat` types in the latest CLP. This PR also has a related PR in Velox repo: https://github.com/y-scope/velox/pull/37, so **this PR should be merged after that PR is merged.**

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

End-to-end tested the queries used in the unit tests in this PR: https://github.com/y-scope/velox/pull/37
Passed the CI.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added two additional CLP float types; both are now returned as DOUBLE for consistent numeric handling.

- **Documentation**
  - Updated connector docs with a new section describing the expanded set of CLP double types and their unified mapping to DOUBLE.

- **Chores**
  - Updated native execution submodule pointer to the latest commit for alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->