### PR TITLE
feat: Add CLP UDF docs

### DIFF
--- a/presto-docs/src/main/sphinx/connector/clp.rst
+++ b/presto-docs/src/main/sphinx/connector/clp.rst
@@ -350,7 +350,7 @@ Path-based Functions
 
 .. function:: CLP_GET_DOUBLE(varchar) -> double
 
-    Returns the double value at the given JSON path, where the column type is ``Float``.  Returns a Presto ``DOUBLE``.
+    Returns the double value at the given JSON path, where the column type is ``Float``. Returns a Presto ``DOUBLE``.
 
 .. function:: CLP_GET_BOOL(varchar) -> boolean
 
@@ -372,11 +372,11 @@ Examples
 
 .. code-block:: sql
 
-    SELECT CLP_GET_STRING(msg.author) AS author
+    SELECT CLP_GET_STRING('msg.author') AS author
     FROM clp.default.table_1
-    WHERE CLP_GET_INT('msg.timestamp') > 1620000000;
+    WHERE CLP_GET_BIGINT('msg.timestamp') > 1620000000;
 
-    SELECT CLP_GET_STRING_ARRAY(msg.tags) AS tags
+    SELECT CLP_GET_STRING_ARRAY('msg.tags') AS tags
     FROM clp.default.table_2
     WHERE CLP_GET_BOOL('msg.is_active') = true;
 

--- a/presto-docs/src/main/sphinx/connector/clp.rst
+++ b/presto-docs/src/main/sphinx/connector/clp.rst
@@ -306,6 +306,126 @@ Each JSON log maps to this unified ``ROW`` type, with absent fields represented 
 ``status``, ``thread_num``, ``backtrace``) become fields within the ``ROW``, clearly reflecting the nested and varying
 structures of the original JSON logs.
 
+CLP Functions
+-------------
+
+In semi-structured logs, the number of potential keys can grow significantly, resulting in extremely wide Presto tables
+with many columns. To manage this complexity, the metadata provider may expose only a subset of the full schema,
+typically the static fields or those most relevant to expected queries.
+
+To enable access to dynamic or less common fields not present in the exposed schema, CLP provides two set of functions
+to help users query flexible log schemas while keeping the table metadata definition concise. These functions are only
+available in the CLP connector and are not part of standard Presto SQL.
+
+- JSON path functions (e.g., ``CLP_GET_STRING``)
+- Wildcard column matching functions for use in filter predicates (e.g., ``CLP_WILDCARD_STRING_COLUMN``)
+
+There is **no performance penalty** for using these functions. During query optimization, they are rewritten into
+references to actual schema-backed columns or valid symbols in KQL queries. This avoids additional parsing overhead and
+delivers performance comparable to querying standard columns.
+
+Path-Based Functions
+^^^^^^^^^^^^^^^^^^^^
+
+.. function:: CLP_GET_STRING(varchar) -> varchar
+
+    Returns the string value of the given JSON path, where the column type is one of: ``ClpString``, ``VarString``, or
+    ``DateString``. Returns a Presto ``VARCHAR``.
+
+.. function:: CLP_GET_BIGINT(varchar) -> bigint
+
+    Returns the integer value of the given JSON path, where the column type is ``Integer``, Returns a Presto ``BIGINT``.
+
+.. function:: CLP_GET_DOUBLE(varchar) -> double
+
+    Returns the double value of the given JSON path, where the column type is ``Float``.  Returns a Presto ``DOUBLE``.
+
+.. function:: CLP_GET_BOOL(varchar) -> boolean
+
+    Returns the double value of the given JSON path, where the column type is ``Boolean``. Returns a Presto ``BOOLEAN``.
+
+.. function:: CLP_GET_STRING_ARRAY(varchar) -> array(varchar)
+
+    Returns the array value of the given JSON path, where the column type is ``UnstructuredArray`` and converts each
+    element into a string. Returns a Presto ``ARRAY(VARCHAR)``.
+
+.. note::
+
+   - JSON paths must be **constant string literals**; variables are not supported.
+   - Wildcards (e.g., ``msg.*.ts``) are **not supported**.
+   - If a path is invalid or missing, the function returns ``NULL`` rather than raising an error.
+
+Examples:
+
+.. code-block:: sql
+
+    SELECT CLP_GET_STRING(msg.author) AS author
+    FROM clp.default.table_1
+    WHERE CLP_GET_INT('msg.timestamp') > 1620000000;
+
+    SELECT CLP_GET_STRING_ARRAY(msg.tags) AS tags
+    FROM clp.default.table_2
+    WHERE CLP_GET_BOOL('msg.is_active') = true;
+
+
+Wildcard Column Functions
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+These functions are used to apply filter predicates across all columns of a certain type. They are useful for searching
+across unknown or dynamic schemas without specifying exact column names. Similar to the path-based functions, these
+functions are rewritten during query optimization to a KQL query that matches the appropriate columns.
+
+.. function:: CLP_WILDCARD_STRING_COLUMN() -> varchar
+
+   Represents all columns of CLP types: ``ClpString``, ``VarString``, and ``DateString``.
+
+.. function:: CLP_WILDCARD_INT_COLUMN() -> bigint
+
+   Represents all columns of CLP type: ``Integer``.
+
+.. function:: CLP_WILDCARD_FLOAT_COLUMN() -> double
+
+   Represents all columns of CLP type: ``Float``.
+
+.. function:: CLP_WILDCARD_BOOL_COLUMN() -> boolean
+
+   Represents all columns of CLP type: ``Boolean``.
+
+.. note::
+
+   - They must appear **only in filter conditions** (`WHERE` clause). They cannot be selected or passed as arguments
+     to other functions.
+   - Supported operators includes:
+
+     ::
+
+         =   (EQUAL)
+         !=  (NOT_EQUAL)
+         <   (LESS_THAN)
+         <=  (LESS_THAN_OR_EQUAL)
+         >   (GREATER_THAN)
+         >=  (GREATER_THAN_OR_EQUAL)
+         LIKE
+         BETWEEN
+         IN
+
+     Use of other operators (e.g., arithmetic or function calls) with wildcard functions is not allowed and will result
+     in a query error.
+
+Examples:
+
+.. code-block:: sql
+
+   -- Matches if any string column contains "Beijing"
+   SELECT *
+   FROM clp.default.table_1
+   WHERE CLP_WILDCARD_STRING_COLUMN() = 'Beijing';
+
+   -- Matches if any integer column equals 1
+   SELECT *
+   FROM clp.default.table_2
+   WHERE CLP_WILDCARD_INT_COLUMN() = 1;
+
 ***********
 SQL support
 ***********

--- a/presto-docs/src/main/sphinx/connector/clp.rst
+++ b/presto-docs/src/main/sphinx/connector/clp.rst
@@ -325,15 +325,16 @@ CLP Functions
 *************
 
 Semi-structured logs can have many potential keys, which can lead to very wide Presto tables. To keep table metadata
-concise and still preserve access to dynamic fields, the connector provides two sets of functions that are specific to
+concise and still preserve access to dynamic fields, the connector provides three sets of functions that are specific to
 the CLP connector. These functions are not part of standard Presto SQL.
 
 - JSON path functions (e.g., ``CLP_GET_STRING``)
 - Wildcard column matching functions for use in filter predicates (e.g., ``CLP_WILDCARD_STRING_COLUMN``)
+- A function for retrieving the entire row in JSON format (i.e., ``CLP_GET_JSON_STRING``)
 
-There is **no performance penalty** when using these functions. During query optimization, the connector rewrites these
-functions into references to concrete schema-backed columns or valid symbols in KQL queries. This avoids additional
-parsing overhead and delivers performance comparable to querying standard columns.
+For the first two sets of functions, there is **no performance overhead**. During query optimization, the connector
+rewrites these functions into references to concrete schema-backed columns or valid symbols in KQL queries. This avoids
+unnecessary parsing overhead and delivers performance comparable to querying standard columns.
 
 Path-based Functions
 ====================
@@ -438,6 +439,40 @@ Examples
    SELECT *
    FROM clp.default.table_2
    WHERE CLP_WILDCARD_INT_COLUMN() = 1;
+
+JSON String Function
+====================
+
+The ``CLP_GET_JSON_STRING``` function provides a convenient way to retrieve the entire log record—including both
+schema-backed and dynamic fields—as a single JSON string. This enables users to inspect, debug, or export complete
+records in their raw JSON form.
+
+Similar to the path-based and wildcard functions, this function is rewritten during query optimization to a special
+internal column. During query execution, this column is serialized into a JSON string that represents the full record.
+
+.. function:: CLP_GET_JSON_STRING() -> varchar
+
+   Returns the full log record as a JSON string, preserving all schema-backed and dynamic fields.
+
+.. note::
+
+   This function can only be used in the ``SELECT``` list to retrieve the complete JSON representation of each record.
+   It cannot be used within filter predicates (``WHERE`` clause) or as an argument to other functions.
+
+Examples
+--------
+
+.. code-block:: sql
+
+   -- Retrieve each record as a JSON string
+   SELECT CLP_GET_JSON_STRING()
+   FROM clp.default.table_1
+   LIMIT 10;
+
+   -- Retrieve JSON along with selected fields
+   SELECT timestamp, CLP_GET_JSON_STRING()
+   FROM clp.default.table_1
+   WHERE CLP_WILDCARD_STRING_COLUMN() = 'error';
 
 ***********
 SQL support

--- a/presto-docs/src/main/sphinx/connector/clp.rst
+++ b/presto-docs/src/main/sphinx/connector/clp.rst
@@ -306,12 +306,13 @@ Each JSON log maps to this unified ``ROW`` type, with absent fields represented 
 ``status``, ``thread_num``, ``backtrace``) become fields within the ``ROW``, clearly reflecting the nested and varying
 structures of the original JSON logs.
 
+*************
 CLP Functions
--------------
+*************
 
-In semi-structured logs, the number of potential keys can grow significantly, resulting in extremely wide Presto tables
-with many columns. To manage this complexity, the metadata provider may expose only a subset of the full schema,
-typically the static fields or those most relevant to expected queries.
+Semi-structured logs can have many potential keys, which can lead to very wide Presto tables. To keep table metadata
+concise and still preserve access to dynamic fields, the connector provides two sets of functions that are specific to
+the CLP connector. These functions are not part of standard Presto SQL.
 
 To enable access to dynamic or less common fields not present in the exposed schema, CLP provides two set of functions
 to help users query flexible log schemas while keeping the table metadata definition concise. These functions are only
@@ -320,33 +321,33 @@ available in the CLP connector and are not part of standard Presto SQL.
 - JSON path functions (e.g., ``CLP_GET_STRING``)
 - Wildcard column matching functions for use in filter predicates (e.g., ``CLP_WILDCARD_STRING_COLUMN``)
 
-There is **no performance penalty** for using these functions. During query optimization, they are rewritten into
-references to actual schema-backed columns or valid symbols in KQL queries. This avoids additional parsing overhead and
-delivers performance comparable to querying standard columns.
+There is **no performance penalty** when using these functions. During query optimization, the connector rewrites these
+functions to references to concrete schema-backed columns or valid symbols in KQL queries. This avoids additional
+parsing overhead and delivers performance comparable to querying standard columns.
 
 Path-Based Functions
-^^^^^^^^^^^^^^^^^^^^
+====================
 
 .. function:: CLP_GET_STRING(varchar) -> varchar
 
-    Returns the string value of the given JSON path, where the column type is one of: ``ClpString``, ``VarString``, or
+    Returns the string value at the given JSON path, where the column type is one of: ``ClpString``, ``VarString``, or
     ``DateString``. Returns a Presto ``VARCHAR``.
 
 .. function:: CLP_GET_BIGINT(varchar) -> bigint
 
-    Returns the integer value of the given JSON path, where the column type is ``Integer``, Returns a Presto ``BIGINT``.
+    Returns the integer value at the given JSON path, where the column type is ``Integer``, Returns a Presto ``BIGINT``.
 
 .. function:: CLP_GET_DOUBLE(varchar) -> double
 
-    Returns the double value of the given JSON path, where the column type is ``Float``.  Returns a Presto ``DOUBLE``.
+    Returns the double value at the given JSON path, where the column type is ``Float``.  Returns a Presto ``DOUBLE``.
 
 .. function:: CLP_GET_BOOL(varchar) -> boolean
 
-    Returns the double value of the given JSON path, where the column type is ``Boolean``. Returns a Presto ``BOOLEAN``.
+    Returns the boolean value at the given JSON path, where the column type is ``Boolean``. Returns a Presto ``BOOLEAN``.
 
 .. function:: CLP_GET_STRING_ARRAY(varchar) -> array(varchar)
 
-    Returns the array value of the given JSON path, where the column type is ``UnstructuredArray`` and converts each
+    Returns the array value at the given JSON path, where the column type is ``UnstructuredArray`` and converts each
     element into a string. Returns a Presto ``ARRAY(VARCHAR)``.
 
 .. note::
@@ -355,7 +356,8 @@ Path-Based Functions
    - Wildcards (e.g., ``msg.*.ts``) are **not supported**.
    - If a path is invalid or missing, the function returns ``NULL`` rather than raising an error.
 
-Examples:
+Examples
+--------
 
 .. code-block:: sql
 
@@ -369,7 +371,7 @@ Examples:
 
 
 Wildcard Column Functions
-^^^^^^^^^^^^^^^^^^^^^^^^^
+=========================
 
 These functions are used to apply filter predicates across all columns of a certain type. They are useful for searching
 across unknown or dynamic schemas without specifying exact column names. Similar to the path-based functions, these
@@ -377,25 +379,25 @@ functions are rewritten during query optimization to a KQL query that matches th
 
 .. function:: CLP_WILDCARD_STRING_COLUMN() -> varchar
 
-   Represents all columns of CLP types: ``ClpString``, ``VarString``, and ``DateString``.
+   Represents all columns whose CLP types are ``ClpString``, ``VarString``, or ``DateString``.
 
 .. function:: CLP_WILDCARD_INT_COLUMN() -> bigint
 
-   Represents all columns of CLP type: ``Integer``.
+   Represents all columns whose CLP type is ``Integer``.
 
 .. function:: CLP_WILDCARD_FLOAT_COLUMN() -> double
 
-   Represents all columns of CLP type: ``Float``.
+   Represents all columns whose CLP type is ``Float``.
 
 .. function:: CLP_WILDCARD_BOOL_COLUMN() -> boolean
 
-   Represents all columns of CLP type: ``Boolean``.
+   Represents all columns whose CLP type is ``Boolean``.
 
 .. note::
 
-   - They must appear **only in filter conditions** (`WHERE` clause). They cannot be selected or passed as arguments
-     to other functions.
-   - Supported operators includes:
+   - Wildcard functions must appear **only in filter conditions** (`WHERE` clause). They cannot be selected and cannot
+     be passed as arguments to other functions.
+   - Supported operators include:
 
      ::
 
@@ -412,7 +414,8 @@ functions are rewritten during query optimization to a KQL query that matches th
      Use of other operators (e.g., arithmetic or function calls) with wildcard functions is not allowed and will result
      in a query error.
 
-Examples:
+Examples
+--------
 
 .. code-block:: sql
 

--- a/presto-docs/src/main/sphinx/connector/clp.rst
+++ b/presto-docs/src/main/sphinx/connector/clp.rst
@@ -328,18 +328,14 @@ Semi-structured logs can have many potential keys, which can lead to very wide P
 concise and still preserve access to dynamic fields, the connector provides two sets of functions that are specific to
 the CLP connector. These functions are not part of standard Presto SQL.
 
-To enable access to dynamic or less common fields not present in the exposed schema, CLP provides two set of functions
-to help users query flexible log schemas while keeping the table metadata definition concise. These functions are only
-available in the CLP connector and are not part of standard Presto SQL.
-
 - JSON path functions (e.g., ``CLP_GET_STRING``)
 - Wildcard column matching functions for use in filter predicates (e.g., ``CLP_WILDCARD_STRING_COLUMN``)
 
 There is **no performance penalty** when using these functions. During query optimization, the connector rewrites these
-functions to references to concrete schema-backed columns or valid symbols in KQL queries. This avoids additional
+functions into references to concrete schema-backed columns or valid symbols in KQL queries. This avoids additional
 parsing overhead and delivers performance comparable to querying standard columns.
 
-Path-Based Functions
+Path-based Functions
 ====================
 
 .. function:: CLP_GET_STRING(varchar) -> varchar
@@ -349,7 +345,7 @@ Path-Based Functions
 
 .. function:: CLP_GET_BIGINT(varchar) -> bigint
 
-    Returns the integer value at the given JSON path, where the column type is ``Integer``, Returns a Presto ``BIGINT``.
+    Returns the integer value at the given JSON path, where the column type is ``Integer``. Returns a Presto ``BIGINT``.
 
 .. function:: CLP_GET_DOUBLE(varchar) -> double
 

--- a/presto-docs/src/main/sphinx/connector/clp.rst
+++ b/presto-docs/src/main/sphinx/connector/clp.rst
@@ -365,7 +365,7 @@ Path-based Functions
 
    - JSON paths must be **constant string literals**; variables are not supported.
    - Wildcards (e.g., ``msg.*.ts``) are **not supported**.
-   - If a path is invalid or missing, the function returns ``NULL`` rather than raising an error.
+   - If a path is invalid or missing in a given record, the function returns ``NULL`` rather than raising an error.
 
 Examples
 --------
@@ -455,9 +455,9 @@ internal column. During query execution, this column is serialized into a JSON s
    Returns the full log record as a JSON string, preserving all schema-backed and dynamic fields.
 
 .. note::
-
-   This function can only be used in the ``SELECT``` list to retrieve the complete JSON representation of each record.
-   It cannot be used within filter predicates (``WHERE`` clause) or as an argument to other functions.
+   This function can only be used in the list of projected columns in a ``SELECT``` clause to retrieve the complete
+   JSON representation of each record. It cannot be used within filter predicates (``WHERE`` clause) or as an argument
+   to other functions.
 
 Examples
 --------


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR adds docs for `CLP_GET_*` and `CLP_WILDCARD_*` UDFs.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Added a CLP Functions guide describing path-based JSON helpers and wildcard column helpers, their return types, constraints (constant string literals only, no wildcards) and NULL behaviour.
  - Documented usage patterns, supported operators, filter-only restrictions, and examples for strings, numbers, booleans and arrays.
  - Added a "SQL support" section and noted duplicated content to be consolidated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->