### PR TITLE
fix: Fix pushdown generation bug for `NOT LIKE` and `TIMESTAMP` comparisons.

### DIFF
--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpFilterToKqlConverter.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpFilterToKqlConverter.java
@@ -554,6 +554,7 @@ public class ClpFilterToKqlConverter
      *
      * @param info parsed SUBSTR call info
      * @param targetString the literal string being compared to
+     * @param isEqual whether the operator is EQUAL or not
      * @return an Optional containing either a ClpExpression with the equivalent KQL query
      */
     private Optional<ClpExpression> interpretSubstringEquality(SubstrInfo info, String targetString, boolean isEqual)

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpFilterToKqlConverter.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpFilterToKqlConverter.java
@@ -57,6 +57,8 @@ import static com.facebook.presto.common.type.DoubleType.DOUBLE;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.common.type.RealType.REAL;
 import static com.facebook.presto.common.type.SmallintType.SMALLINT;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP_MICROSECONDS;
 import static com.facebook.presto.common.type.TinyintType.TINYINT;
 import static com.facebook.presto.plugin.clp.ClpErrorCode.CLP_PUSHDOWN_UNSUPPORTED_EXPRESSION;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.AND;
@@ -486,7 +488,7 @@ public class ClpFilterToKqlConverter
             RowExpression possibleSubstring,
             RowExpression possibleLiteral)
     {
-        if (!operator.equals(EQUAL)) {
+        if (!operator.equals(EQUAL) && !operator.equals(NOT_EQUAL)) {
             return Optional.empty();
         }
 
@@ -501,7 +503,7 @@ public class ClpFilterToKqlConverter
         }
 
         String targetString = getLiteralString((ConstantExpression) possibleLiteral);
-        return interpretSubstringEquality(maybeSubstringCall.get(), targetString);
+        return interpretSubstringEquality(maybeSubstringCall.get(), targetString, operator.equals(EQUAL));
     }
 
     /**
@@ -554,8 +556,12 @@ public class ClpFilterToKqlConverter
      * @param targetString the literal string being compared to
      * @return an Optional containing either a ClpExpression with the equivalent KQL query
      */
-    private Optional<ClpExpression> interpretSubstringEquality(SubstrInfo info, String targetString)
+    private Optional<ClpExpression> interpretSubstringEquality(SubstrInfo info, String targetString, boolean isEqual)
     {
+        StringBuilder result = new StringBuilder();
+        if (!isEqual) {
+            result.append("NOT ");
+        }
         if (info.lengthExpression != null) {
             Optional<Integer> maybeStart = parseIntValue(info.startExpression);
             Optional<Integer> maybeLen = parseLengthLiteral(info.lengthExpression, targetString);
@@ -564,7 +570,6 @@ public class ClpFilterToKqlConverter
                 int start = maybeStart.get();
                 int len = maybeLen.get();
                 if (start > 0 && len == targetString.length()) {
-                    StringBuilder result = new StringBuilder();
                     result.append(info.variableName).append(": \"");
                     for (int i = 1; i < start; i++) {
                         result.append("?");
@@ -579,7 +584,6 @@ public class ClpFilterToKqlConverter
             if (maybeStart.isPresent()) {
                 int start = maybeStart.get();
                 if (start > 0) {
-                    StringBuilder result = new StringBuilder();
                     result.append(info.variableName).append(": \"");
                     for (int i = 1; i < start; i++) {
                         result.append("?");
@@ -588,7 +592,8 @@ public class ClpFilterToKqlConverter
                     return Optional.of(new ClpExpression(result.toString()));
                 }
                 if (start == -targetString.length()) {
-                    return Optional.of(new ClpExpression(format("%s: \"*%s\"", info.variableName, targetString)));
+                    result.append(format("%s: \"*%s\"", info.variableName, targetString));
+                    return Optional.of(new ClpExpression(result.toString()));
                 }
             }
         }
@@ -914,6 +919,8 @@ public class ClpFilterToKqlConverter
                 || type.equals(TINYINT)
                 || type.equals(DOUBLE)
                 || type.equals(REAL)
+                || type.equals(TIMESTAMP)
+                || type.equals(TIMESTAMP_MICROSECONDS)
                 || type instanceof DecimalType;
     }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR identified an existing bug:
For the filter like this:
```sql
city.Region.Name NOT LIKE 'hello%'
```
The generated node is `"<>(SUBSTR(DEREFERENCE(DEREFERENCE(city, 1), 0), 1, 5), Slice{base=[B@b39989, address=16, length=5})"`. However, in the current `TestClpFilterKql`, since we only use our own optimizer, the generated node is `"not(=(SUBSTR(DEREFERENCE(DEREFERENCE(city, 1), 1), 1, 5), Slice{base=[B@2d10e0b1, address=16, length=5}))"`. This slight difference cause the diffferent code path when generating the pushdown for this. The former one will not pass the first if statement in `ClpFilterToKqlConverter.tryInterpretSubstringEquality()` so that no pushdown will be generated.

Another bug is the the `TIMESTAMP` constant will be considered as a "valid" constant when processing the comparisons in the filter. This PR added two supported `TIMESTAMP` types to support the comparisons for them. Their values are number of epoch in milliseconds and microseconds.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

Passed the CI.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Adds support for NOT EQUAL conditions in substring-based filters when translating predicates.
  - Expands filter pushdown to recognize timestamp types for broader predicate handling.

- Performance
  - Improves query efficiency by enabling more filters to be pushed down, reducing scanned data and speeding execution.

- Compatibility
  - Enhances timestamp comparison handling within numeric-compatible contexts without changing user-facing APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->