### PR TITLE
feat: Add `clp_get_json_string` UDF.

### DIFF
--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpFunctions.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpFunctions.java
@@ -19,7 +19,6 @@ import com.facebook.presto.spi.function.Description;
 import com.facebook.presto.spi.function.ScalarFunction;
 import com.facebook.presto.spi.function.SqlType;
 import io.airlift.slice.Slice;
-import io.airlift.slice.Slices;
 
 public final class ClpFunctions
 {

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpFunctions.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpFunctions.java
@@ -19,6 +19,7 @@ import com.facebook.presto.spi.function.Description;
 import com.facebook.presto.spi.function.ScalarFunction;
 import com.facebook.presto.spi.function.SqlType;
 import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
 
 public final class ClpFunctions
 {
@@ -96,5 +97,13 @@ public final class ClpFunctions
     public static boolean clpWildcardBoolColumn()
     {
         throw new UnsupportedOperationException("CLP_WILDCARD_BOOL_COLUMN is a placeholder function without implementation.");
+    }
+
+    @ScalarFunction(value = "CLP_GET_JSON_STRING", deterministic = false)
+    @Description("Converts an entire log record into a JSON string.")
+    @SqlType(StandardTypes.VARCHAR)
+    public static Slice clpGetJSONString()
+    {
+        throw new UnsupportedOperationException("CLP_GET_JSON_STRING is a placeholder function without implementation.");
     }
 }

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpUdfRewriter.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpUdfRewriter.java
@@ -58,6 +58,7 @@ import static java.util.Objects.requireNonNull;
 public final class ClpUdfRewriter
         implements ConnectorPlanOptimizer
 {
+    public static final String JSON_STRING_PLACEHOLDER = "__json_string";
     private final FunctionMetadataManager functionManager;
 
     public ClpUdfRewriter(FunctionMetadataManager functionManager)
@@ -123,7 +124,7 @@ public final class ClpUdfRewriter
             for (Map.Entry<VariableReferenceExpression, RowExpression> entry : node.getAssignments().getMap().entrySet()) {
                 newAssignments.put(
                         entry.getKey(),
-                        rewriteClpUdfs(entry.getValue(), functionManager, variableAllocator));
+                        rewriteClpUdfs(entry.getValue(), functionManager, variableAllocator, true));
             }
 
             PlanNode newSource = rewritePlanSubtree(node.getSource());
@@ -148,20 +149,30 @@ public final class ClpUdfRewriter
          * @param expression the input expression to analyze and possibly rewrite
          * @param functionManager function manager used to resolve function metadata
          * @param variableAllocator variable allocator used to create new variable references
+         * @param inProjectNode whether the CLP UDFs are in a {@link ProjectNode}
          * @return a possibly rewritten {@link RowExpression} with <code>CLP_GET_*</code> calls
          * replaced
          */
         private RowExpression rewriteClpUdfs(
                 RowExpression expression,
                 FunctionMetadataManager functionManager,
-                VariableAllocator variableAllocator)
+                VariableAllocator variableAllocator,
+                boolean inProjectNode)
         {
             // Handle CLP_GET_* function calls
             if (expression instanceof CallExpression) {
                 CallExpression call = (CallExpression) expression;
                 String functionName = functionManager.getFunctionMetadata(call.getFunctionHandle()).getName().getObjectName().toUpperCase();
 
-                if (functionName.startsWith("CLP_GET_")) {
+                if (inProjectNode && functionName.equals("CLP_GET_JSON_STRING")) {
+                    VariableReferenceExpression newValue =
+                            new VariableReferenceExpression(expression.getSourceLocation(), JSON_STRING_PLACEHOLDER, expression.getType());
+                    ClpColumnHandle targetHandle = new ClpColumnHandle(JSON_STRING_PLACEHOLDER, call.getType());
+
+                    globalColumnVarMap.put(targetHandle, newValue);
+                    return newValue;
+                }
+                else if (functionName.startsWith("CLP_GET_")) {
                     if (call.getArguments().size() != 1 || !(call.getArguments().get(0) instanceof ConstantExpression)) {
                         throw new PrestoException(CLP_PUSHDOWN_UNSUPPORTED_EXPRESSION,
                                 "CLP_GET_* UDF must have a single constant string argument");
@@ -187,7 +198,7 @@ public final class ClpUdfRewriter
 
                 // Recurse into arguments
                 List<RowExpression> rewrittenArgs = call.getArguments().stream()
-                        .map(arg -> rewriteClpUdfs(arg, functionManager, variableAllocator))
+                        .map(arg -> rewriteClpUdfs(arg, functionManager, variableAllocator, inProjectNode))
                         .collect(toImmutableList());
 
                 return new CallExpression(call.getDisplayName(), call.getFunctionHandle(), call.getType(), rewrittenArgs);
@@ -198,7 +209,7 @@ public final class ClpUdfRewriter
                 SpecialFormExpression special = (SpecialFormExpression) expression;
 
                 List<RowExpression> rewrittenArgs = special.getArguments().stream()
-                        .map(arg -> rewriteClpUdfs(arg, functionManager, variableAllocator))
+                        .map(arg -> rewriteClpUdfs(arg, functionManager, variableAllocator, inProjectNode))
                         .collect(toImmutableList());
 
                 return new SpecialFormExpression(special.getSourceLocation(), special.getForm(), special.getType(), rewrittenArgs);
@@ -298,7 +309,7 @@ public final class ClpUdfRewriter
          */
         private FilterNode buildNewFilterNode(FilterNode node)
         {
-            RowExpression newPredicate = rewriteClpUdfs(node.getPredicate(), functionManager, variableAllocator);
+            RowExpression newPredicate = rewriteClpUdfs(node.getPredicate(), functionManager, variableAllocator, false);
             PlanNode newSource = rewritePlanSubtree(node.getSource());
             return new FilterNode(node.getSourceLocation(), idAllocator.getNextId(), newSource, newPredicate);
         }

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpUdfRewriter.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpUdfRewriter.java
@@ -165,8 +165,10 @@ public final class ClpUdfRewriter
                 String functionName = functionManager.getFunctionMetadata(call.getFunctionHandle()).getName().getObjectName().toUpperCase();
 
                 if (inProjectNode && functionName.equals("CLP_GET_JSON_STRING")) {
-                    VariableReferenceExpression newValue =
-                            new VariableReferenceExpression(expression.getSourceLocation(), JSON_STRING_PLACEHOLDER, expression.getType());
+                    VariableReferenceExpression newValue = variableAllocator.newVariable(
+                            expression.getSourceLocation(),
+                            JSON_STRING_PLACEHOLDER,
+                            call.getType());
                     ClpColumnHandle targetHandle = new ClpColumnHandle(JSON_STRING_PLACEHOLDER, call.getType());
 
                     globalColumnVarMap.put(targetHandle, newValue);


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR introduces the `clp_get_json_string` UDF, which is rewritten into a special column named `__json_string` during UDF rewriting. With [Velox support](https://github.com/y-scope/velox/pull/40), this UDF enables fetching a serialized JSON string representation of a row.

Note: `clp_get_json_string` is currently supported only in projection fields.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

Did an end-to-end testing with a sample dataset
```
presto:default> select timestamp, clp_get_json_string() from default where clp_wildcard_string_column() in ('profile_update', 'logout');
      timestamp       |                                                                          _col1                                                                           
----------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------
 2025-05-13T15:00:20Z | {"timestamp":"2025-05-13T15:00:20Z","level":"INFO","service":"user-service","event":{"action":"logout"},"user":{"id":"12345"}}                           
 2025-05-13T15:00:06Z | {"timestamp":"2025-05-13T15:00:06Z","level":"INFO","service":"user-service","event":{"action":"profile_update"},"user":{"id":"67890","name":"Jane Doe"}} 
 2025-05-13T15:00:20Z | {"timestamp":"2025-05-13T15:00:20Z","level":"INFO","service":"user-service","event":{"action":"logout"},"user":{"id":"12345"}}                           
 2025-05-13T15:00:06Z | {"timestamp":"2025-05-13T15:00:06Z","level":"INFO","service":"user-service","event":{"action":"profile_update"},"user":{"id":"67890","name":"Jane Doe"}} 
(4 rows)

Query 20251018_182705_00001_ikv76, FINISHED, 1 node
Splits: 3 total, 3 done (100.00%)
[Latency: client-side: 225ms, server-side: 191ms] [6 rows, 0B] [31 rows/s, 0B/s]

presto:default> select event.type, clp_get_json_string() from default_ir;
      type      |                                                                                                                            _col1                                                                                     >
----------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------->
 network        | {"event":{"details":{"destination":{"ip":"10.0.1.5","port":80},"source":{"ip":"192.168.3.10"}},"severity":"INFO","subtype":"connection","tags":["inbound","tcp"],"type":"network"},"timestamp":1746003000}           >
 storage        | {"event":{"details":{"mount":"/var/log","usage":{"percent":92}},"severity":"WARNING","subtype":"disk_usage","tags":["filesystem","monitoring"],"type":"storage"},"timestamp":1746003005}                             >
 process        | {"event":{"details":{"id":1234,"name":"cron"},"severity":"INFO","subtype":"start","tags":["system","init"],"type":"process"},"timestamp":1746003010}                                                                 >
 authentication | {"event":{"details":{"ip":"203.0.113.20","reason":"invalid password"},"severity":"ERROR","subtype":"failure","tags":["login","security"],"type":"authentication","user":{"method":"ssh","name":"guest"}},"timestamp":>
 service        | {"event":{"details":{"name":"httpd","state":"running","uptime":{"seconds":3600}},"severity":"INFO","subtype":"status","tags":["daemon","http"],"type":"service"},"timestamp":1746003020}                             >
 security       | {"event":{"details":{"payload":"SELECT * FROM users;","rule":{"id":"SQLI-001"},"target":"/api/data"},"severity":"HIGH","subtype":"alert","tags":["threat","sql"],"type":"security"},"timestamp":1746003025}          >
 memory         | {"event":{"details":{"free":{"gb":7.5},"total":{"gb":16},"used":{"gb":8.5}},"severity":"NORMAL","subtype":"usage","tags":["resources"],"type":"memory"},"timestamp":1746003030}                                      >
 configuration  | {"event":{"details":{"component":"database","setting":{"name":"timeout","newValue":60,"oldValue":30}},"severity":"INFO","subtype":"change","tags":["admin","settings"],"type":"configuration","user":{"name":"admin"}>
 file           | {"event":{"details":{"flags":["sensitive","audit"],"operation":"read","path":"/etc/shadow","permissions":"rw-------"},"severity":"WARNING","subtype":"access","tags":["file","privileged"],"type":"file","user":{"nam>
 backup         | {"event":{"details":{"duration":{"seconds":1200},"job":{"name":"daily_backup","status":"completed"},"size":{"gb":25.3}},"severity":"INFO","subtype":"status","tags":["backup","daily"],"type":"backup"},"timestamp":1>
(10 rows)

Query 20251022_215732_00010_fizjr, FINISHED, 1 node
Splits: 2 total, 2 done (100.00%)
[Latency: client-side: 137ms, server-side: 111ms] [10 rows, 0B] [90 rows/s, 0B/s]
```

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a scalar function to extract JSON string data from CLP-compressed columns in Presto queries.

* **Improvements**
  * Improved query rewrite and optimization logic for CLP functions, including better handling of projections and push-downs to improve performance of JSON string retrieval.

* **Tests**
  * Updated and added tests covering JSON string handling and CLP query optimization scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->