### PR TITLE
fix: Rewrite CLP UDFs across full plan tree

### DIFF
--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/TestClpUdfRewriter.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/TestClpUdfRewriter.java
@@ -274,7 +274,7 @@ public class TestClpUdfRewriter
 
         Plan plan = localQueryRunner.createPlan(
                 session,
-                "SELECT CLP_GET_JSON_STRING() from test WHERE CLP_GET_BIGINT('user_id') = 0",
+                "SELECT CLP_GET_JSON_STRING() from test WHERE CLP_GET_BIGINT('user_id') = 0 ORDER BY fare",
                 WarningCollector.NOOP);
         ClpUdfRewriter udfRewriter = new ClpUdfRewriter(functionAndTypeManager);
         PlanNode optimizedPlan = udfRewriter.optimize(plan.getRoot(), session.toConnectorSession(), variableAllocator, planNodeIdAllocator);
@@ -294,6 +294,7 @@ public class TestClpUdfRewriter
                                 ClpTableScanMatcher.clpTableScanPattern(
                                         new ClpTableLayoutHandle(table, Optional.of("user_id: 0"), Optional.empty()),
                                         ImmutableSet.of(
+                                                fare,
                                                 new ClpColumnHandle("user_id", BIGINT),
                                                 new ClpColumnHandle(JSON_STRING_PLACEHOLDER, VARCHAR))))));
     }


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This change refactors the CLP UDF rewriting logic to ensure that all relevant plan nodes are correctly processed during query plan rewriting.

## Background

Previously, only the top-level `ProjectNode` was visited by the rewriter. In complex queries that involves distributed execution
```sql
select to_unixtime(from_iso8601_timestamp(timestamp)), clp_get_json_string() from default where to_unixtime(from_iso8601_timestamp(timestamp)) > 0 order by timestamp limit 10
```
The plan looks like
```
Output → Project → Exchange → Sort → Exchange → Project → Filter → TableScan
```

the second `ProjectNode` was skipped, resulting in incomplete CLP UDF rewrites.

## Changes

+ Replaced manual recursion (`rewritePlanSubtree`) with a proper `ConnectorPlanRewriter` visitor traversal.
+ Implemented `visitFilter`, and `visitTableScan` to rewrite expressions and propagate new variable mappings.
+ Removed unnecessary custom subtree traversal logic.



# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
+ A unit test was modified to generate a distributed plan that could trigger the error before.
+ End-to-end tests have been performed.


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal query plan rewriting logic using visitor pattern traversal for improved code structure and maintainability.

* **Tests**
  * Updated test cases to align with changes in query plan handling and column projection logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->