### PR TITLE
refactor: Make Pinot query endpoint URL construction overridable

### DIFF
--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/UberClpPinotSplitProvider.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/UberClpPinotSplitProvider.java
@@ -1,0 +1,45 @@
+package com.facebook.presto.plugin.clp.split;
+
+import com.facebook.presto.plugin.clp.ClpConfig;
+
+import javax.inject.Inject;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+/**
+ * Uber-specific implementation of CLP Pinot split provider.
+ * <p>
+ * At Uber, Pinot is accessed through Neutrino, a cross-region routing and aggregation service
+ * that provides a unified interface for querying distributed Pinot clusters. This implementation
+ * customizes the SQL query endpoint URL to use Neutrino's global statements API instead of
+ * the standard Pinot query endpoint.
+ * </p>
+ */
+public class UberClpPinotSplitProvider extends ClpPinotSplitProvider {
+    /**
+     * Constructs an Uber CLP Pinot split provider with the given configuration.
+     *
+     * @param config the CLP configuration
+     */
+    @Inject
+    public UberClpPinotSplitProvider(ClpConfig config) {
+        super(config);
+    }
+
+    /**
+     * Constructs the Neutrino SQL query endpoint URL for Uber's Pinot infrastructure.
+     * <p>
+     * Instead of using Pinot's standard {@code /query/sql} endpoint, this method constructs
+     * a URL pointing to Neutrino's {@code /v1/globalStatements} endpoint, which provides
+     * cross-region query routing and aggregation capabilities.
+     * </p>
+     *
+     * @param config the CLP configuration containing the base Neutrino service URL
+     * @return the Neutrino global statements endpoint URL
+     * @throws MalformedURLException if the constructed URL is invalid
+     */
+    @Override
+    protected URL buildPinotSqlQueryEndpointUrl(ClpConfig config) throws MalformedURLException {
+        return new URL(config.getMetadataDbUrl() + "/v1/globalStatements");
+    }
+}


### PR DESCRIPTION
# Description
Refactors `ClpPinotSplitProvider` to make Pinot SQL query endpoint URL construction overridable, enabling organizations with custom Pinot infrastructure (e.g., Uber's Neutrino) to easily integrate without modifying core logic.

## Motivation
Previously, the Pinot query endpoint URL was hardcoded in the constructor, making it difficult for organizations with custom Pinot infrastructure to integrate. This change introduces an extensibility point that allows subclasses to override URL construction without duplicating the entire split provider logic.

## Changes
- Extract `buildPinotSqlQueryEndpointUrl()` as protected method in `ClpPinotSplitProvider`
- Rename `pinotDatabaseUrl` to `pinotSqlQueryEndpointUrl` for improved clarity
- Add `UberClpPinotSplitProvider` example implementation using Neutrino's `/v1/globalStatements` endpoint
- Add comprehensive Javadoc documentation for extensibility

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.


<!-- Describe what tests and validation you performed on the change. -->



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
