### PR TITLE
Update workflows to use organization self-hosted runners

### DIFF
--- a/.github/workflows/prestissimo-worker-images-build.yml
+++ b/.github/workflows/prestissimo-worker-images-build.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   prestissimo-worker-images-build:
     name: "prestissimo-worker-images-build"
-    runs-on: "ubuntu-22.04"
+    runs-on: y-scope/Default
     steps:
       - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"
         with:

--- a/.github/workflows/prestocpp-format-and-header-check.yml
+++ b/.github/workflows/prestocpp-format-and-header-check.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   prestocpp-format-and-header-check:
-    runs-on: ubuntu-latest
+    runs-on: y-scope/Default
     container:
       image: public.ecr.aws/oss-presto/velox-dev:check
     steps:

--- a/.github/workflows/prestocpp-linux-build-and-unit-test.yml
+++ b/.github/workflows/prestocpp-linux-build-and-unit-test.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   prestocpp-linux-build-for-test:
-    runs-on: ubuntu-22.04
+    runs-on: y-scope/Default
     container:
       image: prestodb/presto-native-dependency:0.293-20250522140509-484b00e
     env:
@@ -97,7 +97,7 @@ jobs:
 
   prestocpp-linux-presto-e2e-tests:
     needs: prestocpp-linux-build-for-test
-    runs-on: ubuntu-22.04
+    runs-on: y-scope/Default
     container:
       image: prestodb/presto-native-dependency:0.293-20250522140509-484b00e
     env:
@@ -172,7 +172,7 @@ jobs:
 
   prestocpp-linux-presto-native-tests:
     needs: prestocpp-linux-build-for-test
-    runs-on: ubuntu-22.04
+    runs-on: y-scope/Default
     strategy:
       fail-fast: false
       matrix:
@@ -248,7 +248,7 @@ jobs:
 
   prestocpp-linux-presto-sidecar-tests:
     needs: prestocpp-linux-build-for-test
-    runs-on: ubuntu-22.04
+    runs-on: y-scope/Default
     container:
       image: prestodb/presto-native-dependency:0.293-20250522140509-484b00e
     env:


### PR DESCRIPTION
## Summary

This PR updates GitHub Actions workflows to use the organization's self-hosted runners instead of GitHub-hosted runners.

## Changes

Changed `runs-on` configuration in three workflow files:
- **prestocpp-linux-build-and-unit-test.yml** (all 4 jobs)
- **prestissimo-worker-images-build.yml**
- **prestocpp-format-and-header-check.yml**

From: `ubuntu-22.04` / `ubuntu-latest`  
To: `y-scope/Default`

## Benefits

- ✅ Workflows run on self-hosted infrastructure (baker1, baker2, baker4, baker7 machines)
- ✅ Forks can use organization runners via the Default runner group
- ✅ Better resource utilization across multiple machines with 8-core and 16-core options
- ✅ No changes to workflow logic or behavior

## Infrastructure

The organization runners are managed by Actions Runner Controller (ARC) in Kubernetes clusters on baker machines:
- Baker2: 16-core runners
- Baker7: 8-core runners
- Baker1: 16-core runners
- Baker4: 16-core runners

All runners are auto-scaling (min: 0, max: 4) and use ephemeral runners for security.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration infrastructure configurations to use optimized runner environments across multiple build workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->