### PR TITLE
Fix runner group syntax in workflows

### DIFF
--- a/.github/workflows/prestissimo-worker-images-build.yml
+++ b/.github/workflows/prestissimo-worker-images-build.yml
@@ -7,7 +7,8 @@ on:
 jobs:
   prestissimo-worker-images-build:
     name: "prestissimo-worker-images-build"
-    runs-on: y-scope/Default
+    runs-on:
+      group: Default
     steps:
       - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"
         with:

--- a/.github/workflows/prestocpp-format-and-header-check.yml
+++ b/.github/workflows/prestocpp-format-and-header-check.yml
@@ -20,7 +20,8 @@ concurrency:
 
 jobs:
   prestocpp-format-and-header-check:
-    runs-on: y-scope/Default
+    runs-on:
+      group: Default
     container:
       image: public.ecr.aws/oss-presto/velox-dev:check
     steps:

--- a/.github/workflows/prestocpp-linux-build-and-unit-test.yml
+++ b/.github/workflows/prestocpp-linux-build-and-unit-test.yml
@@ -20,7 +20,8 @@ concurrency:
 
 jobs:
   prestocpp-linux-build-for-test:
-    runs-on: y-scope/Default
+    runs-on:
+      group: Default
     container:
       image: prestodb/presto-native-dependency:0.293-20250522140509-484b00e
     env:
@@ -97,7 +98,8 @@ jobs:
 
   prestocpp-linux-presto-e2e-tests:
     needs: prestocpp-linux-build-for-test
-    runs-on: y-scope/Default
+    runs-on:
+      group: Default
     container:
       image: prestodb/presto-native-dependency:0.293-20250522140509-484b00e
     env:
@@ -172,7 +174,8 @@ jobs:
 
   prestocpp-linux-presto-native-tests:
     needs: prestocpp-linux-build-for-test
-    runs-on: y-scope/Default
+    runs-on:
+      group: Default
     strategy:
       fail-fast: false
       matrix:
@@ -248,7 +251,8 @@ jobs:
 
   prestocpp-linux-presto-sidecar-tests:
     needs: prestocpp-linux-build-for-test
-    runs-on: y-scope/Default
+    runs-on:
+      group: Default
     container:
       image: prestodb/presto-native-dependency:0.293-20250522140509-484b00e
     env:


### PR DESCRIPTION
## Summary

This PR fixes the runner group syntax in GitHub Actions workflows. The previous PR (#93) used incorrect syntax that prevented the workflows from matching the self-hosted runners.

## The Issue

The previous syntax was:
```yaml
runs-on: y-scope/Default
```

This syntax is invalid for runner groups. GitHub Actions does not support `org-name/group-name` format.

## The Fix

Changed to the correct GitHub Actions runner group syntax:
```yaml
runs-on:
  group: Default
```

## Documentation Reference

From [GitHub Actions documentation](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/using-self-hosted-runners-in-a-workflow#using-groups-to-control-where-jobs-are-run):

> To specify a runner group, use `runs-on` with the `group` key

## Updated Workflows

- **prestocpp-linux-build-and-unit-test.yml** (all 4 jobs)
- **prestissimo-worker-images-build.yml**
- **prestocpp-format-and-header-check.yml**

## Testing

With this fix, workflows will correctly target the "Default" runner group where all organization self-hosted runners (baker1, baker2, baker4, baker7) are registered.

## Fork Support

This works for forks when the organization's runner group settings allow fork access.