### PR TITLE
Test: Verify ARC runners are working

### DIFF
--- a/.github/workflows/prestissimo-worker-images-build.yml
+++ b/.github/workflows/prestissimo-worker-images-build.yml
@@ -7,7 +7,8 @@ on:
 jobs:
   prestissimo-worker-images-build:
     name: "prestissimo-worker-images-build"
-    runs-on: y-scope/Default
+    runs-on:
+      group: Default
     steps:
       - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"
         with:

--- a/.github/workflows/prestissimo-worker-images-build.yml
+++ b/.github/workflows/prestissimo-worker-images-build.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   prestissimo-worker-images-build:
     name: "prestissimo-worker-images-build"
-    runs-on: "ubuntu-22.04"
+    runs-on: y-scope/Default
     steps:
       - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"
         with:

--- a/.github/workflows/prestocpp-format-and-header-check.yml
+++ b/.github/workflows/prestocpp-format-and-header-check.yml
@@ -20,7 +20,8 @@ concurrency:
 
 jobs:
   prestocpp-format-and-header-check:
-    runs-on: y-scope/Default
+    runs-on:
+      group: Default
     container:
       image: public.ecr.aws/oss-presto/velox-dev:check
     steps:

--- a/.github/workflows/prestocpp-format-and-header-check.yml
+++ b/.github/workflows/prestocpp-format-and-header-check.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   prestocpp-format-and-header-check:
-    runs-on: ubuntu-latest
+    runs-on: y-scope/Default
     container:
       image: public.ecr.aws/oss-presto/velox-dev:check
     steps:

--- a/.github/workflows/prestocpp-linux-build-and-unit-test.yml
+++ b/.github/workflows/prestocpp-linux-build-and-unit-test.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   prestocpp-linux-build-for-test:
-    runs-on: ubuntu-22.04
+    runs-on: y-scope/Default
     container:
       image: prestodb/presto-native-dependency:0.293-20250522140509-484b00e
     env:
@@ -97,7 +97,7 @@ jobs:
 
   prestocpp-linux-presto-e2e-tests:
     needs: prestocpp-linux-build-for-test
-    runs-on: ubuntu-22.04
+    runs-on: y-scope/Default
     container:
       image: prestodb/presto-native-dependency:0.293-20250522140509-484b00e
     env:
@@ -172,7 +172,7 @@ jobs:
 
   prestocpp-linux-presto-native-tests:
     needs: prestocpp-linux-build-for-test
-    runs-on: ubuntu-22.04
+    runs-on: y-scope/Default
     strategy:
       fail-fast: false
       matrix:
@@ -248,7 +248,7 @@ jobs:
 
   prestocpp-linux-presto-sidecar-tests:
     needs: prestocpp-linux-build-for-test
-    runs-on: ubuntu-22.04
+    runs-on: y-scope/Default
     container:
       image: prestodb/presto-native-dependency:0.293-20250522140509-484b00e
     env:

--- a/.github/workflows/prestocpp-linux-build-and-unit-test.yml
+++ b/.github/workflows/prestocpp-linux-build-and-unit-test.yml
@@ -20,7 +20,8 @@ concurrency:
 
 jobs:
   prestocpp-linux-build-for-test:
-    runs-on: y-scope/Default
+    runs-on:
+      group: Default
     container:
       image: prestodb/presto-native-dependency:0.293-20250522140509-484b00e
     env:
@@ -97,7 +98,8 @@ jobs:
 
   prestocpp-linux-presto-e2e-tests:
     needs: prestocpp-linux-build-for-test
-    runs-on: y-scope/Default
+    runs-on:
+      group: Default
     container:
       image: prestodb/presto-native-dependency:0.293-20250522140509-484b00e
     env:
@@ -172,7 +174,8 @@ jobs:
 
   prestocpp-linux-presto-native-tests:
     needs: prestocpp-linux-build-for-test
-    runs-on: y-scope/Default
+    runs-on:
+      group: Default
     strategy:
       fail-fast: false
       matrix:
@@ -248,7 +251,8 @@ jobs:
 
   prestocpp-linux-presto-sidecar-tests:
     needs: prestocpp-linux-build-for-test
-    runs-on: y-scope/Default
+    runs-on:
+      group: Default
     container:
       image: prestodb/presto-native-dependency:0.293-20250522140509-484b00e
     env:

--- a/README.md
+++ b/README.md
@@ -137,3 +137,4 @@ Please refer to the [contribution guidelines](https://github.com/prestodb/presto
 
 By contributing to Presto, you agree that your contributions will be licensed under the [Apache License Version 2.0 (APLv2)](LICENSE).
 
+


### PR DESCRIPTION
## Summary

This is a test PR to verify that the self-hosted Actions Runner Controller (ARC) runners are properly configured and picking up jobs.

## Expected Behavior

With PR #95 merged, workflows should now use the correct runner group syntax:
```yaml
runs-on:
  group: Default
```

This PR should trigger workflows that will be picked up by one of the baker machines:
- Baker2 (16-core)
- Baker7 (8-core)
- Baker1 (16-core)
- Baker4 (16-core)

## Test

This PR makes a trivial change (adding a blank line to README.md) to trigger the CI workflows.

**DO NOT MERGE** - This is a test PR only.