### PR TITLE
Migrate maven-checks workflow to use self-hosted runners

### DIFF
--- a/.github/workflows/maven-checks.yml
+++ b/.github/workflows/maven-checks.yml
@@ -24,7 +24,8 @@ jobs:
       fail-fast: false
       matrix:
         java: [ 8.0.442, 17.0.13 ]
-    runs-on: ubuntu-latest
+    runs-on:
+      group: Default
     timeout-minutes: 45
     steps:
       - name: Free Disk Space
@@ -68,7 +69,8 @@ jobs:
   presto-coordinator-image:
     name: "presto-coordinator-image"
     needs: "maven-checks"
-    runs-on: "ubuntu-22.04"
+    runs-on:
+      group: Default
     steps:
       - uses: "actions/checkout@v4"
         with:


### PR DESCRIPTION
## Summary

This PR migrates the `maven-checks` workflow to use organization self-hosted runners instead of GitHub-hosted runners.

## Changes

Updated both jobs in `maven-checks.yml`:

1. **maven-checks** (Java 8.0.442 and 17.0.13 matrix builds)
   - From: `runs-on: ubuntu-latest`
   - To: `runs-on: { group: Default }`

2. **presto-coordinator-image** (Docker image build)
   - From: `runs-on: ubuntu-22.04`
   - To: `runs-on: { group: Default }`

## Benefits

- ✅ Workflows run on self-hosted infrastructure (baker1, baker2, baker4, baker7)
- ✅ Consistent with other workflows (prestocpp-linux-build-and-unit-test, prestissimo-worker-images-build, etc.)
- ✅ Better resource utilization across organization-managed machines
- ✅ No changes to workflow logic or behavior

## Infrastructure

The workflows will run on the Default runner group containing:
- Baker2: 16-core runners
- Baker7: 8-core runners
- Baker1: 16-core runners
- Baker4: 16-core runners

All runners auto-scale based on demand.