### PR TITLE
ci: add fork PR approval for builder image builds

### DIFF
--- a/.github/workflows/create-builder-image.yml
+++ b/.github/workflows/create-builder-image.yml
@@ -13,6 +13,20 @@ name: create-builder-image
 #
 # Building this image takes ~1 hour, but we only do it when dependencies change.
 # Most CI runs will skip this step because the image already exists.
+#
+# Fork PR Handling:
+# -----------------
+# Fork PRs have restricted permissions and cannot push to ghcr.io by default.
+# To handle this securely:
+# 1. check-builder-image: Fast job to check if image exists (no special permissions)
+# 2. build-builder-image: Only runs if image doesn't exist
+#    - For fork PRs: Requires manual approval via "builder-image" environment
+#    - For same-repo PRs/pushes: Runs automatically
+#
+# Setup Required:
+# 1. Create GitHub Environment "builder-image" in repo settings
+# 2. Add required reviewers to that environment
+# 3. This ensures fork PRs that change dependencies get maintainer review
 
 on:
   workflow_call:
@@ -23,22 +37,77 @@ on:
         type: string
 
 jobs:
-  create-builder-image:
-    name: "create-builder-image"
-    # Use self-hosted runner with 32 cores for faster builds
-    # The [self-hosted, cores=32] syntax is a label filter - it selects runners with both labels
+  # ---------------------------------------------------------------------------
+  # Job 1: Check if builder image exists (fast, no approval needed)
+  # ---------------------------------------------------------------------------
+  check-builder-image:
+    name: "check-builder-image"
+    runs-on: ubuntu-latest
+    outputs:
+      exists: ${{ steps.check-image.outputs.exists }}
+      is-fork: ${{ steps.check-fork.outputs.is-fork }}
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check if builder image exists
+        id: check-image
+        run: |
+          IMAGE_TAG="${{ inputs.builder-image }}"
+          if docker manifest inspect $IMAGE_TAG > /dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "Builder image already exists: $IMAGE_TAG"
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "Builder image does not exist: $IMAGE_TAG"
+          fi
+
+      - name: Check if PR is from fork
+        id: check-fork
+        run: |
+          # For pull_request events, check if head repo differs from base repo
+          # For push events, this is always false (same repo)
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            HEAD_REPO="${{ github.event.pull_request.head.repo.full_name }}"
+            BASE_REPO="${{ github.repository }}"
+            if [[ "$HEAD_REPO" != "$BASE_REPO" ]]; then
+              echo "is-fork=true" >> $GITHUB_OUTPUT
+              echo "PR is from fork: $HEAD_REPO"
+            else
+              echo "is-fork=false" >> $GITHUB_OUTPUT
+              echo "PR is from same repo"
+            fi
+          else
+            echo "is-fork=false" >> $GITHUB_OUTPUT
+            echo "Not a pull_request event"
+          fi
+
+  # ---------------------------------------------------------------------------
+  # Job 2: Build and push builder image (only if doesn't exist)
+  # ---------------------------------------------------------------------------
+  build-builder-image:
+    name: "build-builder-image"
+    needs: check-builder-image
+    # Only run if image doesn't exist
+    if: needs.check-builder-image.outputs.exists == 'false'
+    # For fork PRs, require approval via "builder-image" environment
+    # For same-repo, no environment (runs automatically)
+    # NOTE: Create "builder-image" environment in GitHub repo settings with required reviewers
+    environment: ${{ needs.check-builder-image.outputs.is-fork == 'true' && 'builder-image' || '' }}
     runs-on: [self-hosted, cores=32]
     timeout-minutes: 180
-    # Concurrency control: If two workflows try to build the same image simultaneously,
-    # only one will run. The second will wait (cancel-in-progress: false means don't cancel).
-    # This prevents duplicate builds of the same image.
+    # Concurrency control: prevent duplicate builds of the same image
     concurrency:
       group: ${{ inputs.builder-image }}
       cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: recursive  # Also checkout velox submodule (needed for build)
+          submodules: recursive
           show-progress: false
 
       - name: Login to GitHub Container Registry
@@ -49,31 +118,14 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        # Buildx is Docker's extended build tool with better caching and multi-platform support
         uses: docker/setup-buildx-action@v3
 
-      - name: Check if builder image exists
-        id: check-image
-        run: |
-          # Check if the image already exists in the registry
-          # docker manifest inspect queries the registry without pulling the image
-          IMAGE_TAG="${{ inputs.builder-image }}"
-          if docker manifest inspect $IMAGE_TAG > /dev/null 2>&1; then
-            echo "exists=true" >> $GITHUB_OUTPUT
-            echo "Builder image already exists: $IMAGE_TAG"
-          else
-            echo "exists=false" >> $GITHUB_OUTPUT
-            echo "Builder image does not exist: $IMAGE_TAG"
-          fi
-
       - name: Build and push unified builder image
-        # Only build if image doesn't exist (skip if cached)
-        if: steps.check-image.outputs.exists == 'false'
         uses: docker/build-push-action@v6
         with:
-          context: .  # Build context is the entire repo (needed for setup scripts)
+          context: .
           file: ./.github/dockerfiles/yscope-presto-builder.dockerfile
-          push: true  # Push to ghcr.io after building
+          push: true
           tags: ${{ inputs.builder-image }}
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}


### PR DESCRIPTION
## Summary

Split `create-builder-image` into two jobs to securely handle fork PRs that need to build new builder images.

## Problem

Fork PRs cannot push to ghcr.io due to GitHub Actions permission restrictions. When a fork PR changes dependencies (rare), the builder image doesn't exist and the CI fails with:

```
denied: installation not allowed to Write organization package
```

## Solution

Split into two jobs with conditional approval:

| Job | Runs on | Purpose | Approval |
|-----|---------|---------|----------|
| `check-builder-image` | `ubuntu-latest` | Check if image exists, detect forks | Never |
| `build-builder-image` | `self-hosted` | Build & push image | Fork PRs only |

### How it works

```
Fork PR (dependencies unchanged):
  check-builder-image → image exists → DONE (no approval needed)

Fork PR (dependencies changed):
  check-builder-image → image missing → build-builder-image (⏸️ WAITING FOR APPROVAL)

Same-repo PR/push:
  check-builder-image → build-builder-image (runs automatically if needed)
```

## Setup Required

1. Go to **y-scope/presto** → **Settings** → **Environments**
2. Click **New environment**, name it `builder-image`
3. Add **Required reviewers** (maintainers who should approve fork PR builds)

## Test Plan
- [x] Fork [PR](sample run: https://github.com/y-scope/presto/actions/runs/19808952528) with new image: CI waits for approval before building - can only be completed after this PR is merged
<img width="1716" height="1187" alt="image" src="https://github.com/user-attachments/assets/0696def4-b06e-4a3f-9eaf-0a5d49dec230" />
<img width="1723" height="1200" alt="image" src="https://github.com/user-attachments/assets/4075ecd4-1ddc-46b1-bf64-cf7de8eb461d" />
<img width="1717" height="1175" alt="image" src="https://github.com/user-attachments/assets/c458b5f9-9a23-4206-94c7-12b60f4c717c" />

