### PR TITLE
test: fork PR to test builder image approval workflow

### DIFF
--- a/presto-clp/pom.xml
+++ b/presto-clp/pom.xml
@@ -19,6 +19,19 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.msgpack</groupId>
+            <artifactId>msgpack-core</artifactId>
+            <version>0.9.8</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>4.6.1</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
             <scope>runtime</scope>


### PR DESCRIPTION
## Purpose

This is a test PR from a fork to verify the builder image approval workflow works correctly.

## What this tests

1. This PR adds new Maven dependencies to `presto-clp/pom.xml`
2. This changes the POM hash, triggering a new builder image build
3. Since this is a fork PR, it should require approval via the `builder-image` environment

## Expected behavior

- `check-builder-image` job should run and detect:
  - Image does not exist (new hash)
  - PR is from a fork
- `build-builder-image` job should wait for approval

## Cleanup

Delete this PR after testing.