### PR TITLE
fix(ci): fail early for fork PRs needing new builder image

### DIFF
--- a/.github/workflows/create-builder-image.yml
+++ b/.github/workflows/create-builder-image.yml
@@ -13,6 +13,20 @@ name: create-builder-image
 #
 # Building this image takes ~1 hour, but we only do it when dependencies change.
 # Most CI runs will skip this step because the image already exists.
+#
+# Fork PR Handling:
+# -----------------
+# Fork PRs have restricted permissions and cannot push to ghcr.io by default.
+# To handle this securely:
+# 1. check-builder-image: Fast job to check if image exists (no special permissions)
+# 2. build-builder-image: Only runs if image doesn't exist
+#    - For fork PRs: Requires manual approval via "builder-image" environment
+#    - For same-repo PRs/pushes: Runs automatically
+#
+# Setup Required:
+# 1. Create GitHub Environment "builder-image" in repo settings
+# 2. Add required reviewers to that environment
+# 3. This ensures fork PRs that change dependencies get maintainer review
 
 on:
   workflow_call:
@@ -23,22 +37,77 @@ on:
         type: string
 
 jobs:
-  create-builder-image:
-    name: "create-builder-image"
-    # Use self-hosted runner with 32 cores for faster builds
-    # The [self-hosted, cores=32] syntax is a label filter - it selects runners with both labels
+  # ---------------------------------------------------------------------------
+  # Job 1: Check if builder image exists (fast, no approval needed)
+  # ---------------------------------------------------------------------------
+  check-builder-image:
+    name: "check-builder-image"
+    runs-on: ubuntu-latest
+    outputs:
+      exists: ${{ steps.check-image.outputs.exists }}
+      is-fork: ${{ steps.check-fork.outputs.is-fork }}
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check if builder image exists
+        id: check-image
+        run: |
+          IMAGE_TAG="${{ inputs.builder-image }}"
+          if docker manifest inspect $IMAGE_TAG > /dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "Builder image already exists: $IMAGE_TAG"
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "Builder image does not exist: $IMAGE_TAG"
+          fi
+
+      - name: Check if PR is from fork
+        id: check-fork
+        run: |
+          # For pull_request events, check if head repo differs from base repo
+          # For push events, this is always false (same repo)
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            HEAD_REPO="${{ github.event.pull_request.head.repo.full_name }}"
+            BASE_REPO="${{ github.repository }}"
+            if [[ "$HEAD_REPO" != "$BASE_REPO" ]]; then
+              echo "is-fork=true" >> $GITHUB_OUTPUT
+              echo "PR is from fork: $HEAD_REPO"
+            else
+              echo "is-fork=false" >> $GITHUB_OUTPUT
+              echo "PR is from same repo"
+            fi
+          else
+            echo "is-fork=false" >> $GITHUB_OUTPUT
+            echo "Not a pull_request event"
+          fi
+
+  # ---------------------------------------------------------------------------
+  # Job 2: Build and push builder image (only if doesn't exist)
+  # ---------------------------------------------------------------------------
+  build-builder-image:
+    name: "build-builder-image"
+    needs: check-builder-image
+    # Only run if image doesn't exist
+    if: needs.check-builder-image.outputs.exists == 'false'
+    # For fork PRs, require approval via "builder-image" environment
+    # For same-repo, no environment (runs automatically)
+    # NOTE: Create "builder-image" environment in GitHub repo settings with required reviewers
+    environment: ${{ needs.check-builder-image.outputs.is-fork == 'true' && 'builder-image' || '' }}
     runs-on: [self-hosted, cores=32]
     timeout-minutes: 180
-    # Concurrency control: If two workflows try to build the same image simultaneously,
-    # only one will run. The second will wait (cancel-in-progress: false means don't cancel).
-    # This prevents duplicate builds of the same image.
+    # Concurrency control: prevent duplicate builds of the same image
     concurrency:
       group: ${{ inputs.builder-image }}
       cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: recursive  # Also checkout velox submodule (needed for build)
+          submodules: recursive
           show-progress: false
 
       - name: Login to GitHub Container Registry
@@ -49,31 +118,14 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        # Buildx is Docker's extended build tool with better caching and multi-platform support
         uses: docker/setup-buildx-action@v3
 
-      - name: Check if builder image exists
-        id: check-image
-        run: |
-          # Check if the image already exists in the registry
-          # docker manifest inspect queries the registry without pulling the image
-          IMAGE_TAG="${{ inputs.builder-image }}"
-          if docker manifest inspect $IMAGE_TAG > /dev/null 2>&1; then
-            echo "exists=true" >> $GITHUB_OUTPUT
-            echo "Builder image already exists: $IMAGE_TAG"
-          else
-            echo "exists=false" >> $GITHUB_OUTPUT
-            echo "Builder image does not exist: $IMAGE_TAG"
-          fi
-
       - name: Build and push unified builder image
-        # Only build if image doesn't exist (skip if cached)
-        if: steps.check-image.outputs.exists == 'false'
         uses: docker/build-push-action@v6
         with:
-          context: .  # Build context is the entire repo (needed for setup scripts)
+          context: .
           file: ./.github/dockerfiles/yscope-presto-builder.dockerfile
-          push: true  # Push to ghcr.io after building
+          push: true
           tags: ${{ inputs.builder-image }}
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}

--- a/.github/workflows/create-builder-image.yml
+++ b/.github/workflows/create-builder-image.yml
@@ -16,17 +16,28 @@ name: create-builder-image
 #
 # Fork PR Handling:
 # -----------------
-# Fork PRs have restricted permissions and cannot push to ghcr.io by default.
-# To handle this securely:
-# 1. check-builder-image: Fast job to check if image exists (no special permissions)
-# 2. build-builder-image: Only runs if image doesn't exist
-#    - For fork PRs: Requires manual approval via "builder-image" environment
-#    - For same-repo PRs/pushes: Runs automatically
+# Fork PRs cannot push to ghcr.io because GitHub restricts GITHUB_TOKEN to
+# read-only for fork PRs (security measure to prevent malicious forks from
+# pushing artifacts).
 #
-# Setup Required:
-# 1. Create GitHub Environment "builder-image" in repo settings
-# 2. Add required reviewers to that environment
-# 3. This ensures fork PRs that change dependencies get maintainer review
+# References:
+# - GitHub Docs - fork PRs use "GITHUB_TOKEN with read-only permission":
+#   https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository
+# - GitHub Docs - "typically you can't grant write access" to forks:
+#   https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
+# - Upstream prestodb/presto uses pinned dependency images built out-of-band:
+#   https://github.com/prestodb/presto/blob/master/presto-native-execution/scripts/dockerfiles/README.md
+#
+# When a fork PR requires a new builder image (dependencies changed):
+#
+# For y-scope members:
+#   Submit from a branch on y-scope/presto directly (not from a fork).
+#
+# For external contributors:
+#   1. Create a separate PR containing ONLY the dependency changes
+#   2. Ask a y-scope maintainer to review and merge that dependency-only PR
+#   3. Wait for the merge commit to build and push the new builder image
+#   4. Re-run CI on your original PR - it will now find the image and proceed
 
 on:
   workflow_call:
@@ -38,14 +49,13 @@ on:
 
 jobs:
   # ---------------------------------------------------------------------------
-  # Job 1: Check if builder image exists (fast, no approval needed)
+  # Check if builder image exists and handle fork PRs
   # ---------------------------------------------------------------------------
   check-builder-image:
     name: "check-builder-image"
     runs-on: ubuntu-latest
     outputs:
       exists: ${{ steps.check-image.outputs.exists }}
-      is-fork: ${{ steps.check-fork.outputs.is-fork }}
     steps:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -66,38 +76,55 @@ jobs:
             echo "Builder image does not exist: $IMAGE_TAG"
           fi
 
-      - name: Check if PR is from fork
-        id: check-fork
+      # Fail early with clear instructions if fork PR needs a new builder image
+      - name: Fail if fork PR needs new builder image
+        if: steps.check-image.outputs.exists == 'false'
         run: |
-          # For pull_request events, check if head repo differs from base repo
-          # For push events, this is always false (same repo)
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             HEAD_REPO="${{ github.event.pull_request.head.repo.full_name }}"
             BASE_REPO="${{ github.repository }}"
             if [[ "$HEAD_REPO" != "$BASE_REPO" ]]; then
-              echo "is-fork=true" >> $GITHUB_OUTPUT
-              echo "PR is from fork: $HEAD_REPO"
-            else
-              echo "is-fork=false" >> $GITHUB_OUTPUT
-              echo "PR is from same repo"
+              echo "::error::Builder image does not exist and cannot be built from fork PRs."
+              echo ""
+              echo "========================================================================"
+              echo "FORK PR: New builder image required"
+              echo "========================================================================"
+              echo ""
+              echo "This PR requires a new builder image that does not exist:"
+              echo "  ${{ inputs.builder-image }}"
+              echo ""
+              echo "Fork PRs cannot push to ghcr.io (GITHUB_TOKEN is read-only for forks)."
+              echo ""
+              echo "HOW TO RESOLVE:"
+              echo ""
+              echo "  For y-scope members:"
+              echo "    Submit from a branch on y-scope/presto directly (not from a fork)."
+              echo ""
+              echo "  For external contributors:"
+              echo "    1. Create a separate PR containing ONLY the dependency changes"
+              echo "    2. Ask a y-scope maintainer to review and merge that PR"
+              echo "    3. Wait for the merge to build the new builder image (~1 hour)"
+              echo "    4. Re-run CI on your original PR - it will now find the image"
+              echo ""
+              echo "REFERENCES:"
+              echo "  - GitHub Docs on fork PR permissions:"
+              echo "    https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs"
+              echo "  - Upstream prestodb/presto uses the same approach:"
+              echo "    https://github.com/prestodb/presto/blob/master/presto-native-execution/scripts/dockerfiles/README.md"
+              echo ""
+              echo "========================================================================"
+              exit 1
             fi
-          else
-            echo "is-fork=false" >> $GITHUB_OUTPUT
-            echo "Not a pull_request event"
           fi
+          echo "Not a fork PR, proceeding to build image..."
 
   # ---------------------------------------------------------------------------
-  # Job 2: Build and push builder image (only if doesn't exist)
+  # Build and push builder image (only for same-repo PRs/pushes when needed)
   # ---------------------------------------------------------------------------
   build-builder-image:
     name: "build-builder-image"
     needs: check-builder-image
-    # Only run if image doesn't exist
     if: needs.check-builder-image.outputs.exists == 'false'
-    # For fork PRs, require approval via "builder-image" environment
-    # For same-repo, no environment (runs automatically)
-    # NOTE: Create "builder-image" environment in GitHub repo settings with required reviewers
-    environment: ${{ needs.check-builder-image.outputs.is-fork == 'true' && 'builder-image' || '' }}
     runs-on: [self-hosted, cores=32]
     timeout-minutes: 180
     # Concurrency control: prevent duplicate builds of the same image


### PR DESCRIPTION
## Summary

Fixes https://github.com/y-scope/presto/pull/115 - the environment-based approval approach didn't work after testing.

The environment-based approval failed because GitHub Actions doesn't grant write permissions to fork PRs even after environment approval - `GITHUB_TOKEN` remains read-only for security reasons.

## Changes

Replace environment-based approval with a **fail-early approach** that provides clear instructions:

- **For y-scope members**: Submit from a branch on y-scope/presto directly
- **For external contributors**: 
  1. Create a separate PR with only dependency changes
  2. Ask a maintainer to merge it (builds the image)
  3. Re-run CI on original PR

This follows the same approach used by upstream prestodb/presto.

## References

- GitHub Docs - fork PRs use read-only GITHUB_TOKEN: https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
- Upstream prestodb/presto builds dependency images out-of-band: https://github.com/prestodb/presto/blob/master/presto-native-execution/scripts/dockerfiles/README.md

## Test Plan

- [x] Fork PR (#116) will now fail at `check-builder-image` with clear instructions instead of failing at Docker push with permission denied