### PR TITLE
fix: Add VARCHAR support in push down

### DIFF
--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpFilterToKqlConverter.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpFilterToKqlConverter.java
@@ -111,6 +111,9 @@ public class ClpFilterToKqlConverter
     private static final Set<OperatorType> LOGICAL_BINARY_OPS_FILTER =
             ImmutableSet.of(EQUAL, NOT_EQUAL, LESS_THAN, LESS_THAN_OR_EQUAL, GREATER_THAN, GREATER_THAN_OR_EQUAL);
 
+    private static final String KQL_BETWEEN_PREDICATE_NUMERIC_FORMAT = "%s >= %s AND %s <= %s";
+    private static final String KQL_BETWEEN_PREDICATE_STRING_FORMAT = "%s >= '%s' AND %s <= '%s'";
+
     private final StandardFunctionResolution standardFunctionResolution;
     private final FunctionMetadataManager functionMetadataManager;
     private final Map<VariableReferenceExpression, ColumnHandle> assignments;
@@ -322,12 +325,11 @@ public class ClpFilterToKqlConverter
         if (!isMetadataColumn) {
             String lowerBound = getLiteralString((ConstantExpression) lower);
             String upperBound = getLiteralString((ConstantExpression) upper);
-            if (isClpCompatibleNumericType(lhs.getType())) {
-                kql = String.format("%s >= %s AND %s <= %s", variable, lowerBound, variable, upperBound);
-            }
-            else {
-                kql = String.format("%s >= '%s' AND %s <= '%s'", variable, lowerBound, variable, upperBound);
-            }
+            String kqlPredicate = isClpCompatibleNumericType(lhs.getType()) ?
+                    KQL_BETWEEN_PREDICATE_NUMERIC_FORMAT :
+                    KQL_BETWEEN_PREDICATE_STRING_FORMAT;
+            kql = String.format(kqlPredicate, variable, lowerBound, variable, upperBound);
+
         }
 
         return new ClpExpression(kql, metadataExpr, variableExpression.getPushDownVariables());

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpFilterToKqlConverter.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpFilterToKqlConverter.java
@@ -279,22 +279,6 @@ public class ClpFilterToKqlConverter
         String variable = variableOpt.get();
         boolean isMetadataColumn = metadataFilterColumns.contains(variable);
 
-        // Type validation
-        boolean numericCompatible =
-                isClpCompatibleNumericType(lhs.getType())
-                        && isClpCompatibleNumericType(lower.getType())
-                        && isClpCompatibleNumericType(upper.getType());
-
-        if (!numericCompatible) {
-            if (isMetadataColumn) {
-                throw new PrestoException(
-                        CLP_PUSHDOWN_UNSUPPORTED_EXPRESSION,
-                        "Metadata BETWEEN requires numeric-compatible types. Received: " + node);
-            }
-            // Non-metadata columns just fallback (cannot push down)
-            return new ClpExpression(node);
-        }
-
         // Metadata columns must have constant bounds
         if (isMetadataColumn &&
                 (!(lower instanceof ConstantExpression) || !(upper instanceof ConstantExpression))) {
@@ -338,7 +322,11 @@ public class ClpFilterToKqlConverter
         if (!isMetadataColumn) {
             String lowerBound = getLiteralString((ConstantExpression) lower);
             String upperBound = getLiteralString((ConstantExpression) upper);
-            kql = String.format("%s >= %s AND %s <= %s", variable, lowerBound, variable, upperBound);
+            if (isClpCompatibleNumericType(lower.getType())) {
+                kql = String.format("%s >= %s AND %s <= %s", variable, lowerBound, variable, upperBound);
+            } else {
+                kql = String.format("%s >= '%s' AND %s <= '%s'", variable, lowerBound, variable, upperBound);
+            }
         }
 
         return new ClpExpression(kql, metadataExpr, variableExpression.getPushDownVariables());
@@ -1048,10 +1036,8 @@ public class ClpFilterToKqlConverter
     }
 
     /**
-     * Checks if the type is one of the numeric types that can be pushed down to CLP.
-     *
      * @param type the type to check
-     * @return whether the type can be pushed down.
+     * @return whether the type is one of the numeric types compatible with CLP.
      */
     public static boolean isClpCompatibleNumericType(Type type)
     {

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpFilterToKqlConverter.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpFilterToKqlConverter.java
@@ -322,7 +322,7 @@ public class ClpFilterToKqlConverter
         if (!isMetadataColumn) {
             String lowerBound = getLiteralString((ConstantExpression) lower);
             String upperBound = getLiteralString((ConstantExpression) upper);
-            if (isClpCompatibleNumericType(lower.getType())) {
+            if (isClpCompatibleNumericType(lhs.getType())) {
                 kql = String.format("%s >= %s AND %s <= %s", variable, lowerBound, variable, upperBound);
             }
             else {

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpFilterToKqlConverter.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpFilterToKqlConverter.java
@@ -324,7 +324,8 @@ public class ClpFilterToKqlConverter
             String upperBound = getLiteralString((ConstantExpression) upper);
             if (isClpCompatibleNumericType(lower.getType())) {
                 kql = String.format("%s >= %s AND %s <= %s", variable, lowerBound, variable, upperBound);
-            } else {
+            }
+            else {
                 kql = String.format("%s >= '%s' AND %s <= '%s'", variable, lowerBound, variable, upperBound);
             }
         }

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpFilterToKqlConverter.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpFilterToKqlConverter.java
@@ -329,7 +329,6 @@ public class ClpFilterToKqlConverter
                     KQL_BETWEEN_PREDICATE_NUMERIC_FORMAT :
                     KQL_BETWEEN_PREDICATE_STRING_FORMAT;
             kql = String.format(kqlPredicate, variable, lowerBound, variable, upperBound);
-
         }
 
         return new ClpExpression(kql, metadataExpr, variableExpression.getPushDownVariables());

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpFilterToKqlConverter.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpFilterToKqlConverter.java
@@ -324,11 +324,13 @@ public class ClpFilterToKqlConverter
         String kql = null;
         if (!isMetadataColumn) {
             String lowerBound = getLiteralString((ConstantExpression) lower);
+            String escapedLower = escapeKqlSpecialCharsForStringValue(lowerBound);
             String upperBound = getLiteralString((ConstantExpression) upper);
+            String escapedUpper = escapeKqlSpecialCharsForStringValue(upperBound);
             String kqlPredicate = isClpCompatibleNumericType(lhs.getType()) ?
                     KQL_BETWEEN_PREDICATE_NUMERIC_FORMAT :
                     KQL_BETWEEN_PREDICATE_STRING_FORMAT;
-            kql = String.format(kqlPredicate, variable, lowerBound, variable, upperBound);
+            kql = String.format(kqlPredicate, variable, escapedLower, variable, escapedUpper);
         }
 
         return new ClpExpression(kql, metadataExpr, variableExpression.getPushDownVariables());

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/optimization/TestClpFilterToKql.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/optimization/TestClpFilterToKql.java
@@ -116,7 +116,11 @@ public class TestClpFilterToKql
 
         // If the last two arguments of BETWEEN are not numeric constants, then the CLP connector
         // won't push them down.
-        testPushDown(sessionHolder, "city.Name BETWEEN 'a' AND 'b'", null, "city.Name BETWEEN 'a' AND 'b'");
+        testPushDown(
+                sessionHolder,
+                "city.Name BETWEEN 'a' AND 'b'",
+                "city.Name >= 'a' AND city.Name <= 'b'",
+                null);
     }
 
     @Test


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR fixes issue: https://github.com/y-scope/presto/issues/106. 

When a predicate clause contains a range condition on a VARCHAR column (e.g., `ts >= '123' AND ts <= '456'`), we should still perform predicate pushdown or split filtering. String comparison is valid and supported, so these predicates should not be excluded from optimization.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

- All unit tests.
- E2E testing:
  - `SELECT severity FROM clp.DEFAULT.cockroachdb_ir WHERE (ts >= '1679710000570000000' AND ts <='1679711330571000000')` where ts is VARCHAR data column
  - The resulting KQL is: `ts >= '1679710000570000000' AND ts <= '1679711330571000000'`


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
