### PR TITLE
fix: Resolve exposed range-mapped metadata column in split pruning and push down (fixes #121).

### DIFF
--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpConnector.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpConnector.java
@@ -66,7 +66,7 @@ public class ClpConnector
     @Override
     public ConnectorPlanOptimizerProvider getConnectorPlanOptimizerProvider()
     {
-        return new ClpPlanOptimizerProvider(functionManager, functionResolution, clpSplitMetadataConfig);
+        return new ClpPlanOptimizerProvider(functionManager, functionResolution, clpSplitMetadataConfig, metadata);
     }
 
     @Override

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpComputePushDown.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpComputePushDown.java
@@ -26,7 +26,6 @@ import com.facebook.presto.spi.ConnectorPlanOptimizer;
 import com.facebook.presto.spi.ConnectorPlanRewriter;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorTableLayoutHandle;
-import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.VariableAllocator;
@@ -55,7 +54,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
-import static com.facebook.presto.plugin.clp.ClpErrorCode.CLP_UNSUPPORTED_METADATA_PROJECTION;
 import static com.facebook.presto.spi.ConnectorPlanRewriter.rewriteWith;
 import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
@@ -148,10 +146,10 @@ public class ClpComputePushDown
                     // After extracting values from the metadata database, these will be mapped back to exposed names
                     // for projection.
                     String originalColumnName = exposedToOriginalMap.get(columnName);
-                    if (metadataColumnsWithRangeBound.contains(originalColumnName)) {
-                        throw new PrestoException(CLP_UNSUPPORTED_METADATA_PROJECTION,
-                                format("Unsupported metadata projection column: %s", columnName));
-                    }
+//                    if (metadataColumnsWithRangeBound.contains(originalColumnName)) {
+//                        throw new PrestoException(CLP_UNSUPPORTED_METADATA_PROJECTION,
+//                                format("Unsupported metadata projection column: %s", columnName));
+//                    }
                     metadataProjections.add(originalColumnName);
                 }
             }
@@ -349,20 +347,20 @@ public class ClpComputePushDown
 
             Map<VariableReferenceExpression, ColumnHandle> assignments = tableScanNode.getAssignments();
             SchemaTableName schemaTableName = clpTableHandle.getSchemaTableName();
-            Set<String> metadataColumns = metadataConfig.getMetadataColumns(schemaTableName).keySet();
-            Set<String> dataColumnsWithRangeBounds = metadataConfig.getDataColumnsWithRangeBounds(schemaTableName);
             ClpExpression clpExpression = filterNode.getPredicate().accept(
                     new ClpFilterToKqlConverter(
                             functionResolution,
                             functionManager,
                             assignments,
-                            metadataColumns,
-                            dataColumnsWithRangeBounds),
+                            metadataConfig,
+                            schemaTableName),
                     null);
             Optional<String> kqlQuery = clpExpression.getPushDownExpression();
             Optional<RowExpression> metadataExpression = clpExpression.getMetadataExpression();
             Optional<RowExpression> remainingPredicate = clpExpression.getRemainingExpression();
             Set<String> pushDownVariables = clpExpression.getPushDownVariables();
+            Set<String> metadataColumns = metadataConfig.getMetadataColumns(schemaTableName).keySet();
+            Set<String> dataColumnsWithRangeBounds = metadataConfig.getDataColumnsWithRangeBounds(schemaTableName);
             boolean allInMetadata = pushDownVariables.stream().allMatch(
                     v -> metadataColumns.contains(v) || dataColumnsWithRangeBounds.contains(v));
 

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpComputePushDown.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpComputePushDown.java
@@ -353,6 +353,8 @@ public class ClpComputePushDown
             Map<VariableReferenceExpression, ColumnHandle> assignments = tableScanNode.getAssignments();
             SchemaTableName schemaTableName = clpTableHandle.getSchemaTableName();
 
+            Map<String, ColumnHandle> columnHandles = clpMetadata.getColumnHandles(null, clpTableHandle);
+
             ClpExpression clpExpression = filterNode.getPredicate().accept(
                     new ClpFilterToKqlConverter(
                             functionResolution,
@@ -360,8 +362,7 @@ public class ClpComputePushDown
                             assignments,
                             metadataConfig,
                             schemaTableName,
-                            clpMetadata,
-                            clpTableHandle),
+                            columnHandles),
                     null);
             Optional<String> kqlQuery = clpExpression.getPushDownExpression();
             Optional<RowExpression> metadataExpression = clpExpression.getMetadataExpression();

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpComputePushDown.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpComputePushDown.java
@@ -66,15 +66,18 @@ public class ClpComputePushDown
     private final FunctionMetadataManager functionManager;
     private final StandardFunctionResolution functionResolution;
     private final ClpSplitMetadataConfig metadataConfig;
+    private final ClpMetadata clpMetadata;
 
     public ClpComputePushDown(
             FunctionMetadataManager functionManager,
             StandardFunctionResolution functionResolution,
-            ClpSplitMetadataConfig metadataConfig)
+            ClpSplitMetadataConfig metadataConfig,
+            ClpMetadata clpMetadata)
     {
         this.functionManager = requireNonNull(functionManager, "functionManager is null");
         this.functionResolution = requireNonNull(functionResolution, "functionResolution is null");
         this.metadataConfig = requireNonNull(metadataConfig, "metadataConfig is null");
+        this.clpMetadata = requireNonNull(clpMetadata, "clpMetadata is null");
     }
 
     @Override
@@ -347,13 +350,23 @@ public class ClpComputePushDown
 
             Map<VariableReferenceExpression, ColumnHandle> assignments = tableScanNode.getAssignments();
             SchemaTableName schemaTableName = clpTableHandle.getSchemaTableName();
+
+            // Build column type map from ClpMetadata
+            Map<String, com.facebook.presto.common.type.Type> allColumnTypes = new java.util.HashMap<>();
+            Map<String, ColumnHandle> columnHandles = clpMetadata.getColumnHandles(null, clpTableHandle);
+            for (Map.Entry<String, ColumnHandle> entry : columnHandles.entrySet()) {
+                ClpColumnHandle columnHandle = (ClpColumnHandle) entry.getValue();
+                allColumnTypes.put(columnHandle.getOriginalColumnName(), columnHandle.getColumnType());
+            }
+
             ClpExpression clpExpression = filterNode.getPredicate().accept(
                     new ClpFilterToKqlConverter(
                             functionResolution,
                             functionManager,
                             assignments,
                             metadataConfig,
-                            schemaTableName),
+                            schemaTableName,
+                            allColumnTypes),
                     null);
             Optional<String> kqlQuery = clpExpression.getPushDownExpression();
             Optional<RowExpression> metadataExpression = clpExpression.getMetadataExpression();

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpFilterToKqlConverter.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpFilterToKqlConverter.java
@@ -121,19 +121,40 @@ public class ClpFilterToKqlConverter
     private final Map<VariableReferenceExpression, ColumnHandle> assignments;
     private final ClpSplitMetadataConfig metadataConfig;
     private final SchemaTableName schemaTableName;
+    private final Map<String, Type> allColumnTypes;
 
     public ClpFilterToKqlConverter(
             StandardFunctionResolution standardFunctionResolution,
             FunctionMetadataManager functionMetadataManager,
             Map<VariableReferenceExpression, ColumnHandle> assignments,
             ClpSplitMetadataConfig metadataConfig,
-            SchemaTableName schemaTableName)
+            SchemaTableName schemaTableName,
+            Map<String, Type> allColumnTypes)
     {
         this.standardFunctionResolution = requireNonNull(standardFunctionResolution, "standardFunctionResolution is null");
         this.functionMetadataManager = requireNonNull(functionMetadataManager, "function metadata manager is null");
         this.assignments = requireNonNull(assignments, "assignments is null");
         this.metadataConfig = requireNonNull(metadataConfig, "metadataConfig is null");
         this.schemaTableName = requireNonNull(schemaTableName, "schemaTableName is null");
+        this.allColumnTypes = requireNonNull(allColumnTypes, "allColumnTypes is null");
+    }
+
+    /**
+     * Gets the type of a data column from the full table schema.
+     *
+     * @param columnName the name of the data column
+     * @return the type of the column
+     * @throws PrestoException if the column is not found in the table schema
+     */
+    private Type getDataColumnType(String columnName)
+    {
+        Type type = allColumnTypes.get(columnName);
+        if (type == null) {
+            throw new PrestoException(
+                    CLP_PUSHDOWN_UNSUPPORTED_EXPRESSION,
+                    "Data column not found in table schema: " + columnName);
+        }
+        return type;
     }
 
     @Override
@@ -282,9 +303,11 @@ public class ClpFilterToKqlConverter
         }
 
         String variable = variableOpt.get();
+        Type variableType = lhs.getType();
         Map<String, String> metadataColumnWithRangeBounds = metadataConfig.getExposedToRangeMapping(schemaTableName);
         if (metadataColumnWithRangeBounds.containsKey(variable)) {
             variable = metadataColumnWithRangeBounds.get(variable);
+            variableType = getDataColumnType(variable);
         }
         boolean isMetadataColumn = metadataConfig.getMetadataColumns(schemaTableName).keySet().contains(variable);
 
@@ -331,7 +354,7 @@ public class ClpFilterToKqlConverter
         if (!isMetadataColumn) {
             String lowerBound = getLiteralString((ConstantExpression) lower);
             String upperBound = getLiteralString((ConstantExpression) upper);
-            String kqlPredicate = isClpCompatibleNumericType(lhs.getType()) ?
+            String kqlPredicate = isClpCompatibleNumericType(variableType) ?
                     KQL_BETWEEN_PREDICATE_NUMERIC_FORMAT :
                     KQL_BETWEEN_PREDICATE_STRING_FORMAT;
             kql = String.format(kqlPredicate, variable, lowerBound, variable, upperBound);

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpFilterToKqlConverter.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpFilterToKqlConverter.java
@@ -41,6 +41,7 @@ import io.airlift.slice.Slice;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -155,6 +156,32 @@ public class ClpFilterToKqlConverter
                     "Data column not found in table schema: " + columnName);
         }
         return ((ClpColumnHandle) handle).getColumnType();
+    }
+
+    /**
+     * Resolves an exposed variable name and type to its underlying data column representation.
+     * <p>
+     * Certain exposed metadata columns map to actual data columns with range bounds stored in
+     * the metadata database. When such a mapping exists, this method resolves the exposed column
+     * name to the underlying data column name and updates the type accordingly to facilitate
+     * data push down. This resolution is necessary because exposed metadata column types may
+     * differ from their corresponding data column types in the archive.
+     *
+     * @param variableName the exposed column name to resolve
+     * @param variableType the type of the exposed column
+     * @return a pair (Map.Entry) containing the resolved column name (key) and its type (value).
+     *         If no mapping exists, returns the original name and type unchanged.
+     */
+    private Map.Entry<String, Type> resolveExposedRangeBoundVariableAndType(String variableName, Type variableType)
+    {
+        Map<String, String> exposedToRangeMapping = metadataConfig.getExposedToRangeMapping(schemaTableName);
+        if (exposedToRangeMapping.containsKey(variableName)) {
+            // Resolve to the actual data column name and retrieve its type from the table schema
+            String dataColumnName = exposedToRangeMapping.get(variableName);
+            Type dataColumnType = getDataColumnType(dataColumnName);
+            return new SimpleImmutableEntry<>(dataColumnName, dataColumnType);
+        }
+        return new SimpleImmutableEntry<>(variableName, variableType);
     }
 
     @Override
@@ -302,13 +329,10 @@ public class ClpFilterToKqlConverter
             return new ClpExpression(node);
         }
 
-        String variable = variableOpt.get();
-        Type variableType = lhs.getType();
-        Map<String, String> metadataColumnWithRangeBounds = metadataConfig.getExposedToRangeMapping(schemaTableName);
-        if (metadataColumnWithRangeBounds.containsKey(variable)) {
-            variable = metadataColumnWithRangeBounds.get(variable);
-            variableType = getDataColumnType(variable);
-        }
+        // Resolve range-bound column mapping with exposed name
+        Map.Entry<String, Type> resolution = resolveExposedRangeBoundVariableAndType(variableOpt.get(), lhs.getType());
+        String variable = resolution.getKey();
+        Type variableType = resolution.getValue();
         boolean isMetadataColumn = metadataConfig.getMetadataColumns(schemaTableName).keySet().contains(variable);
 
         // Metadata columns must have constant bounds
@@ -559,15 +583,13 @@ public class ClpFilterToKqlConverter
             Type variableType,
             CallExpression originalNode)
     {
-        boolean isDataColumnsWithRangeBounds = false;
+        // Resolve range-bound column mapping with exposed name
+        Map.Entry<String, Type> resolution = resolveExposedRangeBoundVariableAndType(variableName, variableType);
+        variableName = resolution.getKey();
+        variableType = resolution.getValue();
 
-        Map<String, String> metadataColumnWithRangeBounds = metadataConfig.getExposedToRangeMapping(schemaTableName);
-        if (metadataColumnWithRangeBounds.containsKey(variableName)) {
-            variableName = metadataColumnWithRangeBounds.get(variableName);
-            variableType = getDataColumnType(variableName);
-            isDataColumnsWithRangeBounds = true;
-        }
-
+        boolean isDataColumnsWithRangeBounds =
+                metadataConfig.getDataColumnsWithRangeBounds(schemaTableName).contains(variableName);
         boolean isVarchar = variableType instanceof VarcharType;
         boolean isMetadataColumn = metadataConfig.getMetadataColumns(schemaTableName).keySet().contains(variableName);
         String formattedLiteral = isVarchar

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpFilterToKqlConverter.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpFilterToKqlConverter.java
@@ -111,6 +111,9 @@ public class ClpFilterToKqlConverter
     private static final Set<OperatorType> LOGICAL_BINARY_OPS_FILTER =
             ImmutableSet.of(EQUAL, NOT_EQUAL, LESS_THAN, LESS_THAN_OR_EQUAL, GREATER_THAN, GREATER_THAN_OR_EQUAL);
 
+    private static final String KQL_BETWEEN_PREDICATE_NUMERIC_FORMAT = "%s >= %s AND %s <= %s";
+    private static final String KQL_BETWEEN_PREDICATE_STRING_FORMAT = "%s >= '%s' AND %s <= '%s'";
+
     private final StandardFunctionResolution standardFunctionResolution;
     private final FunctionMetadataManager functionMetadataManager;
     private final Map<VariableReferenceExpression, ColumnHandle> assignments;
@@ -322,12 +325,11 @@ public class ClpFilterToKqlConverter
         if (!isMetadataColumn) {
             String lowerBound = getLiteralString((ConstantExpression) lower);
             String upperBound = getLiteralString((ConstantExpression) upper);
-            if (isClpCompatibleNumericType(lhs.getType())) {
-                kql = String.format("%s >= %s AND %s <= %s", variable, lowerBound, variable, upperBound);
-            }
-            else {
-                kql = String.format("%s >= '%s' AND %s <= '%s'", variable, lowerBound, variable, upperBound);
-            }
+            String kqlPredicate = isClpCompatibleNumericType(lhs.getType()) ?
+                    KQL_BETWEEN_PREDICATE_NUMERIC_FORMAT :
+                    KQL_BETWEEN_PREDICATE_STRING_FORMAT;
+            kql = String.format(kqlPredicate, variable, lowerBound, variable, upperBound);
+
         }
 
         return new ClpExpression(kql, metadataExpr, variableExpression.getPushDownVariables());

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpFilterToKqlConverter.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpFilterToKqlConverter.java
@@ -21,8 +21,10 @@ import com.facebook.presto.common.type.TimestampType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.VarcharType;
 import com.facebook.presto.plugin.clp.ClpColumnHandle;
+import com.facebook.presto.plugin.clp.split.ClpSplitMetadataConfig;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.function.FunctionHandle;
 import com.facebook.presto.spi.function.FunctionMetadata;
 import com.facebook.presto.spi.function.FunctionMetadataManager;
@@ -117,21 +119,21 @@ public class ClpFilterToKqlConverter
     private final StandardFunctionResolution standardFunctionResolution;
     private final FunctionMetadataManager functionMetadataManager;
     private final Map<VariableReferenceExpression, ColumnHandle> assignments;
-    private final Set<String> metadataFilterColumns;
-    private final Set<String> dataColumnsWithRangeBounds;
+    private final ClpSplitMetadataConfig metadataConfig;
+    private final SchemaTableName schemaTableName;
 
     public ClpFilterToKqlConverter(
             StandardFunctionResolution standardFunctionResolution,
             FunctionMetadataManager functionMetadataManager,
             Map<VariableReferenceExpression, ColumnHandle> assignments,
-            Set<String> metadataFilterColumns,
-            Set<String> dataColumnsWithRangeBounds)
+            ClpSplitMetadataConfig metadataConfig,
+            SchemaTableName schemaTableName)
     {
         this.standardFunctionResolution = requireNonNull(standardFunctionResolution, "standardFunctionResolution is null");
         this.functionMetadataManager = requireNonNull(functionMetadataManager, "function metadata manager is null");
         this.assignments = requireNonNull(assignments, "assignments is null");
-        this.metadataFilterColumns = requireNonNull(metadataFilterColumns, "metadataFilterColumns is null");
-        this.dataColumnsWithRangeBounds = requireNonNull(dataColumnsWithRangeBounds, "dataColumnsWithRangeBounds is null");
+        this.metadataConfig = requireNonNull(metadataConfig, "metadataConfig is null");
+        this.schemaTableName = requireNonNull(schemaTableName, "schemaTableName is null");
     }
 
     @Override
@@ -280,7 +282,11 @@ public class ClpFilterToKqlConverter
         }
 
         String variable = variableOpt.get();
-        boolean isMetadataColumn = metadataFilterColumns.contains(variable);
+        Map<String, String> metadataColumnWithRangeBounds = metadataConfig.getExposedToRangeMapping(schemaTableName);
+        if (metadataColumnWithRangeBounds.containsKey(variable)) {
+            variable = metadataColumnWithRangeBounds.get(variable);
+        }
+        boolean isMetadataColumn = metadataConfig.getMetadataColumns(schemaTableName).keySet().contains(variable);
 
         // Metadata columns must have constant bounds
         if (isMetadataColumn &&
@@ -296,7 +302,7 @@ public class ClpFilterToKqlConverter
         }
 
         RowExpression metadataExpr = null;
-        if (isMetadataColumn || dataColumnsWithRangeBounds.contains(variable)) {
+        if (isMetadataColumn || metadataConfig.getDataColumnsWithRangeBounds(schemaTableName).contains(variable)) {
             VariableReferenceExpression varExpr =
                     new VariableReferenceExpression(lhs.getSourceLocation(), variable, lhs.getType());
             ConstantExpression lowerConst = (ConstantExpression) lower;
@@ -397,7 +403,7 @@ public class ClpFilterToKqlConverter
         }
 
         String variableName = variable.getPushDownExpression().get();
-        if (metadataFilterColumns.contains(variableName)) {
+        if (metadataConfig.getMetadataColumns(schemaTableName).keySet().contains(variableName)) {
             throw new PrestoException(
                     CLP_PUSHDOWN_UNSUPPORTED_EXPRESSION,
                     "Metadata filter columns are not supported for LIKE predicate" + node);
@@ -529,8 +535,8 @@ public class ClpFilterToKqlConverter
             CallExpression originalNode)
     {
         boolean isVarchar = constant.getType() instanceof VarcharType;
-        boolean isMetadataColumn = metadataFilterColumns.contains(variableName);
-        boolean isDataColumnsWithRangeBounds = dataColumnsWithRangeBounds.contains(variableName);
+        boolean isMetadataColumn = metadataConfig.getMetadataColumns(schemaTableName).keySet().contains(variableName);
+        boolean isDataColumnsWithRangeBounds = metadataConfig.getDataColumnsWithRangeBounds(schemaTableName).contains(variableName);
         String formattedLiteral = isVarchar
                 ? "\"" + escapeKqlSpecialCharsForStringValue(literalString) + "\""
                 : literalString;
@@ -624,7 +630,7 @@ public class ClpFilterToKqlConverter
         }
 
         String varName = variable.getPushDownExpression().get();
-        if (metadataFilterColumns.contains(varName)) {
+        if (metadataConfig.getMetadataColumns(schemaTableName).keySet().contains(varName)) {
             throw new PrestoException(
                     CLP_PUSHDOWN_UNSUPPORTED_EXPRESSION,
                     "Metadata filter columns are not supported for substr call" + callExpression);
@@ -900,7 +906,7 @@ public class ClpFilterToKqlConverter
             return new ClpExpression(node);
         }
         String variableName = variable.getPushDownExpression().get();
-        if (metadataFilterColumns.contains(variableName)) {
+        if (metadataConfig.getMetadataColumns(schemaTableName).keySet().contains(variableName)) {
             throw new PrestoException(
                     CLP_PUSHDOWN_UNSUPPORTED_EXPRESSION,
                     "Metadata filter columns are not supported for IN predicate" + node);
@@ -949,7 +955,7 @@ public class ClpFilterToKqlConverter
         }
 
         String variableName = expression.getPushDownExpression().get();
-        if (metadataFilterColumns.contains(variableName)) {
+        if (metadataConfig.getMetadataColumns(schemaTableName).keySet().contains(variableName)) {
             throw new PrestoException(
                     CLP_PUSHDOWN_UNSUPPORTED_EXPRESSION,
                     "Metadata filter columns are not supported for IN predicate" + node);

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpFilterToKqlConverter.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpFilterToKqlConverter.java
@@ -559,9 +559,17 @@ public class ClpFilterToKqlConverter
             Type variableType,
             CallExpression originalNode)
     {
-        boolean isVarchar = constant.getType() instanceof VarcharType;
+        boolean isDataColumnsWithRangeBounds = false;
+
+        Map<String, String> metadataColumnWithRangeBounds = metadataConfig.getExposedToRangeMapping(schemaTableName);
+        if (metadataColumnWithRangeBounds.containsKey(variableName)) {
+            variableName = metadataColumnWithRangeBounds.get(variableName);
+            variableType = getDataColumnType(variableName);
+            isDataColumnsWithRangeBounds = true;
+        }
+
+        boolean isVarchar = variableType instanceof VarcharType;
         boolean isMetadataColumn = metadataConfig.getMetadataColumns(schemaTableName).keySet().contains(variableName);
-        boolean isDataColumnsWithRangeBounds = metadataConfig.getDataColumnsWithRangeBounds(schemaTableName).contains(variableName);
         String formattedLiteral = isVarchar
                 ? "\"" + escapeKqlSpecialCharsForStringValue(literalString) + "\""
                 : literalString;

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpFilterToKqlConverter.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpFilterToKqlConverter.java
@@ -115,7 +115,7 @@ public class ClpFilterToKqlConverter
             ImmutableSet.of(EQUAL, NOT_EQUAL, LESS_THAN, LESS_THAN_OR_EQUAL, GREATER_THAN, GREATER_THAN_OR_EQUAL);
 
     private static final String KQL_BETWEEN_PREDICATE_NUMERIC_FORMAT = "%s >= %s AND %s <= %s";
-    private static final String KQL_BETWEEN_PREDICATE_STRING_FORMAT = "%s >= '%s' AND %s <= '%s'";
+    private static final String KQL_BETWEEN_PREDICATE_STRING_FORMAT = "%s >= \"%s\" AND %s <= \"%s\"";
 
     private final StandardFunctionResolution standardFunctionResolution;
     private final FunctionMetadataManager functionMetadataManager;
@@ -578,9 +578,8 @@ public class ClpFilterToKqlConverter
 
         boolean isDataColumnsWithRangeBounds =
                 metadataConfig.getDataColumnsWithRangeBounds(schemaTableName).contains(variableName);
-        boolean isVarchar = variableType instanceof VarcharType;
         boolean isMetadataColumn = metadataConfig.getMetadataColumns(schemaTableName).keySet().contains(variableName);
-        String formattedLiteral = isVarchar
+        String formattedLiteral = variableType instanceof VarcharType
                 ? "\"" + escapeKqlSpecialCharsForStringValue(literalString) + "\""
                 : literalString;
 
@@ -593,8 +592,8 @@ public class ClpFilterToKqlConverter
             else if (operator.equals(NOT_EQUAL)) {
                 pushDownExpression = format("NOT %s: %s", variableName, formattedLiteral);
             }
-            else if (LOGICAL_BINARY_OPS_FILTER.contains(operator) && !isVarchar) {
-                pushDownExpression = format("%s %s %s", variableName, operator.getOperator(), literalString);
+            else if (LOGICAL_BINARY_OPS_FILTER.contains(operator)) {
+                pushDownExpression = format("%s %s %s", variableName, operator.getOperator(), formattedLiteral);
             }
 
             if (pushDownExpression == null) {

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpFilterToKqlConverter.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpFilterToKqlConverter.java
@@ -279,22 +279,6 @@ public class ClpFilterToKqlConverter
         String variable = variableOpt.get();
         boolean isMetadataColumn = metadataFilterColumns.contains(variable);
 
-        // Type validation
-        boolean numericCompatible =
-                isClpCompatibleNumericType(lhs.getType())
-                        && isClpCompatibleNumericType(lower.getType())
-                        && isClpCompatibleNumericType(upper.getType());
-
-        if (!numericCompatible) {
-            if (isMetadataColumn) {
-                throw new PrestoException(
-                        CLP_PUSHDOWN_UNSUPPORTED_EXPRESSION,
-                        "Metadata BETWEEN requires numeric-compatible types. Received: " + node);
-            }
-            // Non-metadata columns just fallback (cannot push down)
-            return new ClpExpression(node);
-        }
-
         // Metadata columns must have constant bounds
         if (isMetadataColumn &&
                 (!(lower instanceof ConstantExpression) || !(upper instanceof ConstantExpression))) {
@@ -338,7 +322,11 @@ public class ClpFilterToKqlConverter
         if (!isMetadataColumn) {
             String lowerBound = getLiteralString((ConstantExpression) lower);
             String upperBound = getLiteralString((ConstantExpression) upper);
-            kql = String.format("%s >= %s AND %s <= %s", variable, lowerBound, variable, upperBound);
+            if (isClpCompatibleNumericType(lower.getType())) {
+                kql = String.format("%s >= %s AND %s <= %s", variable, lowerBound, variable, upperBound);
+            } else {
+                kql = String.format("%s >= '%s' AND %s <= '%s'", variable, lowerBound, variable, upperBound);
+            }
         }
 
         return new ClpExpression(kql, metadataExpr, variableExpression.getPushDownVariables());
@@ -1048,10 +1036,8 @@ public class ClpFilterToKqlConverter
     }
 
     /**
-     * Checks if the type is one of the numeric types that can be pushed down to CLP.
-     *
      * @param type the type to check
-     * @return whether the type can be pushed down.
+     * @return whether the type is one of the numeric types compatible with CLP.
      */
     public static boolean isClpCompatibleNumericType(Type type)
     {

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpFilterToKqlConverter.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpFilterToKqlConverter.java
@@ -322,7 +322,7 @@ public class ClpFilterToKqlConverter
         if (!isMetadataColumn) {
             String lowerBound = getLiteralString((ConstantExpression) lower);
             String upperBound = getLiteralString((ConstantExpression) upper);
-            if (isClpCompatibleNumericType(lower.getType())) {
+            if (isClpCompatibleNumericType(lhs.getType())) {
                 kql = String.format("%s >= %s AND %s <= %s", variable, lowerBound, variable, upperBound);
             }
             else {

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpFilterToKqlConverter.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpFilterToKqlConverter.java
@@ -324,7 +324,8 @@ public class ClpFilterToKqlConverter
             String upperBound = getLiteralString((ConstantExpression) upper);
             if (isClpCompatibleNumericType(lower.getType())) {
                 kql = String.format("%s >= %s AND %s <= %s", variable, lowerBound, variable, upperBound);
-            } else {
+            }
+            else {
                 kql = String.format("%s >= '%s' AND %s <= '%s'", variable, lowerBound, variable, upperBound);
             }
         }

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpFilterToKqlConverter.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpFilterToKqlConverter.java
@@ -329,7 +329,6 @@ public class ClpFilterToKqlConverter
                     KQL_BETWEEN_PREDICATE_NUMERIC_FORMAT :
                     KQL_BETWEEN_PREDICATE_STRING_FORMAT;
             kql = String.format(kqlPredicate, variable, lowerBound, variable, upperBound);
-
         }
 
         return new ClpExpression(kql, metadataExpr, variableExpression.getPushDownVariables());

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpFilterToKqlConverter.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpFilterToKqlConverter.java
@@ -21,8 +21,6 @@ import com.facebook.presto.common.type.TimestampType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.VarcharType;
 import com.facebook.presto.plugin.clp.ClpColumnHandle;
-import com.facebook.presto.plugin.clp.ClpMetadata;
-import com.facebook.presto.plugin.clp.ClpTableHandle;
 import com.facebook.presto.plugin.clp.split.ClpSplitMetadataConfig;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.PrestoException;
@@ -123,7 +121,7 @@ public class ClpFilterToKqlConverter
     private final Map<VariableReferenceExpression, ColumnHandle> assignments;
     private final ClpSplitMetadataConfig metadataConfig;
     private final SchemaTableName schemaTableName;
-    private final Map<String, Type> allColumnTypes;
+    private final Map<String, ColumnHandle> columnHandles;
 
     public ClpFilterToKqlConverter(
             StandardFunctionResolution standardFunctionResolution,
@@ -131,24 +129,14 @@ public class ClpFilterToKqlConverter
             Map<VariableReferenceExpression, ColumnHandle> assignments,
             ClpSplitMetadataConfig metadataConfig,
             SchemaTableName schemaTableName,
-            ClpMetadata clpMetadata,
-            ClpTableHandle clpTableHandle)
+            Map<String, ColumnHandle> columnHandles)
     {
         this.standardFunctionResolution = requireNonNull(standardFunctionResolution, "standardFunctionResolution is null");
         this.functionMetadataManager = requireNonNull(functionMetadataManager, "function metadata manager is null");
         this.assignments = requireNonNull(assignments, "assignments is null");
         this.metadataConfig = requireNonNull(metadataConfig, "metadataConfig is null");
         this.schemaTableName = requireNonNull(schemaTableName, "schemaTableName is null");
-
-        // Build column type map from clpMetadata
-        requireNonNull(clpMetadata, "clpMetadata is null");
-        requireNonNull(clpTableHandle, "clpTableHandle is null");
-        this.allColumnTypes = new java.util.HashMap<>();
-        Map<String, ColumnHandle> columnHandles = clpMetadata.getColumnHandles(null, clpTableHandle);
-        for (Map.Entry<String, ColumnHandle> entry : columnHandles.entrySet()) {
-            ClpColumnHandle columnHandle = (ClpColumnHandle) entry.getValue();
-            this.allColumnTypes.put(columnHandle.getOriginalColumnName(), columnHandle.getColumnType());
-        }
+        this.columnHandles = requireNonNull(columnHandles, "columnHandles is null");
     }
 
     /**
@@ -160,13 +148,13 @@ public class ClpFilterToKqlConverter
      */
     private Type getDataColumnType(String columnName)
     {
-        Type type = allColumnTypes.get(columnName);
-        if (type == null) {
+        ColumnHandle handle = columnHandles.get(columnName);
+        if (handle == null) {
             throw new PrestoException(
                     CLP_PUSHDOWN_UNSUPPORTED_EXPRESSION,
                     "Data column not found in table schema: " + columnName);
         }
-        return type;
+        return ((ClpColumnHandle) handle).getColumnType();
     }
 
     @Override

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpFilterToKqlConverter.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpFilterToKqlConverter.java
@@ -141,24 +141,6 @@ public class ClpFilterToKqlConverter
     }
 
     /**
-     * Gets the type of a data column from the full table schema.
-     *
-     * @param columnName the name of the data column
-     * @return the type of the column
-     * @throws PrestoException if the column is not found in the table schema
-     */
-    private Type getDataColumnType(String columnName)
-    {
-        ColumnHandle handle = columnHandles.get(columnName);
-        if (handle == null) {
-            throw new PrestoException(
-                    CLP_PUSHDOWN_UNSUPPORTED_EXPRESSION,
-                    "Data column not found in table schema: " + columnName);
-        }
-        return ((ClpColumnHandle) handle).getColumnType();
-    }
-
-    /**
      * Resolves an exposed variable name and type to its underlying data column representation.
      * <p>
      * Certain exposed metadata columns map to actual data columns with range bounds stored in
@@ -178,7 +160,13 @@ public class ClpFilterToKqlConverter
         if (exposedToRangeMapping.containsKey(variableName)) {
             // Resolve to the actual data column name and retrieve its type from the table schema
             String dataColumnName = exposedToRangeMapping.get(variableName);
-            Type dataColumnType = getDataColumnType(dataColumnName);
+            ColumnHandle handle = columnHandles.get(dataColumnName);
+            if (handle == null) {
+                throw new PrestoException(
+                        CLP_PUSHDOWN_UNSUPPORTED_EXPRESSION,
+                        "Data column not found in table schema: " + dataColumnName);
+            }
+            Type dataColumnType = ((ClpColumnHandle) handle).getColumnType();
             return new SimpleImmutableEntry<>(dataColumnName, dataColumnType);
         }
         return new SimpleImmutableEntry<>(variableName, variableType);

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpPlanOptimizerProvider.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpPlanOptimizerProvider.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.plugin.clp.optimization;
 
+import com.facebook.presto.plugin.clp.ClpMetadata;
 import com.facebook.presto.plugin.clp.split.ClpSplitMetadataConfig;
 import com.facebook.presto.spi.ConnectorPlanOptimizer;
 import com.facebook.presto.spi.connector.ConnectorPlanOptimizerProvider;
@@ -30,16 +31,19 @@ public class ClpPlanOptimizerProvider
     private final FunctionMetadataManager functionManager;
     private final StandardFunctionResolution functionResolution;
     private final ClpSplitMetadataConfig clpSplitMetadataConfig;
+    private final ClpMetadata clpMetadata;
 
     @Inject
     public ClpPlanOptimizerProvider(
             FunctionMetadataManager functionManager,
             StandardFunctionResolution functionResolution,
-            ClpSplitMetadataConfig clpSplitMetadataConfig)
+            ClpSplitMetadataConfig clpSplitMetadataConfig,
+            ClpMetadata clpMetadata)
     {
         this.functionManager = functionManager;
         this.functionResolution = functionResolution;
         this.clpSplitMetadataConfig = clpSplitMetadataConfig;
+        this.clpMetadata = clpMetadata;
     }
 
     @Override
@@ -51,6 +55,6 @@ public class ClpPlanOptimizerProvider
     @Override
     public Set<ConnectorPlanOptimizer> getPhysicalPlanOptimizers()
     {
-        return ImmutableSet.of(new ClpComputePushDown(functionManager, functionResolution, clpSplitMetadataConfig));
+        return ImmutableSet.of(new ClpComputePushDown(functionManager, functionResolution, clpSplitMetadataConfig, clpMetadata));
     }
 }

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpSplitMetadataConfig.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpSplitMetadataConfig.java
@@ -258,6 +258,22 @@ public class ClpSplitMetadataConfig
     }
 
     /**
+     * @param name the {@link SchemaTableName} of the target table
+     * @return a map from exposed column name → range bound data column name
+     */
+    public Map<String, String> getExposedToRangeMapping(SchemaTableName name)
+    {
+        TableConfig cfg = getTableConfig(name);
+        Map<String, String> mapping = new HashMap<>();
+        for (MetaColumn c : cfg.metaColumns.values()) {
+            if (c.asRangeBoundOf != null) {
+                mapping.put(c.exposedAs, c.asRangeBoundOf);
+            }
+        }
+        return mapping;
+    }
+
+    /**
      * Merges and returns the effective {@link TableConfig} for the given table, taking into account
      * the hierarchical configuration structure: global → schema → table.
      *

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/TestClpQueryBase.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/TestClpQueryBase.java
@@ -89,8 +89,17 @@ public class TestClpQueryBase
                             RowType.field("Name", VARCHAR)))))));
     protected static final ClpColumnHandle fare = new ClpColumnHandle("fare", DOUBLE);
     protected static final ClpColumnHandle isHoliday = new ClpColumnHandle("isHoliday", BOOLEAN);
+    protected static final ClpColumnHandle cityRegionId = new ClpColumnHandle("city.Region.Id", BIGINT);
+    // Columns for testing exposed-to-data column mapping:
+    protected static final ClpColumnHandle timestampExposed = new ClpColumnHandle("timestampExposed", VARCHAR);
+    protected static final ClpColumnHandle timestampData = new ClpColumnHandle("timestampData", VARCHAR);
+    protected static final ClpColumnHandle valueExposed = new ClpColumnHandle("valueExposed", BIGINT);
+    protected static final ClpColumnHandle valueData = new ClpColumnHandle("valueData", BIGINT);
+    protected static final ClpColumnHandle varCharExposed = new ClpColumnHandle("varCharExposed", VARCHAR);
+    protected static final ClpColumnHandle bigIntData = new ClpColumnHandle("bigIntData", BIGINT);
+
     protected static final Map<VariableReferenceExpression, ColumnHandle> variableToColumnHandleMap =
-            Stream.of(city, fare, isHoliday)
+            Stream.of(city, fare, isHoliday, cityRegionId, timestampExposed, timestampData, valueExposed, valueData, varCharExposed, bigIntData)
                     .collect(toMap(
                             ch -> new VariableReferenceExpression(Optional.empty(), ch.getColumnName(), ch.getColumnType()),
                             ch -> ch));

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/TestClpTopN.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/TestClpTopN.java
@@ -292,17 +292,11 @@ public class TestClpTopN
                 session,
                 sql,
                 WarningCollector.NOOP);
-        // Create a stub ClpMetadata for testing
-        ClpMetadata stubMetadata = new ClpMetadata(null, null) {
-            @Override
-            public Map<String, ColumnHandle> getColumnHandles(com.facebook.presto.spi.ConnectorSession session, com.facebook.presto.spi.ConnectorTableHandle tableHandle)
-            {
-                // Return empty map as this test doesn't need column schema
-                return ImmutableMap.of();
-            }
-        };
+        mockClpMetadata = mock(ClpMetadata.class);
+        when(mockClpMetadata.getColumnHandles(any(), any()))
+                .thenReturn(ImmutableMap.of());
 
-        ClpComputePushDown optimizer = new ClpComputePushDown(functionAndTypeManager, functionResolution, clpSplitMetadataConfig, stubMetadata);
+        ClpComputePushDown optimizer = new ClpComputePushDown(functionAndTypeManager, functionResolution, clpSplitMetadataConfig, mockClpMetadata);
         PlanNode optimizedPlan = optimizer.optimize(plan.getRoot(), session.toConnectorSession(), variableAllocator, planNodeIdAllocator);
         PlanNode optimizedPlanWithUniqueId = freshenIds(optimizedPlan, new PlanNodeIdAllocator());
 

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/TestClpTopN.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/TestClpTopN.java
@@ -284,7 +284,17 @@ public class TestClpTopN
                 session,
                 sql,
                 WarningCollector.NOOP);
-        ClpComputePushDown optimizer = new ClpComputePushDown(functionAndTypeManager, functionResolution, clpSplitMetadataConfig);
+        // Create a stub ClpMetadata for testing
+        ClpMetadata stubMetadata = new ClpMetadata(null, null) {
+            @Override
+            public Map<String, ColumnHandle> getColumnHandles(com.facebook.presto.spi.ConnectorSession session, com.facebook.presto.spi.ConnectorTableHandle tableHandle)
+            {
+                // Return empty map as this test doesn't need column schema
+                return ImmutableMap.of();
+            }
+        };
+
+        ClpComputePushDown optimizer = new ClpComputePushDown(functionAndTypeManager, functionResolution, clpSplitMetadataConfig, stubMetadata);
         PlanNode optimizedPlan = optimizer.optimize(plan.getRoot(), session.toConnectorSession(), variableAllocator, planNodeIdAllocator);
         PlanNode optimizedPlanWithUniqueId = freshenIds(optimizedPlan, new PlanNodeIdAllocator());
 

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/TestClpTopN.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/TestClpTopN.java
@@ -88,6 +88,9 @@ import static com.facebook.presto.sql.planner.assertions.MatchResult.match;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.node;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 
 @Test(singleThreaded = true)
@@ -109,6 +112,7 @@ public class TestClpTopN
     private ClpSplitProvider splitProvider;
     private PlanNodeIdAllocator planNodeIdAllocator;
     private VariableAllocator variableAllocator;
+    private ClpMetadata mockClpMetadata;
 
     @BeforeMethod
     public void setUp()
@@ -203,6 +207,10 @@ public class TestClpTopN
         SchemaTableName schemaTableName = new SchemaTableName("defualt", "test");
         planNodeIdAllocator = new PlanNodeIdAllocator();
         variableAllocator = new VariableAllocator();
+
+        mockClpMetadata = mock(ClpMetadata.class);
+        when(mockClpMetadata.getColumnHandles(any(), any()))
+                .thenReturn(ImmutableMap.of());
     }
 
     @AfterMethod

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/optimization/TestClpComputePushDown.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/optimization/TestClpComputePushDown.java
@@ -51,6 +51,9 @@ import java.util.Set;
 
 import static com.facebook.presto.common.type.DoubleType.DOUBLE;
 import static com.facebook.presto.plugin.clp.ClpErrorCode.CLP_UNSUPPORTED_METADATA_PROJECTION;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertTrue;
@@ -69,6 +72,7 @@ public class TestClpComputePushDown
     private SchemaTableName schemaTableName;
     private ClpTableHandle clpTableHandle;
     private ConnectorId connectorId;
+    private ClpMetadata mockClpMetadata;
 
     @BeforeMethod
     public void setUp()
@@ -88,19 +92,14 @@ public class TestClpComputePushDown
 
         metadataConfig = new ClpSplitMetadataConfig(config, functionAndTypeManager);
 
-        // Create a stub ClpMetadata that returns the columns from TestClpQueryBase
-        ClpMetadata stubMetadata = new ClpMetadata(null, null) {
-            @Override
-            public Map<String, ColumnHandle> getColumnHandles(com.facebook.presto.spi.ConnectorSession session, com.facebook.presto.spi.ConnectorTableHandle tableHandle)
-            {
-                return ImmutableMap.of(
+        mockClpMetadata = mock(ClpMetadata.class);
+        when(mockClpMetadata.getColumnHandles(any(), any()))
+                .thenReturn(ImmutableMap.of(
                         TestClpQueryBase.city.getColumnName(), TestClpQueryBase.city,
                         TestClpQueryBase.fare.getColumnName(), TestClpQueryBase.fare,
-                        TestClpQueryBase.isHoliday.getColumnName(), TestClpQueryBase.isHoliday);
-            }
-        };
+                        TestClpQueryBase.isHoliday.getColumnName(), TestClpQueryBase.isHoliday));
 
-        optimizer = new ClpComputePushDown(functionAndTypeManager, functionResolution, metadataConfig, stubMetadata);
+        optimizer = new ClpComputePushDown(functionAndTypeManager, functionResolution, metadataConfig, mockClpMetadata);
         idAllocator = new PlanNodeIdAllocator();
         variableAllocator = new VariableAllocator();
         schemaTableName = new SchemaTableName("default", "table_1");

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/optimization/TestClpComputePushDown.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/optimization/TestClpComputePushDown.java
@@ -18,6 +18,7 @@ import com.facebook.presto.common.type.Type;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.plugin.clp.ClpColumnHandle;
 import com.facebook.presto.plugin.clp.ClpConfig;
+import com.facebook.presto.plugin.clp.ClpMetadata;
 import com.facebook.presto.plugin.clp.ClpTableHandle;
 import com.facebook.presto.plugin.clp.ClpTableLayoutHandle;
 import com.facebook.presto.plugin.clp.ClpTransactionHandle;
@@ -86,7 +87,20 @@ public class TestClpComputePushDown
         functionResolution = new FunctionResolution(functionAndTypeManager.getFunctionAndTypeResolver());
 
         metadataConfig = new ClpSplitMetadataConfig(config, functionAndTypeManager);
-        optimizer = new ClpComputePushDown(functionAndTypeManager, functionResolution, metadataConfig);
+
+        // Create a stub ClpMetadata that returns the columns from TestClpQueryBase
+        ClpMetadata stubMetadata = new ClpMetadata(null, null) {
+            @Override
+            public Map<String, ColumnHandle> getColumnHandles(com.facebook.presto.spi.ConnectorSession session, com.facebook.presto.spi.ConnectorTableHandle tableHandle)
+            {
+                return ImmutableMap.of(
+                        TestClpQueryBase.city.getColumnName(), TestClpQueryBase.city,
+                        TestClpQueryBase.fare.getColumnName(), TestClpQueryBase.fare,
+                        TestClpQueryBase.isHoliday.getColumnName(), TestClpQueryBase.isHoliday);
+            }
+        };
+
+        optimizer = new ClpComputePushDown(functionAndTypeManager, functionResolution, metadataConfig, stubMetadata);
         idAllocator = new PlanNodeIdAllocator();
         variableAllocator = new VariableAllocator();
         schemaTableName = new SchemaTableName("default", "table_1");

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/optimization/TestClpFilterToKql.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/optimization/TestClpFilterToKql.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.plugin.clp.optimization;
 
 import com.facebook.presto.common.type.Type;
+import com.facebook.presto.plugin.clp.ClpColumnHandle;
 import com.facebook.presto.plugin.clp.TestClpQueryBase;
 import com.facebook.presto.plugin.clp.split.ClpSplitMetadataConfig;
 import com.facebook.presto.spi.ColumnHandle;
@@ -403,13 +404,21 @@ public class TestClpFilterToKql
             }
         };
 
+        // Build column type map from variableToColumnHandleMap
+        Map<String, Type> allColumnTypes = new HashMap<>();
+        for (Map.Entry<VariableReferenceExpression, ColumnHandle> entry : variableToColumnHandleMap.entrySet()) {
+            ClpColumnHandle columnHandle = (ClpColumnHandle) entry.getValue();
+            allColumnTypes.put(columnHandle.getOriginalColumnName(), columnHandle.getColumnType());
+        }
+
         return pushDownExpression.accept(
                 new ClpFilterToKqlConverter(
                         standardFunctionResolution,
                         functionAndTypeManager,
                         assignments,
                         stubConfig,
-                        testTableName),
+                        testTableName,
+                        allColumnTypes),
                 null);
     }
 

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/optimization/TestClpFilterToKql.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/optimization/TestClpFilterToKql.java
@@ -354,7 +354,7 @@ public class TestClpFilterToKql
                 dataColumnsWithRangeBounds,
                 exposedToRangeMapping);
 
-        // Test multiple exposed columns in logical binary expression
+        // Test multiple exposed columns in the logical binary expression
         testPushDownWithExposedRangeBound(
                 sessionHolder,
                 "timestampExposed >= '100'",

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/optimization/TestClpFilterToKql.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/optimization/TestClpFilterToKql.java
@@ -27,16 +27,15 @@ import com.google.common.collect.ImmutableSet;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -427,15 +426,6 @@ public class TestClpFilterToKql
         when(mockMetadataConfig.getExposedToRangeMapping(any(SchemaTableName.class)))
                 .thenReturn(exposedToRangeMapping);
 
-        // Add data columns with range bounds to columnHandles if not already present
-        Map<String, ColumnHandle> extendedColumnHandles = new HashMap<>(columnHandles);
-        for (String dataColumn : dataColumnsWithRangeBounds) {
-            if (!extendedColumnHandles.containsKey(dataColumn)) {
-                // Create a mock ClpColumnHandle for the missing data column
-                extendedColumnHandles.put(dataColumn, new ClpColumnHandle(dataColumn, BIGINT));
-            }
-        }
-
         return pushDownExpression.accept(
                 new ClpFilterToKqlConverter(
                         standardFunctionResolution,
@@ -443,7 +433,7 @@ public class TestClpFilterToKql
                         assignments,
                         mockMetadataConfig,
                         testTableName,
-                        extendedColumnHandles),
+                        columnHandles),
                 null);
     }
 

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/optimization/TestClpFilterToKql.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/optimization/TestClpFilterToKql.java
@@ -116,7 +116,11 @@ public class TestClpFilterToKql
 
         // If the last two arguments of BETWEEN are not numeric constants, then the CLP connector
         // won't push them down.
-        testPushDown(sessionHolder, "city.Name BETWEEN 'a' AND 'b'", null, "city.Name BETWEEN 'a' AND 'b'");
+        testPushDown(
+                sessionHolder,
+                "city.Name BETWEEN 'a' AND 'b'",
+                "city.Name >= 'a' AND city.Name <= 'b'",
+                null);
     }
 
     @Test

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/optimization/TestClpFilterToKql.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/optimization/TestClpFilterToKql.java
@@ -13,8 +13,11 @@
  */
 package com.facebook.presto.plugin.clp.optimization;
 
+import com.facebook.presto.common.type.Type;
 import com.facebook.presto.plugin.clp.TestClpQueryBase;
+import com.facebook.presto.plugin.clp.split.ClpSplitMetadataConfig;
 import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.planner.TypeProvider;
@@ -379,13 +382,34 @@ public class TestClpFilterToKql
     {
         RowExpression pushDownExpression = getRowExpression(sqlExpression, sessionHolder);
         Map<VariableReferenceExpression, ColumnHandle> assignments = new HashMap<>(variableToColumnHandleMap);
+
+        // Create a stub ClpSplitMetadataConfig that returns the provided sets
+        SchemaTableName testTableName = new SchemaTableName("test", "table");
+        ClpSplitMetadataConfig stubConfig = new ClpSplitMetadataConfig(null, functionAndTypeManager) {
+            @Override
+            public Map<String, Type> getMetadataColumns(SchemaTableName name)
+            {
+                Map<String, Type> result = new HashMap<>();
+                for (String col : metadataFilterColumns) {
+                    result.put(col, BIGINT);
+                }
+                return result;
+            }
+
+            @Override
+            public Set<String> getDataColumnsWithRangeBounds(SchemaTableName name)
+            {
+                return dataColumnsWithRangeBounds;
+            }
+        };
+
         return pushDownExpression.accept(
                 new ClpFilterToKqlConverter(
                         standardFunctionResolution,
                         functionAndTypeManager,
                         assignments,
-                        metadataFilterColumns,
-                        dataColumnsWithRangeBounds),
+                        stubConfig,
+                        testTableName),
                 null);
     }
 

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/optimization/TestClpFilterToKql.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/optimization/TestClpFilterToKql.java
@@ -53,14 +53,13 @@ public class TestClpFilterToKql
     {
         testTableName = new SchemaTableName("test", "table");
 
-        // Build column handles map from variableToColumnHandleMap
+        // Build table schema
         columnHandles = ImmutableMap.copyOf(
                 variableToColumnHandleMap.entrySet().stream()
                         .collect(java.util.stream.Collectors.toMap(
                                 e -> ((ClpColumnHandle) e.getValue()).getOriginalColumnName(),
                                 Map.Entry::getValue)));
 
-        // Create mock ClpSplitMetadataConfig
         mockMetadataConfig = mock(ClpSplitMetadataConfig.class);
     }
 
@@ -147,7 +146,7 @@ public class TestClpFilterToKql
         testPushDown(
                 sessionHolder,
                 "city.Name BETWEEN 'a' AND 'b'",
-                "city.Name >= 'a' AND city.Name <= 'b'",
+                "city.Name >= \"a\" AND city.Name <= \"b\"",
                 null);
     }
 
@@ -266,6 +265,7 @@ public class TestClpFilterToKql
     {
         SessionHolder sessionHolder = new SessionHolder();
         Set<String> testMetadataFilterColumns = ImmutableSet.of("fare");
+        // Assuming no exposed name, directly reference the bounded data column
         Set<String> testDataColumnsWithRangeBounds = ImmutableSet.of("city.Region.Id");
 
         // Normal case
@@ -318,6 +318,102 @@ public class TestClpFilterToKql
                 TypeProvider.viewOf(ImmutableMap.of("city.Region.Id", BIGINT)),
                 testMetadataFilterColumns,
                 testDataColumnsWithRangeBounds);
+    }
+
+    @Test
+    public void testExposedRangeBoundColumnResolutionToDataColumn()
+    {
+        SessionHolder sessionHolder = new SessionHolder();
+
+        // Define explicit mapping: exposed column name -> data column name
+        Map<String, String> exposedToRangeMapping = ImmutableMap.of(
+                "timestampExposed", "timestampData",
+                "valueExposed", "valueData",
+                "varCharExposed", "bigIntData");  // Different types: exposed is VARCHAR, data is BIGINT
+
+        // The data columns that have range bounds in metadata
+        Set<String> dataColumnsWithRangeBounds = ImmutableSet.of("timestampData", "valueData", "bigIntData");
+
+        // Test BETWEEN with VARCHAR exposed columns
+        testPushDownWithExposedRangeBound(
+                sessionHolder,
+                "timestampExposed BETWEEN '100' AND '200'",
+                "timestampData >= \"100\" AND timestampData <= \"200\"",
+                null,  // no remaining expression
+                ImmutableSet.of(),  // no metadata-only columns
+                dataColumnsWithRangeBounds,
+                exposedToRangeMapping);
+
+        // Test comparison with the BIGINT exposed column
+        testPushDownWithExposedRangeBound(
+                sessionHolder,
+                "valueExposed >= 50",
+                "valueData >= 50",
+                null,
+                ImmutableSet.of(),
+                dataColumnsWithRangeBounds,
+                exposedToRangeMapping);
+
+        // Test multiple exposed columns in logical binary expression
+        testPushDownWithExposedRangeBound(
+                sessionHolder,
+                "timestampExposed >= '100'",
+                "timestampData >= \"100\"",
+                null,
+                ImmutableSet.of(),
+                dataColumnsWithRangeBounds,
+                exposedToRangeMapping);
+
+        testPushDownWithExposedRangeBound(
+                sessionHolder,
+                "timestampExposed = '100'",
+                "timestampData: \"100\"",
+                null,
+                ImmutableSet.of(),
+                dataColumnsWithRangeBounds,
+                exposedToRangeMapping);
+
+        testPushDownWithExposedRangeBound(
+                sessionHolder,
+                "timestampExposed <= '200'",
+                "timestampData <= \"200\"",
+                null,
+                ImmutableSet.of(),
+                dataColumnsWithRangeBounds,
+                exposedToRangeMapping);
+
+        // Test multiple exposed columns in compound expression
+        testPushDownWithExposedRangeBound(
+                sessionHolder,
+                "timestampExposed >= '100' AND valueExposed < 200",
+                "(timestampData >= \"100\" AND valueData < 200)",
+                null,
+                ImmutableSet.of(),
+                dataColumnsWithRangeBounds,
+                exposedToRangeMapping);
+
+        // Test exposed column with different type from data column
+        // varCharExposed is VARCHAR (metadata type), but bigIntData is BIGINT (actual data type)
+        // The generated KQL should use bigIntData with BIGINT type
+        testPushDownWithExposedRangeBound(
+                sessionHolder,
+                "varCharExposed >= '10'",
+                "bigIntData >= 10",
+                null,
+                ImmutableSet.of(),
+                dataColumnsWithRangeBounds,
+                exposedToRangeMapping);
+
+
+        // Test compound expression with type-mismatched exposed column
+        testPushDownWithExposedRangeBound(
+                sessionHolder,
+                "varCharExposed > '50' AND varCharExposed < '1000'",
+                "(bigIntData > 50 AND bigIntData < 1000)",
+                null,
+                ImmutableSet.of(),
+                dataColumnsWithRangeBounds,
+                exposedToRangeMapping);
     }
 
     @Test
@@ -377,6 +473,19 @@ public class TestClpFilterToKql
                 dataColumnsWithRangeBounds);
     }
 
+    private void testPushDownWithExposedRangeBound(
+            SessionHolder sessionHolder,
+            String sql,
+            String expectedKql,
+            String expectedRemaining,
+            Set<String> metadataFilterColumns,
+            Set<String> dataColumnsWithRangeBounds,
+            Map<String, String> exposedToRangeMapping)
+    {
+        ClpExpression clpExpression = tryPushDown(sql, sessionHolder, metadataFilterColumns, dataColumnsWithRangeBounds, exposedToRangeMapping);
+        testFilter(clpExpression, expectedKql, expectedRemaining, sessionHolder);
+    }
+
     private void testPushDown(
             SessionHolder sessionHolder,
             String sql,
@@ -388,6 +497,7 @@ public class TestClpFilterToKql
     {
         ClpExpression clpExpression = tryPushDown(sql, sessionHolder, metadataFilterColumns, dataColumnsWithRangeBounds);
         testFilter(clpExpression, expectedKql, null, sessionHolder);
+        // verify metadata split pruning
         if (expectedMetadataSqlQuery != null) {
             assertTrue(clpExpression.getMetadataExpression().isPresent());
             assertEquals(
@@ -399,16 +509,36 @@ public class TestClpFilterToKql
         }
     }
 
+    /**
+     * Test helper for filter pushdown with default identity mapping for exposed columns.
+     */
     private ClpExpression tryPushDown(
             String sqlExpression,
             SessionHolder sessionHolder,
             Set<String> metadataFilterColumns,
             Set<String> dataColumnsWithRangeBounds)
     {
+        // Build identity mapping: exposed name -> data column name (same name)
+        Map<String, String> exposedToRangeMapping = new HashMap<>();
+        for (String dataColumn : dataColumnsWithRangeBounds) {
+            exposedToRangeMapping.put(dataColumn, dataColumn);
+        }
+        return tryPushDown(sqlExpression, sessionHolder, metadataFilterColumns, dataColumnsWithRangeBounds, exposedToRangeMapping);
+    }
+
+    /**
+     * Test helper for filter pushdown with explicit exposed-to-data column mapping.
+     */
+    private ClpExpression tryPushDown(
+            String sqlExpression,
+            SessionHolder sessionHolder,
+            Set<String> metadataFilterColumns,
+            Set<String> dataColumnsWithRangeBounds,
+            Map<String, String> exposedToRangeMapping)
+    {
         RowExpression pushDownExpression = getRowExpression(sqlExpression, sessionHolder);
         Map<VariableReferenceExpression, ColumnHandle> assignments = new HashMap<>(variableToColumnHandleMap);
 
-        // Configure the mock for this test case
         Map<String, Type> metadataColumnsMap = new HashMap<>();
         for (String col : metadataFilterColumns) {
             metadataColumnsMap.put(col, BIGINT);
@@ -417,12 +547,6 @@ public class TestClpFilterToKql
                 .thenReturn(metadataColumnsMap);
         when(mockMetadataConfig.getDataColumnsWithRangeBounds(any(SchemaTableName.class)))
                 .thenReturn(dataColumnsWithRangeBounds);
-
-        // Build identity mapping: exposed name -> data column name (same name)
-        Map<String, String> exposedToRangeMapping = new HashMap<>();
-        for (String dataColumn : dataColumnsWithRangeBounds) {
-            exposedToRangeMapping.put(dataColumn, dataColumn);
-        }
         when(mockMetadataConfig.getExposedToRangeMapping(any(SchemaTableName.class)))
                 .thenReturn(exposedToRangeMapping);
 

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/optimization/TestClpFilterToKql.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/optimization/TestClpFilterToKql.java
@@ -15,8 +15,6 @@ package com.facebook.presto.plugin.clp.optimization;
 
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.plugin.clp.ClpColumnHandle;
-import com.facebook.presto.plugin.clp.ClpMetadata;
-import com.facebook.presto.plugin.clp.ClpTableHandle;
 import com.facebook.presto.plugin.clp.TestClpQueryBase;
 import com.facebook.presto.plugin.clp.split.ClpSplitMetadataConfig;
 import com.facebook.presto.spi.ColumnHandle;
@@ -406,21 +404,12 @@ public class TestClpFilterToKql
             }
         };
 
-        // Create a stub ClpMetadata that returns the column handles
-        ClpMetadata stubMetadata = new ClpMetadata(null, null) {
-            @Override
-            public Map<String, ColumnHandle> getColumnHandles(
-                    com.facebook.presto.spi.ConnectorSession session,
-                    com.facebook.presto.spi.ConnectorTableHandle tableHandle)
-            {
-                return ImmutableMap.copyOf(variableToColumnHandleMap.entrySet().stream()
+        // Build column handles map from variableToColumnHandleMap
+        Map<String, ColumnHandle> columnHandles = ImmutableMap.copyOf(
+                variableToColumnHandleMap.entrySet().stream()
                         .collect(java.util.stream.Collectors.toMap(
                                 e -> ((ClpColumnHandle) e.getValue()).getOriginalColumnName(),
                                 Map.Entry::getValue)));
-            }
-        };
-
-        ClpTableHandle clpTableHandle = new ClpTableHandle(testTableName, "test");
 
         return pushDownExpression.accept(
                 new ClpFilterToKqlConverter(
@@ -429,8 +418,7 @@ public class TestClpFilterToKql
                         assignments,
                         stubConfig,
                         testTableName,
-                        stubMetadata,
-                        clpTableHandle),
+                        columnHandles),
                 null);
     }
 

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/optimization/TestClpFilterToKql.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/optimization/TestClpFilterToKql.java
@@ -404,7 +404,6 @@ public class TestClpFilterToKql
                 dataColumnsWithRangeBounds,
                 exposedToRangeMapping);
 
-
         // Test compound expression with type-mismatched exposed column
         testPushDownWithExposedRangeBound(
                 sessionHolder,

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/optimization/TestClpFilterToKql.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/optimization/TestClpFilterToKql.java
@@ -24,7 +24,12 @@ import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.planner.TypeProvider;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -40,6 +45,26 @@ import static org.testng.Assert.assertTrue;
 public class TestClpFilterToKql
         extends TestClpQueryBase
 {
+    private ClpSplitMetadataConfig mockMetadataConfig;
+    private SchemaTableName testTableName;
+    private Map<String, ColumnHandle> columnHandles;
+
+    @BeforeMethod
+    public void setUp()
+    {
+        testTableName = new SchemaTableName("test", "table");
+
+        // Build column handles map from variableToColumnHandleMap
+        columnHandles = ImmutableMap.copyOf(
+                variableToColumnHandleMap.entrySet().stream()
+                        .collect(java.util.stream.Collectors.toMap(
+                                e -> ((ClpColumnHandle) e.getValue()).getOriginalColumnName(),
+                                Map.Entry::getValue)));
+
+        // Create mock ClpSplitMetadataConfig
+        mockMetadataConfig = mock(ClpSplitMetadataConfig.class);
+    }
+
     @Test
     public void testStringMatchPushDown()
     {
@@ -384,41 +409,41 @@ public class TestClpFilterToKql
         RowExpression pushDownExpression = getRowExpression(sqlExpression, sessionHolder);
         Map<VariableReferenceExpression, ColumnHandle> assignments = new HashMap<>(variableToColumnHandleMap);
 
-        // Create a stub ClpSplitMetadataConfig that returns the provided sets
-        SchemaTableName testTableName = new SchemaTableName("test", "table");
-        ClpSplitMetadataConfig stubConfig = new ClpSplitMetadataConfig(null, functionAndTypeManager) {
-            @Override
-            public Map<String, Type> getMetadataColumns(SchemaTableName name)
-            {
-                Map<String, Type> result = new HashMap<>();
-                for (String col : metadataFilterColumns) {
-                    result.put(col, BIGINT);
-                }
-                return result;
-            }
+        // Configure the mock for this test case
+        Map<String, Type> metadataColumnsMap = new HashMap<>();
+        for (String col : metadataFilterColumns) {
+            metadataColumnsMap.put(col, BIGINT);
+        }
+        when(mockMetadataConfig.getMetadataColumns(any(SchemaTableName.class)))
+                .thenReturn(metadataColumnsMap);
+        when(mockMetadataConfig.getDataColumnsWithRangeBounds(any(SchemaTableName.class)))
+                .thenReturn(dataColumnsWithRangeBounds);
 
-            @Override
-            public Set<String> getDataColumnsWithRangeBounds(SchemaTableName name)
-            {
-                return dataColumnsWithRangeBounds;
-            }
-        };
+        // Build identity mapping: exposed name -> data column name (same name)
+        Map<String, String> exposedToRangeMapping = new HashMap<>();
+        for (String dataColumn : dataColumnsWithRangeBounds) {
+            exposedToRangeMapping.put(dataColumn, dataColumn);
+        }
+        when(mockMetadataConfig.getExposedToRangeMapping(any(SchemaTableName.class)))
+                .thenReturn(exposedToRangeMapping);
 
-        // Build column handles map from variableToColumnHandleMap
-        Map<String, ColumnHandle> columnHandles = ImmutableMap.copyOf(
-                variableToColumnHandleMap.entrySet().stream()
-                        .collect(java.util.stream.Collectors.toMap(
-                                e -> ((ClpColumnHandle) e.getValue()).getOriginalColumnName(),
-                                Map.Entry::getValue)));
+        // Add data columns with range bounds to columnHandles if not already present
+        Map<String, ColumnHandle> extendedColumnHandles = new HashMap<>(columnHandles);
+        for (String dataColumn : dataColumnsWithRangeBounds) {
+            if (!extendedColumnHandles.containsKey(dataColumn)) {
+                // Create a mock ClpColumnHandle for the missing data column
+                extendedColumnHandles.put(dataColumn, new ClpColumnHandle(dataColumn, BIGINT));
+            }
+        }
 
         return pushDownExpression.accept(
                 new ClpFilterToKqlConverter(
                         standardFunctionResolution,
                         functionAndTypeManager,
                         assignments,
-                        stubConfig,
+                        mockMetadataConfig,
                         testTableName,
-                        columnHandles),
+                        extendedColumnHandles),
                 null);
     }
 

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/optimization/TestClpUdfRewriter.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/optimization/TestClpUdfRewriter.java
@@ -139,7 +139,6 @@ public class TestClpUdfRewriter
         planNodeIdAllocator = new PlanNodeIdAllocator();
         variableAllocator = new VariableAllocator();
 
-        // Create mock ClpMetadata
         mockClpMetadata = mock(ClpMetadata.class);
         when(mockClpMetadata.getColumnHandles(any(), any()))
                 .thenReturn(ImmutableMap.of(

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/optimization/TestClpUdfRewriter.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/optimization/TestClpUdfRewriter.java
@@ -158,7 +158,18 @@ public class TestClpUdfRewriter
                 WarningCollector.NOOP);
         ClpUdfRewriter udfRewriter = new ClpUdfRewriter(functionAndTypeManager);
         PlanNode optimizedPlan = udfRewriter.optimize(plan.getRoot(), session.toConnectorSession(), variableAllocator, planNodeIdAllocator);
-        ClpComputePushDown optimizer = new ClpComputePushDown(functionAndTypeManager, functionResolution, splitMetadataConfig);
+        // Create a stub ClpMetadata for testing
+        ClpMetadata stubMetadata = new ClpMetadata(null, null) {
+            @Override
+            public java.util.Map<String, ColumnHandle> getColumnHandles(com.facebook.presto.spi.ConnectorSession session, com.facebook.presto.spi.ConnectorTableHandle tableHandle)
+            {
+                return com.google.common.collect.ImmutableMap.of(
+                        TestClpQueryBase.city.getColumnName(), TestClpQueryBase.city,
+                        TestClpQueryBase.fare.getColumnName(), TestClpQueryBase.fare,
+                        TestClpQueryBase.isHoliday.getColumnName(), TestClpQueryBase.isHoliday);
+            }
+        };
+        ClpComputePushDown optimizer = new ClpComputePushDown(functionAndTypeManager, functionResolution, splitMetadataConfig, stubMetadata);
         optimizedPlan = optimizer.optimize(optimizedPlan, session.toConnectorSession(), variableAllocator, planNodeIdAllocator);
 
         PlanAssert.assertPlan(
@@ -197,7 +208,18 @@ public class TestClpUdfRewriter
                 WarningCollector.NOOP);
         ClpUdfRewriter udfRewriter = new ClpUdfRewriter(functionAndTypeManager);
         PlanNode optimizedPlan = udfRewriter.optimize(plan.getRoot(), session.toConnectorSession(), variableAllocator, planNodeIdAllocator);
-        ClpComputePushDown optimizer = new ClpComputePushDown(functionAndTypeManager, functionResolution, splitMetadataConfig);
+        // Create a stub ClpMetadata for testing
+        ClpMetadata stubMetadata = new ClpMetadata(null, null) {
+            @Override
+            public java.util.Map<String, ColumnHandle> getColumnHandles(com.facebook.presto.spi.ConnectorSession session, com.facebook.presto.spi.ConnectorTableHandle tableHandle)
+            {
+                return com.google.common.collect.ImmutableMap.of(
+                        TestClpQueryBase.city.getColumnName(), TestClpQueryBase.city,
+                        TestClpQueryBase.fare.getColumnName(), TestClpQueryBase.fare,
+                        TestClpQueryBase.isHoliday.getColumnName(), TestClpQueryBase.isHoliday);
+            }
+        };
+        ClpComputePushDown optimizer = new ClpComputePushDown(functionAndTypeManager, functionResolution, splitMetadataConfig, stubMetadata);
         optimizedPlan = optimizer.optimize(optimizedPlan, session.toConnectorSession(), variableAllocator, planNodeIdAllocator);
 
         PlanAssert.assertPlan(
@@ -246,7 +268,18 @@ public class TestClpUdfRewriter
                 WarningCollector.NOOP);
         ClpUdfRewriter udfRewriter = new ClpUdfRewriter(functionAndTypeManager);
         PlanNode optimizedPlan = udfRewriter.optimize(plan.getRoot(), session.toConnectorSession(), variableAllocator, planNodeIdAllocator);
-        ClpComputePushDown optimizer = new ClpComputePushDown(functionAndTypeManager, functionResolution, splitMetadataConfig);
+        // Create a stub ClpMetadata for testing
+        ClpMetadata stubMetadata = new ClpMetadata(null, null) {
+            @Override
+            public java.util.Map<String, ColumnHandle> getColumnHandles(com.facebook.presto.spi.ConnectorSession session, com.facebook.presto.spi.ConnectorTableHandle tableHandle)
+            {
+                return com.google.common.collect.ImmutableMap.of(
+                        TestClpQueryBase.city.getColumnName(), TestClpQueryBase.city,
+                        TestClpQueryBase.fare.getColumnName(), TestClpQueryBase.fare,
+                        TestClpQueryBase.isHoliday.getColumnName(), TestClpQueryBase.isHoliday);
+            }
+        };
+        ClpComputePushDown optimizer = new ClpComputePushDown(functionAndTypeManager, functionResolution, splitMetadataConfig, stubMetadata);
         optimizedPlan = optimizer.optimize(optimizedPlan, session.toConnectorSession(), variableAllocator, planNodeIdAllocator);
 
         PlanAssert.assertPlan(
@@ -283,7 +316,18 @@ public class TestClpUdfRewriter
                 WarningCollector.NOOP);
         ClpUdfRewriter udfRewriter = new ClpUdfRewriter(functionAndTypeManager);
         PlanNode optimizedPlan = udfRewriter.optimize(plan.getRoot(), session.toConnectorSession(), variableAllocator, planNodeIdAllocator);
-        ClpComputePushDown optimizer = new ClpComputePushDown(functionAndTypeManager, functionResolution, splitMetadataConfig);
+        // Create a stub ClpMetadata for testing
+        ClpMetadata stubMetadata = new ClpMetadata(null, null) {
+            @Override
+            public java.util.Map<String, ColumnHandle> getColumnHandles(com.facebook.presto.spi.ConnectorSession session, com.facebook.presto.spi.ConnectorTableHandle tableHandle)
+            {
+                return com.google.common.collect.ImmutableMap.of(
+                        TestClpQueryBase.city.getColumnName(), TestClpQueryBase.city,
+                        TestClpQueryBase.fare.getColumnName(), TestClpQueryBase.fare,
+                        TestClpQueryBase.isHoliday.getColumnName(), TestClpQueryBase.isHoliday);
+            }
+        };
+        ClpComputePushDown optimizer = new ClpComputePushDown(functionAndTypeManager, functionResolution, splitMetadataConfig, stubMetadata);
         optimizedPlan = optimizer.optimize(optimizedPlan, session.toConnectorSession(), variableAllocator, planNodeIdAllocator);
 
         PlanAssert.assertPlan(

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/optimization/TestClpUdfRewriter.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/optimization/TestClpUdfRewriter.java
@@ -79,6 +79,9 @@ import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.filter
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.node;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @Test(singleThreaded = true)
 public class TestClpUdfRewriter
@@ -98,6 +101,7 @@ public class TestClpUdfRewriter
     private ClpSplitMetadataConfig splitMetadataConfig;
     private PlanNodeIdAllocator planNodeIdAllocator;
     private VariableAllocator variableAllocator;
+    private ClpMetadata mockClpMetadata;
 
     @BeforeMethod
     public void setUp()
@@ -134,6 +138,14 @@ public class TestClpUdfRewriter
         splitMetadataConfig = new ClpSplitMetadataConfig(new ClpConfig(), functionAndTypeManager);
         planNodeIdAllocator = new PlanNodeIdAllocator();
         variableAllocator = new VariableAllocator();
+
+        // Create mock ClpMetadata
+        mockClpMetadata = mock(ClpMetadata.class);
+        when(mockClpMetadata.getColumnHandles(any(), any()))
+                .thenReturn(ImmutableMap.of(
+                        TestClpQueryBase.city.getColumnName(), TestClpQueryBase.city,
+                        TestClpQueryBase.fare.getColumnName(), TestClpQueryBase.fare,
+                        TestClpQueryBase.isHoliday.getColumnName(), TestClpQueryBase.isHoliday));
     }
 
     @AfterMethod
@@ -158,18 +170,7 @@ public class TestClpUdfRewriter
                 WarningCollector.NOOP);
         ClpUdfRewriter udfRewriter = new ClpUdfRewriter(functionAndTypeManager);
         PlanNode optimizedPlan = udfRewriter.optimize(plan.getRoot(), session.toConnectorSession(), variableAllocator, planNodeIdAllocator);
-        // Create a stub ClpMetadata for testing
-        ClpMetadata stubMetadata = new ClpMetadata(null, null) {
-            @Override
-            public java.util.Map<String, ColumnHandle> getColumnHandles(com.facebook.presto.spi.ConnectorSession session, com.facebook.presto.spi.ConnectorTableHandle tableHandle)
-            {
-                return com.google.common.collect.ImmutableMap.of(
-                        TestClpQueryBase.city.getColumnName(), TestClpQueryBase.city,
-                        TestClpQueryBase.fare.getColumnName(), TestClpQueryBase.fare,
-                        TestClpQueryBase.isHoliday.getColumnName(), TestClpQueryBase.isHoliday);
-            }
-        };
-        ClpComputePushDown optimizer = new ClpComputePushDown(functionAndTypeManager, functionResolution, splitMetadataConfig, stubMetadata);
+        ClpComputePushDown optimizer = new ClpComputePushDown(functionAndTypeManager, functionResolution, splitMetadataConfig, mockClpMetadata);
         optimizedPlan = optimizer.optimize(optimizedPlan, session.toConnectorSession(), variableAllocator, planNodeIdAllocator);
 
         PlanAssert.assertPlan(
@@ -208,18 +209,7 @@ public class TestClpUdfRewriter
                 WarningCollector.NOOP);
         ClpUdfRewriter udfRewriter = new ClpUdfRewriter(functionAndTypeManager);
         PlanNode optimizedPlan = udfRewriter.optimize(plan.getRoot(), session.toConnectorSession(), variableAllocator, planNodeIdAllocator);
-        // Create a stub ClpMetadata for testing
-        ClpMetadata stubMetadata = new ClpMetadata(null, null) {
-            @Override
-            public java.util.Map<String, ColumnHandle> getColumnHandles(com.facebook.presto.spi.ConnectorSession session, com.facebook.presto.spi.ConnectorTableHandle tableHandle)
-            {
-                return com.google.common.collect.ImmutableMap.of(
-                        TestClpQueryBase.city.getColumnName(), TestClpQueryBase.city,
-                        TestClpQueryBase.fare.getColumnName(), TestClpQueryBase.fare,
-                        TestClpQueryBase.isHoliday.getColumnName(), TestClpQueryBase.isHoliday);
-            }
-        };
-        ClpComputePushDown optimizer = new ClpComputePushDown(functionAndTypeManager, functionResolution, splitMetadataConfig, stubMetadata);
+        ClpComputePushDown optimizer = new ClpComputePushDown(functionAndTypeManager, functionResolution, splitMetadataConfig, mockClpMetadata);
         optimizedPlan = optimizer.optimize(optimizedPlan, session.toConnectorSession(), variableAllocator, planNodeIdAllocator);
 
         PlanAssert.assertPlan(
@@ -268,18 +258,7 @@ public class TestClpUdfRewriter
                 WarningCollector.NOOP);
         ClpUdfRewriter udfRewriter = new ClpUdfRewriter(functionAndTypeManager);
         PlanNode optimizedPlan = udfRewriter.optimize(plan.getRoot(), session.toConnectorSession(), variableAllocator, planNodeIdAllocator);
-        // Create a stub ClpMetadata for testing
-        ClpMetadata stubMetadata = new ClpMetadata(null, null) {
-            @Override
-            public java.util.Map<String, ColumnHandle> getColumnHandles(com.facebook.presto.spi.ConnectorSession session, com.facebook.presto.spi.ConnectorTableHandle tableHandle)
-            {
-                return com.google.common.collect.ImmutableMap.of(
-                        TestClpQueryBase.city.getColumnName(), TestClpQueryBase.city,
-                        TestClpQueryBase.fare.getColumnName(), TestClpQueryBase.fare,
-                        TestClpQueryBase.isHoliday.getColumnName(), TestClpQueryBase.isHoliday);
-            }
-        };
-        ClpComputePushDown optimizer = new ClpComputePushDown(functionAndTypeManager, functionResolution, splitMetadataConfig, stubMetadata);
+        ClpComputePushDown optimizer = new ClpComputePushDown(functionAndTypeManager, functionResolution, splitMetadataConfig, mockClpMetadata);
         optimizedPlan = optimizer.optimize(optimizedPlan, session.toConnectorSession(), variableAllocator, planNodeIdAllocator);
 
         PlanAssert.assertPlan(
@@ -316,18 +295,7 @@ public class TestClpUdfRewriter
                 WarningCollector.NOOP);
         ClpUdfRewriter udfRewriter = new ClpUdfRewriter(functionAndTypeManager);
         PlanNode optimizedPlan = udfRewriter.optimize(plan.getRoot(), session.toConnectorSession(), variableAllocator, planNodeIdAllocator);
-        // Create a stub ClpMetadata for testing
-        ClpMetadata stubMetadata = new ClpMetadata(null, null) {
-            @Override
-            public java.util.Map<String, ColumnHandle> getColumnHandles(com.facebook.presto.spi.ConnectorSession session, com.facebook.presto.spi.ConnectorTableHandle tableHandle)
-            {
-                return com.google.common.collect.ImmutableMap.of(
-                        TestClpQueryBase.city.getColumnName(), TestClpQueryBase.city,
-                        TestClpQueryBase.fare.getColumnName(), TestClpQueryBase.fare,
-                        TestClpQueryBase.isHoliday.getColumnName(), TestClpQueryBase.isHoliday);
-            }
-        };
-        ClpComputePushDown optimizer = new ClpComputePushDown(functionAndTypeManager, functionResolution, splitMetadataConfig, stubMetadata);
+        ClpComputePushDown optimizer = new ClpComputePushDown(functionAndTypeManager, functionResolution, splitMetadataConfig, mockClpMetadata);
         optimizedPlan = optimizer.optimize(optimizedPlan, session.toConnectorSession(), variableAllocator, planNodeIdAllocator);
 
         PlanAssert.assertPlan(


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR fixes issue: https://github.com/y-scope/presto/issues/121.

This PR implements support for exposed metadata columns that map to range-bound metadata columns and data column, enabling proper 1) data pushdown with correct type resolution and 2) metadata split pruning with range mapping filtering .

Certain metadata columns exposed to users map to actual data columns with range bounds stored in the metadata database. When these exposed columns are used in filter clause:
  1. The exposed column name needs to be resolved to the underlying data column name and type for **KQL pushdown**.
  2. The exposed column name needs to be resolved to the range-bound metadata column name and type for **split pruning**.

Without this resolution, optimization of data pushdown and split pruning would not be effective.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
- All unit tests.
- E2E testing:
  - Range-mapped filter clause with BETWEEN syntax
    - `SELECT severity, timestamp FROM clp.DEFAULT.cockroachdb_ir WHERE (ts >= '1679710000570000000' AND ts <='1679711330571000000')` where ts is maps to VARCHAR creationtime as lower bound, VARCHAR lastmodifiedtime as upper bound, and BIGINT timestamp as the data field
    - The resulting KQL is: `ts >= 1679710000570000000 AND ts <= 1679711330571000000`
    - The resulting Pinot SQL is: `SELECT tpath, lastmodifiedtime FROM cockroachdb_ir WHERE 1 = 1 AND ((lastmodifiedtime >= '167971000057000000') AND (creationtime <= '1679711330571000000')) LIMIT 999999`
    - Note that the constant values in KQL should be integer, whereas the constant values in Pinot SQL should be string.
  - Range-mapped filter clause with Logical Binary syntax
    - `SELECT severity, timestamp FROM clp.DEFAULT.cockroachdb_ir WHERE  ts <='1679711330571000000'` where ts is maps to VARCHAR creationtime as lower bound, VARCHAR lastmodifiedtime as upper bound, and BIGINT timestamp as the data field
    - The resulting KQL is: ` ts <= 1679711330571000000`
    - The resulting Pinot SQL is: `SELECT tpath, lastmodifiedtime FROM cockroachdb_ir WHERE 1 = 1 AND (creationtime <= '1679711330571000000')) LIMIT 999999`
    - Note that the constant values in KQL should be integer, whereas the constant values in Pinot SQL should be string.


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal metadata handling throughout the query optimizer to support more flexible configuration-driven approaches.
  * Enhanced dependency injection for better separation of concerns in the optimization pipeline.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->