### PR TITLE
fix: Remove redundant ORDER BY clauses from metadata database queries for TopN (fixes #107).

### DIFF
--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpMySqlSplitProvider.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpMySqlSplitProvider.java
@@ -121,9 +121,6 @@ public class ClpMySqlSplitProvider
                 upperBound = dataColumnRangeMapping.get(columnName).getOrDefault("upperBound", upperBound);
             }
 
-            String dir = (ordering.getOrder() == ClpTopNSpec.Order.ASC) ? "ASC" : "DESC";
-            archivePathQuery += " ORDER BY " + "`" + upperBound + "` " + dir;
-
             List<ArchiveMeta> archiveMetaList = fetchArchiveMeta(archivePathQuery, lowerBound, upperBound);
             List<ArchiveMeta> selected = selectTopNArchives(archiveMetaList, topNSpec.getLimit(), ordering.getOrder());
 

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpPinotSplitProvider.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpPinotSplitProvider.java
@@ -64,7 +64,7 @@ public class ClpPinotSplitProvider
         implements ClpSplitProvider
 {
     private static final String SQL_SELECT_SPLITS_TEMPLATE = "SELECT %s FROM %s WHERE 1 = 1 AND (%s) LIMIT 999999";
-    private static final String SQL_SELECT_SPLIT_META_TEMPLATE = "SELECT tpath, creationtime, lastmodifiedtime, num_messages FROM %s WHERE 1 = 1 AND (%s) ORDER BY %s %s LIMIT 999999";
+    private static final String SQL_SELECT_SPLITS_TEMPLATE_WITH_TOPN = "SELECT tpath, creationtime, lastmodifiedtime, num_messages FROM %s WHERE 1 = 1 AND (%s) LIMIT 999999";
     private final ClpConfig config;
 
     protected static final Logger log = Logger.get(ClpPinotSplitProvider.class);
@@ -202,18 +202,9 @@ public class ClpPinotSplitProvider
             ImmutableList.Builder<ClpSplit> splits = new ImmutableList.Builder<>();
             if (topNSpecOptional.isPresent()) {
                 ClpTopNSpec topNSpec = topNSpecOptional.get();
-                // Only handles one range metadata column for now
                 ClpTopNSpec.Ordering ordering = topNSpec.getOrderings().get(0);
-                String columnName = ordering.getColumn();
-                String lowerBound = columnName;
-                String upperBound = columnName;
-                if (dataColumnRangeMapping.containsKey(columnName)) {
-                    lowerBound = dataColumnRangeMapping.get(columnName).getOrDefault("lowerBound", lowerBound);
-                    upperBound = dataColumnRangeMapping.get(columnName).getOrDefault("upperBound", upperBound);
-                }
 
-                String dir = (ordering.getOrder() == ClpTopNSpec.Order.ASC) ? "ASC" : "DESC";
-                String splitMetaQuery = buildSplitMetadataQuery(tableName, metadataFilterQuery.orElse("1 = 1"), upperBound, dir);
+                String splitMetaQuery = buildSplitSelectionQueryWithTopN(tableName, metadataFilterQuery.orElse("1 = 1"));
                 List<ArchiveMeta> archiveMetaList = fetchArchiveMeta(splitMetaQuery, ordering);
                 List<ArchiveMeta> selected = selectTopNArchives(archiveMetaList, topNSpec.getLimit(), ordering.getOrder());
 
@@ -486,14 +477,12 @@ public class ClpPinotSplitProvider
      *
      * @param tableName the Pinot table name
      * @param filterSql the filter SQL expression
-     * @param orderByColumn the column to order by
-     * @param orderDirection the order direction (ASC or DESC)
      * @return the complete SQL query for selecting split metadata
      */
     @VisibleForTesting
-    protected String buildSplitMetadataQuery(String tableName, String filterSql, String orderByColumn, String orderDirection)
+    protected String buildSplitSelectionQueryWithTopN(String tableName, String filterSql)
     {
-        return format(SQL_SELECT_SPLIT_META_TEMPLATE, tableName, filterSql, orderByColumn, orderDirection);
+        return format(SQL_SELECT_SPLITS_TEMPLATE_WITH_TOPN, tableName, filterSql);
     }
 
     /**

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpPinotSplitProvider.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpPinotSplitProvider.java
@@ -294,7 +294,8 @@ public class ClpPinotSplitProvider
     }
 
     /**
-     * Fetches archive metadata from the database.
+     * Fetches archive metadata from the database for TopN processing.
+     * The query must select: tpath, creationtime, lastmodifiedtime, num_messages.
      *
      * @param query    SQL query string that selects the archives
      * @param ordering The top-N ordering specifying which columns contain lowerBound/upperBound

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpUberPinotSplitProvider.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpUberPinotSplitProvider.java
@@ -94,18 +94,9 @@ public class ClpUberPinotSplitProvider
             ImmutableList.Builder<ClpSplit> splits = new ImmutableList.Builder<>();
             if (topNSpecOptional.isPresent()) {
                 ClpTopNSpec topNSpec = topNSpecOptional.get();
-                // Only handles one range metadata column for now
                 ClpTopNSpec.Ordering ordering = topNSpec.getOrderings().get(0);
-                String columnName = ordering.getColumn();
-                String lowerBound = columnName;
-                String upperBound = columnName;
-                if (dataColumnRangeMapping.containsKey(columnName)) {
-                    lowerBound = dataColumnRangeMapping.get(columnName).getOrDefault("lowerBound", lowerBound);
-                    upperBound = dataColumnRangeMapping.get(columnName).getOrDefault("upperBound", upperBound);
-                }
 
-                String dir = (ordering.getOrder() == ClpTopNSpec.Order.ASC) ? "ASC" : "DESC";
-                String splitMetaQuery = buildSplitMetadataQuery(tableName, metadataFilterQuery.orElse("1 = 1"), upperBound, dir);
+                String splitMetaQuery = buildSplitSelectionQueryWithTopN(tableName, metadataFilterQuery.orElse("1 = 1"));
                 List<ArchiveMeta> archiveMetaList = fetchArchiveMeta(splitMetaQuery, ordering);
                 List<ArchiveMeta> selected = selectTopNArchives(archiveMetaList, topNSpec.getLimit(), ordering.getOrder());
 

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/split/TestClpUberPinotSplitProvider.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/split/TestClpUberPinotSplitProvider.java
@@ -227,11 +227,11 @@ public class TestClpUberPinotSplitProvider
         assertTrue(query.contains("SELECT"));
         assertTrue(query.contains("tpath"));
 
-        // Test buildSplitMetadataQuery (inherited from parent)
-        String metaQuery = splitProvider.buildSplitSelectionQueryWithTopN("rta.logging.events", "timestamp > 1000", "timestamp", "DESC");
+        // Test buildSplitSelectionQueryWithTopN (inherited from parent)
+        String metaQuery = splitProvider.buildSplitSelectionQueryWithTopN("rta.logging.events", "timestamp > 1000");
         assertTrue(metaQuery.contains("rta.logging.events"));
         assertTrue(metaQuery.contains("timestamp > 1000"));
-        assertTrue(metaQuery.contains("ORDER BY timestamp DESC"));
+        assertTrue(metaQuery.contains("tpath"));
         assertTrue(metaQuery.contains("creationtime"));
         assertTrue(metaQuery.contains("lastmodifiedtime"));
         assertTrue(metaQuery.contains("num_messages"));

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/split/TestClpUberPinotSplitProvider.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/split/TestClpUberPinotSplitProvider.java
@@ -228,7 +228,7 @@ public class TestClpUberPinotSplitProvider
         assertTrue(query.contains("tpath"));
 
         // Test buildSplitMetadataQuery (inherited from parent)
-        String metaQuery = splitProvider.buildSplitMetadataQuery("rta.logging.events", "timestamp > 1000", "timestamp", "DESC");
+        String metaQuery = splitProvider.buildSplitSelectionQueryWithTopN("rta.logging.events", "timestamp > 1000", "timestamp", "DESC");
         assertTrue(metaQuery.contains("rta.logging.events"));
         assertTrue(metaQuery.contains("timestamp > 1000"));
         assertTrue(metaQuery.contains("ORDER BY timestamp DESC"));


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR fixes issue: https://github.com/y-scope/presto/issues/107

Removes unnecessary ORDER BY clauses from all CLP split provider metadata queries used for TopN (Pinot and MySQL). The ORDER BY was redundant because the TopN algorithm always re-sorts results regardless of database return order.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

- All unit tests
- E2E tests with below query
```
SELECT CLP_GET_JSON_STRING() AS event FROM clp.DEFAULT.cockroachdb_ir 
WHERE
ts > CAST(
    to_unixtime(
        date_add('year', -15, current_timestamp)
    ) * 1000 AS BIGINT
) ORDER BY ts DESC limit 100
```

and we can see after TopN optimization, the number of splits to be searched is 2



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
