### PR TITLE
fix: Skip exposed range-mapped metadata column in metadata projection (fixes #122).

### DIFF
--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpComputePushDown.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpComputePushDown.java
@@ -149,7 +149,7 @@ public class ClpComputePushDown
                     // After extracting values from the metadata database, these will be mapped back to exposed names
                     // for projection.
                     String originalColumnName = exposedToOriginalMap.get(columnName);
-                    // Skip retreiving any value for the range-bound columns; currently, the expected behavior is to
+                    // Skip retrieving any value for the range-bound columns; currently, the expected behavior is to
                     // return NULL for these columns if projected.
                     if (metadataColumnsWithRangeBound.contains(originalColumnName)) {
                         continue;

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpComputePushDown.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpComputePushDown.java
@@ -26,7 +26,6 @@ import com.facebook.presto.spi.ConnectorPlanOptimizer;
 import com.facebook.presto.spi.ConnectorPlanRewriter;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorTableLayoutHandle;
-import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.VariableAllocator;
@@ -55,7 +54,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
-import static com.facebook.presto.plugin.clp.ClpErrorCode.CLP_UNSUPPORTED_METADATA_PROJECTION;
 import static com.facebook.presto.spi.ConnectorPlanRewriter.rewriteWith;
 import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
@@ -151,9 +149,10 @@ public class ClpComputePushDown
                     // After extracting values from the metadata database, these will be mapped back to exposed names
                     // for projection.
                     String originalColumnName = exposedToOriginalMap.get(columnName);
+                    // Skip retreiving any value for the range-bound columns; currently, the expected behavior is to
+                    // return NULL for these columns if projected.
                     if (metadataColumnsWithRangeBound.contains(originalColumnName)) {
-                        throw new PrestoException(CLP_UNSUPPORTED_METADATA_PROJECTION,
-                                format("Unsupported metadata projection column: %s", columnName));
+                        continue;
                     }
                     metadataProjections.add(originalColumnName);
                 }

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/optimization/TestClpComputePushDown.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/optimization/TestClpComputePushDown.java
@@ -54,6 +54,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 @Test(singleThreaded = true)
@@ -294,7 +295,6 @@ public class TestClpComputePushDown
                 TupleDomain.all(),
                 Optional.empty());
 
-        // Verify that the optimizer completes successfully and skips the range-bound column
         PlanNode optimized = optimizer.optimize(
                 originalScan,
                 new SessionHolder().getConnectorSession(),
@@ -304,11 +304,7 @@ public class TestClpComputePushDown
         TableScanNode rewrittenScan = (TableScanNode) optimized;
 
         // Verify that the layout is NOT present (since the only metadata column was range-bound and skipped)
-        if (rewrittenScan.getTable().getLayout().isPresent()) {
-            ClpTableLayoutHandle layout = (ClpTableLayoutHandle) rewrittenScan.getTable().getLayout().get();
-            Set<String> metadataProjections = layout.getOrInitializeSplitMetadataColumnNames();
-            assertTrue(metadataProjections.isEmpty(),
-                    "Range-bound columns should be skipped from metadata projection");
-        }
+        assertFalse(rewrittenScan.getTable().getLayout().isPresent(),
+                "Layout should not be present when only range-bound columns are projected");
     }
 }

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/optimization/TestClpComputePushDown.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/optimization/TestClpComputePushDown.java
@@ -26,7 +26,6 @@ import com.facebook.presto.plugin.clp.TestClpQueryBase;
 import com.facebook.presto.plugin.clp.split.ClpSplitMetadataConfig;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorId;
-import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.VariableAllocator;
@@ -50,14 +49,12 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.facebook.presto.common.type.DoubleType.DOUBLE;
-import static com.facebook.presto.plugin.clp.ClpErrorCode.CLP_UNSUPPORTED_METADATA_PROJECTION;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
 
 @Test(singleThreaded = true)
 public class TestClpComputePushDown
@@ -248,13 +245,13 @@ public class TestClpComputePushDown
     }
 
     /**
-     * Validates that attempting to project a metadata column backed by a range-bound field raises a
-     * CLP_UNSUPPORTED_METADATA_PROJECTION PrestoException with the offending column name in the message.
+     * Validates that projecting a metadata column backed by a range-bound field is handled gracefully
+     * by skipping it in the metadata projection (returning NULL for that column).
      */
     @Test
-    public void testMetadataProjectionWithErrorHandling()
+    public void testMetadataProjectionWithRangeBoundColumn()
     {
-        // Get a metadata column that has range bounds (should trigger the exception)
+        // Get a metadata column that has range bounds (should be skipped in metadata projection)
         Set<String> metadataColumnsWithRangeBound =
                 metadataConfig.getMetadataColumnsWithRangeBounds(schemaTableName);
         Map<String, String> exposedToOriginalMap =
@@ -297,20 +294,21 @@ public class TestClpComputePushDown
                 TupleDomain.all(),
                 Optional.empty());
 
-        // Verify that PrestoException is thrown with the correct error code and message
-        final String columnName = rangeBoundExposedColumn;
-        try {
-            optimizer.optimize(
-                    originalScan,
-                    new SessionHolder().getConnectorSession(),
-                    variableAllocator,
-                    idAllocator);
-            fail("Expected PrestoException to be thrown");
-        }
-        catch (PrestoException e) {
-            assertEquals(e.getErrorCode(), CLP_UNSUPPORTED_METADATA_PROJECTION.toErrorCode());
-            assertTrue(e.getMessage().contains(columnName),
-                    "Exception message should contain the column name: " + columnName);
+        // Verify that the optimizer completes successfully and skips the range-bound column
+        PlanNode optimized = optimizer.optimize(
+                originalScan,
+                new SessionHolder().getConnectorSession(),
+                variableAllocator,
+                idAllocator);
+
+        TableScanNode rewrittenScan = (TableScanNode) optimized;
+
+        // Verify that the layout is NOT present (since the only metadata column was range-bound and skipped)
+        if (rewrittenScan.getTable().getLayout().isPresent()) {
+            ClpTableLayoutHandle layout = (ClpTableLayoutHandle) rewrittenScan.getTable().getLayout().get();
+            Set<String> metadataProjections = layout.getOrInitializeSplitMetadataColumnNames();
+            assertTrue(metadataProjections.isEmpty(),
+                    "Range-bound columns should be skipped from metadata projection");
         }
     }
 }

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/optimization/TestClpComputePushDown.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/optimization/TestClpComputePushDown.java
@@ -53,8 +53,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertTrue;
 
 @Test(singleThreaded = true)


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR fixes issue: https://github.com/y-scope/presto/issues/122

This PR changes the behavior of metadata projection for range-bound columns from throwing an exception to gracefully skipping them (returning NULL values).


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
We manually submit below queries to test the end-to-end result of the implemented code:
- All unit tests 
- Metadata projection integration with other features:
  -  With split pruning: `SELECT zone FROM clp.DEFAULT.cockroachdb_ir WHERE host_name = 'host4' LIMIT  100;`  & `SELECT tpath, timestamp  FROM clp.DEFAULT.cockroachdb_ir WHERE num_messages > 100 LIMIT  100;` 
  - With push down:  `SELECT tpath, timestamp  FROM clp.DEFAULT.cockroachdb_ir WHERE severity = 'INFO' LIMIT  100;` 
  - With UDF:  `SELECT tpath,  CLP_GET_JSON_STRING() AS event FROM clp.DEFAULT.cockroachdb_ir WHERE severity = 'INFO' LIMIT  100;` 
 - Metadata projection integration with range bound column projection and filtering
    - With range bound column projection and filtering: `SELECT ts, CLP_GET_JSON_STRING() FROM clp.DEFAULT.cockroachdb_ir WHERE (ts >= '1679710000570000000' AND ts <= '1679711330571000000') limit 100`
    - With range bound projection only: `SELECT ts, CLP_GET_JSON_STRING() FROM clp.DEFAULT.cockroachdb_ir WHERE host_name = 'host1' limit 100`
    - With range bound filtering only: `SELECT CLP_GET_JSON_STRING() FROM clp.DEFAULT.cockroachdb_ir WHERE (ts >= '1679710000570000000' AND ts <= '1679711330571000000') limit 100`
    - All above queries should return successfully, with 1 and 2 return Null under the column ts.

Note ts is a range-mapped column, mapping to creationtime and lastmodifiedtime in metadata database, and timestamp field in the data field. Other metadata columns used are: zone , host_name, num_messages, tpath. Rest of the columns are assumed to be data field.


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced optimization robustness for metadata projections. Range-bound columns are now gracefully skipped during processing instead of causing operation failures, ensuring optimizations complete successfully.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->