### PR TITLE
feat: Auto-merge metadata columns from split-filter config into table schema

### DIFF
--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/metadata/ClpYamlMetadataProvider.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/metadata/ClpYamlMetadataProvider.java
@@ -14,9 +14,11 @@
 package com.facebook.presto.plugin.clp.metadata;
 
 import com.facebook.airlift.log.Logger;
+import com.facebook.presto.common.type.Type;
 import com.facebook.presto.plugin.clp.ClpColumnHandle;
 import com.facebook.presto.plugin.clp.ClpConfig;
 import com.facebook.presto.plugin.clp.ClpTableHandle;
+import com.facebook.presto.plugin.clp.split.ClpSplitMetadataConfig;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -46,6 +48,7 @@ public class ClpYamlMetadataProvider
 {
     private static final Logger log = Logger.get(ClpYamlMetadataProvider.class);
     private final ClpConfig config;
+    private final ClpSplitMetadataConfig splitMetadataConfig;
     private final ObjectMapper yamlMapper;
 
     // Thread-safe cache for schema names to avoid repeated file parsing
@@ -57,9 +60,10 @@ public class ClpYamlMetadataProvider
     private final Map<String, Map<String, String>> tableSchemaYamlMapPerSchema = new HashMap<>();
 
     @Inject
-    public ClpYamlMetadataProvider(ClpConfig config)
+    public ClpYamlMetadataProvider(ClpConfig config, ClpSplitMetadataConfig splitMetadataConfig)
     {
         this.config = config;
+        this.splitMetadataConfig = splitMetadataConfig;
         // Reuse ObjectMapper instance for better performance
         this.yamlMapper = new ObjectMapper(new YAMLFactory());
     }
@@ -142,7 +146,6 @@ public class ClpYamlMetadataProvider
         String schemaName = schemaTableName.getSchemaName();
         String tableName = schemaTableName.getTableName();
 
-        // Get the schema-specific map
         Map<String, String> tablesInSchema;
         synchronized (tableSchemaYamlMapPerSchema) {
             tablesInSchema = tableSchemaYamlMapPerSchema.get(schemaName);
@@ -159,20 +162,35 @@ public class ClpYamlMetadataProvider
             return Collections.emptyList();
         }
 
-        Path tableSchemaPath = Paths.get(schemaPath);
+        List<ClpColumnHandle> yamlColumns = loadColumnsFromYaml(Paths.get(schemaPath));
+        return mergeMetadataColumns(schemaTableName, yamlColumns);
+    }
+
+    /**
+     * Loads column definitions from a table schema YAML file.
+     *
+     * @param tableSchemaPath path to the YAML file containing column definitions
+     * @return list of column handles parsed from the YAML file, or empty list on error
+     */
+    private List<ClpColumnHandle> loadColumnsFromYaml(Path tableSchemaPath)
+    {
         ClpSchemaTree schemaTree = new ClpSchemaTree(config.isPolymorphicTypeEnabled());
 
         try {
-            // Use the shared yamlMapper for better performance
             Map<String, Object> root = yamlMapper.readValue(
                     new File(tableSchemaPath.toString()),
                     new TypeReference<HashMap<String, Object>>() {});
             ImmutableList.Builder<String> namesBuilder = ImmutableList.builder();
             ImmutableList.Builder<Byte> typesBuilder = ImmutableList.builder();
+
+            // Flatten nested YAML structure into lists of names and type codes
             collectTypes(root, "", namesBuilder, typesBuilder);
             ImmutableList<String> names = namesBuilder.build();
             ImmutableList<Byte> types = typesBuilder.build();
-            // The names and types should have same sizes
+
+            // Rebuild structure from flat lists to be semantically compatible with a schema tree.
+            // Example: ["msg.timestamp", "msg.timestamp", "msg.content"], [0, 3, 3]
+            // becomes: msg: RowType[timestamp_bigint: BIGINT, timestamp_varchar: VARCHAR, content: VARCHAR]
             for (int i = 0; i < names.size(); i++) {
                 schemaTree.addColumn(names.get(i), types.get(i));
             }
@@ -180,14 +198,72 @@ public class ClpYamlMetadataProvider
         }
         catch (IOException e) {
             log.error(format("Failed to parse table schema file %s, error: %s", tableSchemaPath, e.getMessage()), e);
+            return Collections.emptyList();
         }
-        return Collections.emptyList();
+    }
+
+    /**
+     * Merges metadata columns from the split metadata configuration with columns loaded from YAML.
+     *
+     * @param schemaTableName the table to merge columns for
+     * @param yamlColumns columns loaded from the YAML schema file
+     * @return merged list of column handles
+     * @throws PrestoException if a column has conflicting type definitions
+     */
+    private List<ClpColumnHandle> mergeMetadataColumns(
+            SchemaTableName schemaTableName,
+            List<ClpColumnHandle> yamlColumns)
+    {
+        Map<String, Type> metadataColumns = splitMetadataConfig.getMetadataColumns(schemaTableName);
+        if (metadataColumns.isEmpty()) {
+            return yamlColumns;
+        }
+
+        Map<String, ClpColumnHandle> columnMap = new HashMap<>();
+        for (ClpColumnHandle handle : yamlColumns) {
+            columnMap.put(handle.getColumnName(), handle);
+        }
+
+        // Map exposed (user-facing) column names to original (internal) names for aliased metadata columns
+        Map<String, String> exposedToOriginalMap = splitMetadataConfig.getExposedToOriginalMapping(schemaTableName);
+
+        for (Map.Entry<String, Type> entry : metadataColumns.entrySet()) {
+            String exposedColumnName = entry.getKey();
+            Type metadataType = entry.getValue();
+
+            ClpColumnHandle existingColumn = columnMap.get(exposedColumnName);
+            if (existingColumn != null) {
+                // Column exists in YAML: allow if types match (YAML definition wins), error if types conflict
+                if (!existingColumn.getColumnType().equals(metadataType)) {
+                    throw new PrestoException(
+                            CLP_UNSUPPORTED_TABLE_SCHEMA_YAML,
+                            format("Column '%s' in table %s.%s has conflicting type definitions: " +
+                                    "YAML defines %s but split metadata config defines %s",
+                                    exposedColumnName,
+                                    schemaTableName.getSchemaName(),
+                                    schemaTableName.getTableName(),
+                                    existingColumn.getColumnType(),
+                                    metadataType));
+                }
+            }
+            else {
+                String originalColumnName = exposedToOriginalMap.getOrDefault(exposedColumnName, exposedColumnName);
+                ClpColumnHandle metadataColumnHandle = new ClpColumnHandle(
+                        exposedColumnName,
+                        originalColumnName,
+                        metadataType);
+                columnMap.put(exposedColumnName, metadataColumnHandle);
+                log.debug("Added metadata column '%s' to table %s.%s",
+                        exposedColumnName, schemaTableName.getSchemaName(), schemaTableName.getTableName());
+            }
+        }
+
+        return ImmutableList.copyOf(columnMap.values());
     }
 
     @Override
     public List<ClpTableHandle> listTableHandles(String schemaName)
     {
-        // Check if YAML path is configured
         if (config.getMetadataYamlPath() == null) {
             log.warn("Metadata YAML path not configured");
             return Collections.emptyList();
@@ -196,7 +272,6 @@ public class ClpYamlMetadataProvider
         Path tablesSchemaPath = Paths.get(config.getMetadataYamlPath());
 
         try {
-            // Use the shared yamlMapper for better performance
             Map<String, Object> root = yamlMapper.readValue(new File(tablesSchemaPath.toString()),
                     new TypeReference<HashMap<String, Object>>() {});
 
@@ -252,26 +327,39 @@ public class ClpYamlMetadataProvider
         return Collections.emptyList();
     }
 
+    /**
+     * Recursively collects column names and type codes from a nested YAML structure.
+     * <p>
+     * Supports three YAML patterns:
+     * - Leaf node (Number): single type for a column
+     * - List of Numbers: polymorphic column with multiple possible types
+     * - Nested Map: recurses to build dot-notation column names (e.g., "parent.child")
+     *
+     * @param node current node in the YAML tree being traversed
+     * @param prefix accumulated column name prefix from parent nodes
+     * @param namesBuilder accumulates column names in parallel with types
+     * @param typesBuilder accumulates type codes as bytes
+     */
     private void collectTypes(Object node, String prefix, ImmutableList.Builder<String> namesBuilder, ImmutableList.Builder<Byte> typesBuilder)
     {
         if (node instanceof Number) {
+            // Leaf node: single type for this column
             namesBuilder.add(prefix);
             typesBuilder.add(((Number) node).byteValue());
             return;
         }
         if (node instanceof List) {
+            // Polymorphic column: same column name with multiple type possibilities
             for (Number type : (List<Number>) node) {
                 namesBuilder.add(prefix);
                 typesBuilder.add(type.byteValue());
             }
             return;
         }
+        // Nested structure: recurse and build dot-notation names
         for (Map.Entry<String, Object> entry : ((Map<String, Object>) node).entrySet()) {
-            if (!prefix.isEmpty()) {
-                collectTypes(entry.getValue(), format("%s.%s", prefix, entry.getKey()), namesBuilder, typesBuilder);
-                continue;
-            }
-            collectTypes(entry.getValue(), entry.getKey(), namesBuilder, typesBuilder);
+            String nextPrefix = prefix.isEmpty() ? entry.getKey() : format("%s.%s", prefix, entry.getKey());
+            collectTypes(entry.getValue(), nextPrefix, namesBuilder, typesBuilder);
         }
     }
 }

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpComputePushDown.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpComputePushDown.java
@@ -149,7 +149,7 @@ public class ClpComputePushDown
                     // After extracting values from the metadata database, these will be mapped back to exposed names
                     // for projection.
                     String originalColumnName = exposedToOriginalMap.get(columnName);
-                    // Skip retreiving any value for the range-bound columns; currently, the expected behavior is to
+                    // Skip retrieving any value for the range-bound columns; currently, the expected behavior is to
                     // return NULL for these columns if projected.
                     if (metadataColumnsWithRangeBound.contains(originalColumnName)) {
                         continue;

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpComputePushDown.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpComputePushDown.java
@@ -26,7 +26,6 @@ import com.facebook.presto.spi.ConnectorPlanOptimizer;
 import com.facebook.presto.spi.ConnectorPlanRewriter;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorTableLayoutHandle;
-import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.VariableAllocator;
@@ -55,7 +54,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
-import static com.facebook.presto.plugin.clp.ClpErrorCode.CLP_UNSUPPORTED_METADATA_PROJECTION;
 import static com.facebook.presto.spi.ConnectorPlanRewriter.rewriteWith;
 import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
@@ -151,9 +149,10 @@ public class ClpComputePushDown
                     // After extracting values from the metadata database, these will be mapped back to exposed names
                     // for projection.
                     String originalColumnName = exposedToOriginalMap.get(columnName);
+                    // Skip retreiving any value for the range-bound columns; currently, the expected behavior is to
+                    // return NULL for these columns if projected.
                     if (metadataColumnsWithRangeBound.contains(originalColumnName)) {
-                        throw new PrestoException(CLP_UNSUPPORTED_METADATA_PROJECTION,
-                                format("Unsupported metadata projection column: %s", columnName));
+                        continue;
                     }
                     metadataProjections.add(originalColumnName);
                 }

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/TestClpMultiSchema.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/TestClpMultiSchema.java
@@ -13,9 +13,13 @@
  */
 package com.facebook.presto.plugin.clp;
 
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.plugin.clp.metadata.ClpMetadataProvider;
 import com.facebook.presto.plugin.clp.metadata.ClpYamlMetadataProvider;
+import com.facebook.presto.plugin.clp.split.ClpSplitMetadataConfig;
 import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -24,6 +28,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 
+import static com.facebook.presto.metadata.FunctionAndTypeManager.createTestFunctionAndTypeManager;
 import static com.facebook.presto.plugin.clp.ClpConfig.MetadataProviderType.YAML;
 import static com.facebook.presto.plugin.clp.ClpMetadata.DEFAULT_SCHEMA_NAME;
 import static org.testng.Assert.assertEquals;
@@ -31,6 +36,19 @@ import static org.testng.Assert.assertTrue;
 
 public class TestClpMultiSchema
 {
+    private TypeManager typeManager;
+
+    @BeforeClass
+    public void setup()
+    {
+        FunctionAndTypeManager functionAndTypeManager = createTestFunctionAndTypeManager();
+        typeManager = functionAndTypeManager;
+    }
+
+    private ClpSplitMetadataConfig createSplitMetadataConfig(ClpConfig config)
+    {
+        return new ClpSplitMetadataConfig(config, typeManager);
+    }
     @Test
     public void testSingleSchemaDiscovery() throws IOException
     {
@@ -49,7 +67,7 @@ public class TestClpMultiSchema
                 .setMetadataProviderType(YAML)
                 .setMetadataYamlPath(tempFile.getAbsolutePath());
 
-        ClpMetadataProvider provider = new ClpYamlMetadataProvider(config);
+        ClpMetadataProvider provider = new ClpYamlMetadataProvider(config, createSplitMetadataConfig(config));
         List<String> schemas = provider.listSchemaNames();
 
         assertEquals(schemas.size(), 1);
@@ -77,7 +95,7 @@ public class TestClpMultiSchema
                 .setMetadataProviderType(YAML)
                 .setMetadataYamlPath(tempFile.getAbsolutePath());
 
-        ClpMetadataProvider provider = new ClpYamlMetadataProvider(config);
+        ClpMetadataProvider provider = new ClpYamlMetadataProvider(config, createSplitMetadataConfig(config));
         List<String> schemas = provider.listSchemaNames();
 
         assertEquals(schemas.size(), 3);
@@ -94,7 +112,7 @@ public class TestClpMultiSchema
                 .setMetadataProviderType(YAML);
         // Note: not setting metadataYamlPath
 
-        ClpMetadataProvider provider = new ClpYamlMetadataProvider(config);
+        ClpMetadataProvider provider = new ClpYamlMetadataProvider(config, createSplitMetadataConfig(config));
         List<String> schemas = provider.listSchemaNames();
 
         assertEquals(schemas.size(), 1);
@@ -108,7 +126,7 @@ public class TestClpMultiSchema
                 .setMetadataProviderType(YAML)
                 .setMetadataYamlPath("/nonexistent/path/to/metadata.yaml");
 
-        ClpMetadataProvider provider = new ClpYamlMetadataProvider(config);
+        ClpMetadataProvider provider = new ClpYamlMetadataProvider(config, createSplitMetadataConfig(config));
         List<String> schemas = provider.listSchemaNames();
 
         assertEquals(schemas.size(), 1);

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/TestClpYamlMetadata.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/TestClpYamlMetadata.java
@@ -69,13 +69,14 @@ public class TestClpYamlMetadata
                 .setMetadataDbUrl(PINOT_BROKER_URL)
                 .setMetadataProviderType(YAML)
                 .setMetadataYamlPath(tablesSchemaPath);
-        ClpMetadataProvider metadataProvider = new ClpYamlMetadataProvider(config);
+        ClpSplitMetadataConfig splitMetadataConfig = new ClpSplitMetadataConfig(config, functionAndTypeManager);
+        ClpMetadataProvider metadataProvider = new ClpYamlMetadataProvider(config, splitMetadataConfig);
         metadata = new ClpMetadata(config, metadataProvider);
         clpSplitProvider = new ClpPinotSplitProvider(
                 config,
                 functionAndTypeManager,
                 standardFunctionResolution,
-                new ClpSplitMetadataConfig(config, functionAndTypeManager));
+                splitMetadataConfig);
     }
 
     @Test

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/metadata/TestClpYamlMetadataProvider.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/metadata/TestClpYamlMetadataProvider.java
@@ -13,10 +13,16 @@
  */
 package com.facebook.presto.plugin.clp.metadata;
 
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.plugin.clp.ClpColumnHandle;
 import com.facebook.presto.plugin.clp.ClpConfig;
 import com.facebook.presto.plugin.clp.ClpTableHandle;
+import com.facebook.presto.plugin.clp.split.ClpSplitMetadataConfig;
+import com.facebook.presto.spi.SchemaTableName;
 import com.google.common.collect.ImmutableSet;
 import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -27,15 +33,25 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
+import static com.facebook.presto.metadata.FunctionAndTypeManager.createTestFunctionAndTypeManager;
 import static com.facebook.presto.plugin.clp.ClpConfig.MetadataProviderType.YAML;
 import static com.facebook.presto.plugin.clp.ClpMetadata.DEFAULT_SCHEMA_NAME;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 @Test(singleThreaded = true)
 public class TestClpYamlMetadataProvider
 {
     private final List<File> tempFiles = new ArrayList<>();
+    private TypeManager typeManager;
+
+    @BeforeClass
+    public void setup()
+    {
+        FunctionAndTypeManager functionAndTypeManager = createTestFunctionAndTypeManager();
+        typeManager = functionAndTypeManager;
+    }
 
     @AfterClass
     public void cleanup()
@@ -46,6 +62,14 @@ public class TestClpYamlMetadataProvider
                 file.delete();
             }
         }
+    }
+
+    /**
+     * Helper method to create a ClpSplitMetadataConfig for testing
+     */
+    private ClpSplitMetadataConfig createSplitMetadataConfig(ClpConfig config)
+    {
+        return new ClpSplitMetadataConfig(config, typeManager);
     }
 
     /**
@@ -64,7 +88,7 @@ public class TestClpYamlMetadataProvider
                 .setMetadataProviderType(YAML)
                 .setMetadataYamlPath(metadataFile.getAbsolutePath());
 
-        ClpYamlMetadataProvider provider = new ClpYamlMetadataProvider(config);
+        ClpYamlMetadataProvider provider = new ClpYamlMetadataProvider(config, createSplitMetadataConfig(config));
         List<String> schemas = provider.listSchemaNames();
 
         assertEquals(schemas.size(), 1);
@@ -92,7 +116,7 @@ public class TestClpYamlMetadataProvider
                 .setMetadataProviderType(YAML)
                 .setMetadataYamlPath(metadataFile.getAbsolutePath());
 
-        ClpYamlMetadataProvider provider = new ClpYamlMetadataProvider(config);
+        ClpYamlMetadataProvider provider = new ClpYamlMetadataProvider(config, createSplitMetadataConfig(config));
         List<String> schemas = provider.listSchemaNames();
 
         assertEquals(schemas.size(), 4);
@@ -113,7 +137,7 @@ public class TestClpYamlMetadataProvider
                 .setMetadataProviderType(YAML);
         // Note: not setting metadataYamlPath
 
-        ClpYamlMetadataProvider provider = new ClpYamlMetadataProvider(config);
+        ClpYamlMetadataProvider provider = new ClpYamlMetadataProvider(config, createSplitMetadataConfig(config));
         List<String> schemas = provider.listSchemaNames();
 
         assertEquals(schemas.size(), 1);
@@ -130,7 +154,7 @@ public class TestClpYamlMetadataProvider
                 .setMetadataProviderType(YAML)
                 .setMetadataYamlPath("/nonexistent/path/metadata.yaml");
 
-        ClpYamlMetadataProvider provider = new ClpYamlMetadataProvider(config);
+        ClpYamlMetadataProvider provider = new ClpYamlMetadataProvider(config, createSplitMetadataConfig(config));
         List<String> schemas = provider.listSchemaNames();
 
         assertEquals(schemas.size(), 1);
@@ -152,7 +176,7 @@ public class TestClpYamlMetadataProvider
                 .setMetadataProviderType(YAML)
                 .setMetadataYamlPath(metadataFile.getAbsolutePath());
 
-        ClpYamlMetadataProvider provider = new ClpYamlMetadataProvider(config);
+        ClpYamlMetadataProvider provider = new ClpYamlMetadataProvider(config, createSplitMetadataConfig(config));
         List<String> schemas = provider.listSchemaNames();
 
         assertEquals(schemas.size(), 1);
@@ -174,7 +198,7 @@ public class TestClpYamlMetadataProvider
                 .setMetadataProviderType(YAML)
                 .setMetadataYamlPath(metadataFile.getAbsolutePath());
 
-        ClpYamlMetadataProvider provider = new ClpYamlMetadataProvider(config);
+        ClpYamlMetadataProvider provider = new ClpYamlMetadataProvider(config, createSplitMetadataConfig(config));
         List<String> schemas = provider.listSchemaNames();
 
         // Should fall back to default schema on error
@@ -202,7 +226,7 @@ public class TestClpYamlMetadataProvider
                 .setMetadataProviderType(YAML)
                 .setMetadataYamlPath(metadataFile.getAbsolutePath());
 
-        ClpYamlMetadataProvider provider = new ClpYamlMetadataProvider(config);
+        ClpYamlMetadataProvider provider = new ClpYamlMetadataProvider(config, createSplitMetadataConfig(config));
         List<ClpTableHandle> tables = provider.listTableHandles(DEFAULT_SCHEMA_NAME);
 
         assertEquals(tables.size(), 2);
@@ -233,7 +257,7 @@ public class TestClpYamlMetadataProvider
                 .setMetadataProviderType(YAML)
                 .setMetadataYamlPath(metadataFile.getAbsolutePath());
 
-        ClpYamlMetadataProvider provider = new ClpYamlMetadataProvider(config);
+        ClpYamlMetadataProvider provider = new ClpYamlMetadataProvider(config, createSplitMetadataConfig(config));
 
         // Test dev schema
         List<ClpTableHandle> devTables = provider.listTableHandles("dev");
@@ -267,7 +291,7 @@ public class TestClpYamlMetadataProvider
                 .setMetadataProviderType(YAML)
                 .setMetadataYamlPath(metadataFile.getAbsolutePath());
 
-        ClpYamlMetadataProvider provider = new ClpYamlMetadataProvider(config);
+        ClpYamlMetadataProvider provider = new ClpYamlMetadataProvider(config, createSplitMetadataConfig(config));
 
         // Call multiple times to verify consistency
         List<String> schemas1 = provider.listSchemaNames();
@@ -292,7 +316,7 @@ public class TestClpYamlMetadataProvider
                 .setMetadataProviderType(YAML)
                 .setMetadataYamlPath(metadataFile.getAbsolutePath());
 
-        ClpYamlMetadataProvider provider = new ClpYamlMetadataProvider(config);
+        ClpYamlMetadataProvider provider = new ClpYamlMetadataProvider(config, createSplitMetadataConfig(config));
         List<String> schemas = provider.listSchemaNames();
 
         assertTrue(schemas.contains("empty_schema"));
@@ -318,7 +342,7 @@ public class TestClpYamlMetadataProvider
                 .setMetadataProviderType(YAML)
                 .setMetadataYamlPath(metadataFile.getAbsolutePath());
 
-        ClpYamlMetadataProvider provider = new ClpYamlMetadataProvider(config);
+        ClpYamlMetadataProvider provider = new ClpYamlMetadataProvider(config, createSplitMetadataConfig(config));
         List<String> schemas = provider.listSchemaNames();
 
         assertEquals(schemas.size(), 2);
@@ -328,11 +352,429 @@ public class TestClpYamlMetadataProvider
     }
 
     /**
+     * Test that metadata columns from split-filter config are automatically merged with YAML columns
+     */
+    @Test
+    public void testListColumnHandlesWithMetadataColumns() throws IOException
+    {
+        // Create a split metadata config file (JSON format)
+        File splitMetadataFile = createTempJsonFile(
+                "{\n" +
+                "  \"default.test_table\": {\n" +
+                "    \"metaColumns\": {\n" +
+                "      \"file_name\": {\n" +
+                "        \"type\": \"VARCHAR\"\n" +
+                "      },\n" +
+                "      \"begin_timestamp\": {\n" +
+                "        \"type\": \"BIGINT\"\n" +
+                "      }\n" +
+                "    }\n" +
+                "  }\n" +
+                "}");
+
+        // Create a table schema YAML file with regular columns
+        File tableSchemaFile = createTempYamlFile(
+                "order_id: 0\n" +
+                "customer_name: 3\n" +
+                "price: 1\n");
+
+        // Create the main metadata YAML file
+        File metadataFile = createTempYamlFile(
+                "clp:\n" +
+                "  default:\n" +
+                "    test_table: " + tableSchemaFile.getAbsolutePath() + "\n");
+
+        ClpConfig config = new ClpConfig()
+                .setMetadataProviderType(YAML)
+                .setMetadataYamlPath(metadataFile.getAbsolutePath())
+                .setSplitMetadataConfigPath(splitMetadataFile.getAbsolutePath());
+
+        ClpYamlMetadataProvider provider = new ClpYamlMetadataProvider(config, createSplitMetadataConfig(config));
+
+        // Load tables first (required for listColumnHandles to work)
+        provider.listTableHandles(DEFAULT_SCHEMA_NAME);
+
+        // Get column handles for the test table
+        SchemaTableName schemaTableName = new SchemaTableName(DEFAULT_SCHEMA_NAME, "test_table");
+        List<ClpColumnHandle> columns = provider.listColumnHandles(schemaTableName);
+
+        // Verify we have both YAML columns and metadata columns
+        // 3 from YAML (order_id, customer_name, price) + 2 from metadata (file_name, begin_timestamp) = 5 total
+        assertEquals(columns.size(), 5);
+
+        // Build a set of column names for easy verification
+        Set<String> columnNames = ImmutableSet.copyOf(
+                columns.stream()
+                        .map(ClpColumnHandle::getColumnName)
+                        .collect(java.util.stream.Collectors.toList()));
+
+        // Verify YAML columns are present
+        assertTrue(columnNames.contains("order_id"));
+        assertTrue(columnNames.contains("customer_name"));
+        assertTrue(columnNames.contains("price"));
+
+        // Verify metadata columns are present
+        assertTrue(columnNames.contains("file_name"));
+        assertTrue(columnNames.contains("begin_timestamp"));
+    }
+
+    /**
+     * Test that duplicate columns (defined in both YAML and metadata config) are not duplicated
+     */
+    @Test
+    public void testListColumnHandlesWithDuplicateColumns() throws IOException
+    {
+        // Create a split metadata config file (JSON format) with a column that's also in the YAML
+        File splitMetadataFile = createTempJsonFile(
+                "{\n" +
+                "  \"default.dup_table\": {\n" +
+                "    \"metaColumns\": {\n" +
+                "      \"order_id\": {\n" +
+                "        \"type\": \"BIGINT\"\n" +
+                "      },\n" +
+                "      \"file_name\": {\n" +
+                "        \"type\": \"VARCHAR\"\n" +
+                "      }\n" +
+                "    }\n" +
+                "  }\n" +
+                "}");
+
+        // Create a table schema YAML file that also has order_id
+        File tableSchemaFile = createTempYamlFile(
+                "order_id: 0\n" +
+                "customer_name: 3\n");
+
+        // Create the main metadata YAML file
+        File metadataFile = createTempYamlFile(
+                "clp:\n" +
+                "  default:\n" +
+                "    dup_table: " + tableSchemaFile.getAbsolutePath() + "\n");
+
+        ClpConfig config = new ClpConfig()
+                .setMetadataProviderType(YAML)
+                .setMetadataYamlPath(metadataFile.getAbsolutePath())
+                .setSplitMetadataConfigPath(splitMetadataFile.getAbsolutePath());
+
+        ClpYamlMetadataProvider provider = new ClpYamlMetadataProvider(config, createSplitMetadataConfig(config));
+
+        // Load tables first
+        provider.listTableHandles(DEFAULT_SCHEMA_NAME);
+
+        // Get column handles
+        SchemaTableName schemaTableName = new SchemaTableName(DEFAULT_SCHEMA_NAME, "dup_table");
+        List<ClpColumnHandle> columns = provider.listColumnHandles(schemaTableName);
+
+        // Should have 3 columns total: order_id (from YAML, not duplicated), customer_name (from YAML), file_name (from metadata)
+        assertEquals(columns.size(), 3);
+
+        // Build a set of column names
+        Set<String> columnNames = ImmutableSet.copyOf(
+                columns.stream()
+                        .map(ClpColumnHandle::getColumnName)
+                        .collect(java.util.stream.Collectors.toList()));
+
+        assertTrue(columnNames.contains("order_id"));
+        assertTrue(columnNames.contains("customer_name"));
+        assertTrue(columnNames.contains("file_name"));
+
+        // Verify no duplicates by checking list size equals set size
+        assertEquals(columns.size(), columnNames.size());
+    }
+
+    /**
+     * Test that metadata columns are added when YAML has no columns (metadata-only table)
+     */
+    @Test
+    public void testListColumnHandlesMetadataOnly() throws IOException
+    {
+        File splitMetadataFile = createTempJsonFile(
+                "{\n" +
+                "  \"default.metadata_table\": {\n" +
+                "    \"metaColumns\": {\n" +
+                "      \"file_name\": {\n" +
+                "        \"type\": \"VARCHAR\"\n" +
+                "      },\n" +
+                "      \"record_count\": {\n" +
+                "        \"type\": \"BIGINT\"\n" +
+                "      }\n" +
+                "    }\n" +
+                "  }\n" +
+                "}");
+
+        // Empty YAML file (no columns defined)
+        File tableSchemaFile = createTempYamlFile("");
+
+        File metadataFile = createTempYamlFile(
+                "clp:\n" +
+                "  default:\n" +
+                "    metadata_table: " + tableSchemaFile.getAbsolutePath() + "\n");
+
+        ClpConfig config = new ClpConfig()
+                .setMetadataProviderType(YAML)
+                .setMetadataYamlPath(metadataFile.getAbsolutePath())
+                .setSplitMetadataConfigPath(splitMetadataFile.getAbsolutePath());
+
+        ClpYamlMetadataProvider provider = new ClpYamlMetadataProvider(config, createSplitMetadataConfig(config));
+        provider.listTableHandles(DEFAULT_SCHEMA_NAME);
+
+        SchemaTableName schemaTableName = new SchemaTableName(DEFAULT_SCHEMA_NAME, "metadata_table");
+        List<ClpColumnHandle> columns = provider.listColumnHandles(schemaTableName);
+
+        // Should have only the 2 metadata columns
+        assertEquals(columns.size(), 2);
+
+        Set<String> columnNames = ImmutableSet.copyOf(
+                columns.stream()
+                        .map(ClpColumnHandle::getColumnName)
+                        .collect(java.util.stream.Collectors.toList()));
+
+        assertTrue(columnNames.contains("file_name"));
+        assertTrue(columnNames.contains("record_count"));
+    }
+
+    /**
+     * Test that when no split metadata config is provided, only YAML columns are returned
+     */
+    @Test
+    public void testListColumnHandlesYamlOnly() throws IOException
+    {
+        // Create a table schema YAML file with columns
+        File tableSchemaFile = createTempYamlFile(
+                "order_id: 0\n" +
+                "customer_name: 3\n" +
+                "price: 1\n");
+
+        File metadataFile = createTempYamlFile(
+                "clp:\n" +
+                "  default:\n" +
+                "    yaml_table: " + tableSchemaFile.getAbsolutePath() + "\n");
+
+        // No split metadata config path set
+        ClpConfig config = new ClpConfig()
+                .setMetadataProviderType(YAML)
+                .setMetadataYamlPath(metadataFile.getAbsolutePath());
+
+        ClpYamlMetadataProvider provider = new ClpYamlMetadataProvider(config, createSplitMetadataConfig(config));
+        provider.listTableHandles(DEFAULT_SCHEMA_NAME);
+
+        SchemaTableName schemaTableName = new SchemaTableName(DEFAULT_SCHEMA_NAME, "yaml_table");
+        List<ClpColumnHandle> columns = provider.listColumnHandles(schemaTableName);
+
+        // Should have only the 3 YAML columns
+        assertEquals(columns.size(), 3);
+
+        Set<String> columnNames = ImmutableSet.copyOf(
+                columns.stream()
+                        .map(ClpColumnHandle::getColumnName)
+                        .collect(java.util.stream.Collectors.toList()));
+
+        assertTrue(columnNames.contains("order_id"));
+        assertTrue(columnNames.contains("customer_name"));
+        assertTrue(columnNames.contains("price"));
+    }
+
+    /**
+     * Test that exposed-to-original name mapping works correctly
+     */
+    @Test
+    public void testListColumnHandlesWithExposedNames() throws IOException
+    {
+        File splitMetadataFile = createTempJsonFile(
+                "{\n" +
+                "  \"default.exposed_table\": {\n" +
+                "    \"metaColumns\": {\n" +
+                "      \"internal_id\": {\n" +
+                "        \"type\": \"BIGINT\",\n" +
+                "        \"exposedAs\": \"record_id\"\n" +
+                "      },\n" +
+                "      \"internal_timestamp\": {\n" +
+                "        \"type\": \"BIGINT\",\n" +
+                "        \"exposedAs\": \"created_at\"\n" +
+                "      }\n" +
+                "    }\n" +
+                "  }\n" +
+                "}");
+
+        File tableSchemaFile = createTempYamlFile("data_column: 3\n");
+
+        File metadataFile = createTempYamlFile(
+                "clp:\n" +
+                "  default:\n" +
+                "    exposed_table: " + tableSchemaFile.getAbsolutePath() + "\n");
+
+        ClpConfig config = new ClpConfig()
+                .setMetadataProviderType(YAML)
+                .setMetadataYamlPath(metadataFile.getAbsolutePath())
+                .setSplitMetadataConfigPath(splitMetadataFile.getAbsolutePath());
+
+        ClpYamlMetadataProvider provider = new ClpYamlMetadataProvider(config, createSplitMetadataConfig(config));
+        provider.listTableHandles(DEFAULT_SCHEMA_NAME);
+
+        SchemaTableName schemaTableName = new SchemaTableName(DEFAULT_SCHEMA_NAME, "exposed_table");
+        List<ClpColumnHandle> columns = provider.listColumnHandles(schemaTableName);
+
+        assertEquals(columns.size(), 3);
+
+        // Find the metadata columns and verify exposed vs original names
+        ClpColumnHandle recordIdColumn = columns.stream()
+                .filter(c -> c.getColumnName().equals("record_id"))
+                .findFirst()
+                .orElse(null);
+
+        ClpColumnHandle createdAtColumn = columns.stream()
+                .filter(c -> c.getColumnName().equals("created_at"))
+                .findFirst()
+                .orElse(null);
+
+        // Verify exposed names are used for column name
+        assertEquals(recordIdColumn != null, true);
+        assertEquals(createdAtColumn != null, true);
+
+        // Verify original names are stored correctly
+        assertEquals(recordIdColumn.getOriginalColumnName(), "internal_id");
+        assertEquals(createdAtColumn.getOriginalColumnName(), "internal_timestamp");
+    }
+
+    /**
+     * Test behavior with multiple tables having different metadata columns
+     */
+    @Test
+    public void testListColumnHandlesMultipleTables() throws IOException
+    {
+        File splitMetadataFile = createTempJsonFile(
+                "{\n" +
+                "  \"default.table_a\": {\n" +
+                "    \"metaColumns\": {\n" +
+                "      \"file_name\": {\n" +
+                "        \"type\": \"VARCHAR\"\n" +
+                "      }\n" +
+                "    }\n" +
+                "  },\n" +
+                "  \"default.table_b\": {\n" +
+                "    \"metaColumns\": {\n" +
+                "      \"partition_id\": {\n" +
+                "        \"type\": \"BIGINT\"\n" +
+                "      }\n" +
+                "    }\n" +
+                "  }\n" +
+                "}");
+
+        File tableASchemaFile = createTempYamlFile("col_a: 0\n");
+        File tableBSchemaFile = createTempYamlFile("col_b: 3\n");
+
+        File metadataFile = createTempYamlFile(
+                "clp:\n" +
+                "  default:\n" +
+                "    table_a: " + tableASchemaFile.getAbsolutePath() + "\n" +
+                "    table_b: " + tableBSchemaFile.getAbsolutePath() + "\n");
+
+        ClpConfig config = new ClpConfig()
+                .setMetadataProviderType(YAML)
+                .setMetadataYamlPath(metadataFile.getAbsolutePath())
+                .setSplitMetadataConfigPath(splitMetadataFile.getAbsolutePath());
+
+        ClpYamlMetadataProvider provider = new ClpYamlMetadataProvider(config, createSplitMetadataConfig(config));
+        provider.listTableHandles(DEFAULT_SCHEMA_NAME);
+
+        // Test table_a
+        SchemaTableName tableA = new SchemaTableName(DEFAULT_SCHEMA_NAME, "table_a");
+        List<ClpColumnHandle> columnsA = provider.listColumnHandles(tableA);
+        assertEquals(columnsA.size(), 2); // col_a + file_name
+
+        Set<String> columnNamesA = columnsA.stream()
+                .map(ClpColumnHandle::getColumnName)
+                .collect(java.util.stream.Collectors.toSet());
+        assertTrue(columnNamesA.contains("col_a"));
+        assertTrue(columnNamesA.contains("file_name"));
+
+        // Test table_b
+        SchemaTableName tableB = new SchemaTableName(DEFAULT_SCHEMA_NAME, "table_b");
+        List<ClpColumnHandle> columnsB = provider.listColumnHandles(tableB);
+        assertEquals(columnsB.size(), 2); // col_b + partition_id
+
+        Set<String> columnNamesB = columnsB.stream()
+                .map(ClpColumnHandle::getColumnName)
+                .collect(java.util.stream.Collectors.toSet());
+        assertTrue(columnNamesB.contains("col_b"));
+        assertTrue(columnNamesB.contains("partition_id"));
+
+        // Verify table_a doesn't have table_b's metadata column
+        assertEquals(columnNamesA.contains("partition_id"), false);
+        assertEquals(columnNamesB.contains("file_name"), false);
+    }
+
+    /**
+     * Test that conflicting column types between YAML and metadata config throw an exception
+     */
+    @Test
+    public void testListColumnHandlesWithTypeConflict() throws IOException
+    {
+        // Create a split metadata config file where order_id is VARCHAR
+        File splitMetadataFile = createTempJsonFile(
+                "{\n" +
+                "  \"default.conflict_table\": {\n" +
+                "    \"metaColumns\": {\n" +
+                "      \"order_id\": {\n" +
+                "        \"type\": \"VARCHAR\"\n" +
+                "      }\n" +
+                "    }\n" +
+                "  }\n" +
+                "}");
+
+        // Create a table schema YAML file where order_id is BIGINT (type 0)
+        File tableSchemaFile = createTempYamlFile(
+                "order_id: 0\n" +
+                "customer_name: 3\n");
+
+        File metadataFile = createTempYamlFile(
+                "clp:\n" +
+                "  default:\n" +
+                "    conflict_table: " + tableSchemaFile.getAbsolutePath() + "\n");
+
+        ClpConfig config = new ClpConfig()
+                .setMetadataProviderType(YAML)
+                .setMetadataYamlPath(metadataFile.getAbsolutePath())
+                .setSplitMetadataConfigPath(splitMetadataFile.getAbsolutePath());
+
+        ClpYamlMetadataProvider provider = new ClpYamlMetadataProvider(config, createSplitMetadataConfig(config));
+        provider.listTableHandles(DEFAULT_SCHEMA_NAME);
+
+        SchemaTableName schemaTableName = new SchemaTableName(DEFAULT_SCHEMA_NAME, "conflict_table");
+
+        try {
+            provider.listColumnHandles(schemaTableName);
+            fail("Expected PrestoException for type conflict");
+        }
+        catch (Exception e) {
+            assertTrue(e.getMessage().contains("has conflicting type definitions"),
+                    "Exception should mention type conflict: " + e.getMessage());
+            assertTrue(e.getMessage().contains("order_id"),
+                    "Exception should mention the conflicting column name: " + e.getMessage());
+        }
+    }
+
+    /**
      * Helper method to create temporary YAML files for testing
      */
     private File createTempYamlFile(String content) throws IOException
     {
         File tempFile = Files.createTempFile("clp-test-", ".yaml").toFile();
+        tempFile.deleteOnExit();
+        tempFiles.add(tempFile);
+
+        try (FileWriter writer = new FileWriter(tempFile)) {
+            writer.write(content);
+        }
+
+        return tempFile;
+    }
+
+    /**
+     * Helper method to create temporary JSON files for testing
+     */
+    private File createTempJsonFile(String content) throws IOException
+    {
+        File tempFile = Files.createTempFile("clp-test-", ".json").toFile();
         tempFile.deleteOnExit();
         tempFiles.add(tempFile);
 

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/optimization/TestClpComputePushDown.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/optimization/TestClpComputePushDown.java
@@ -54,6 +54,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 @Test(singleThreaded = true)
@@ -294,7 +295,6 @@ public class TestClpComputePushDown
                 TupleDomain.all(),
                 Optional.empty());
 
-        // Verify that the optimizer completes successfully and skips the range-bound column
         PlanNode optimized = optimizer.optimize(
                 originalScan,
                 new SessionHolder().getConnectorSession(),
@@ -304,11 +304,7 @@ public class TestClpComputePushDown
         TableScanNode rewrittenScan = (TableScanNode) optimized;
 
         // Verify that the layout is NOT present (since the only metadata column was range-bound and skipped)
-        if (rewrittenScan.getTable().getLayout().isPresent()) {
-            ClpTableLayoutHandle layout = (ClpTableLayoutHandle) rewrittenScan.getTable().getLayout().get();
-            Set<String> metadataProjections = layout.getOrInitializeSplitMetadataColumnNames();
-            assertTrue(metadataProjections.isEmpty(),
-                    "Range-bound columns should be skipped from metadata projection");
-        }
+        assertFalse(rewrittenScan.getTable().getLayout().isPresent(),
+                "Layout should not be present when only range-bound columns are projected");
     }
 }

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/optimization/TestClpComputePushDown.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/optimization/TestClpComputePushDown.java
@@ -26,7 +26,6 @@ import com.facebook.presto.plugin.clp.TestClpQueryBase;
 import com.facebook.presto.plugin.clp.split.ClpSplitMetadataConfig;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorId;
-import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.VariableAllocator;
@@ -50,14 +49,12 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.facebook.presto.common.type.DoubleType.DOUBLE;
-import static com.facebook.presto.plugin.clp.ClpErrorCode.CLP_UNSUPPORTED_METADATA_PROJECTION;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
 
 @Test(singleThreaded = true)
 public class TestClpComputePushDown
@@ -248,13 +245,13 @@ public class TestClpComputePushDown
     }
 
     /**
-     * Validates that attempting to project a metadata column backed by a range-bound field raises a
-     * CLP_UNSUPPORTED_METADATA_PROJECTION PrestoException with the offending column name in the message.
+     * Validates that projecting a metadata column backed by a range-bound field is handled gracefully
+     * by skipping it in the metadata projection (returning NULL for that column).
      */
     @Test
-    public void testMetadataProjectionWithErrorHandling()
+    public void testMetadataProjectionWithRangeBoundColumn()
     {
-        // Get a metadata column that has range bounds (should trigger the exception)
+        // Get a metadata column that has range bounds (should be skipped in metadata projection)
         Set<String> metadataColumnsWithRangeBound =
                 metadataConfig.getMetadataColumnsWithRangeBounds(schemaTableName);
         Map<String, String> exposedToOriginalMap =
@@ -297,20 +294,21 @@ public class TestClpComputePushDown
                 TupleDomain.all(),
                 Optional.empty());
 
-        // Verify that PrestoException is thrown with the correct error code and message
-        final String columnName = rangeBoundExposedColumn;
-        try {
-            optimizer.optimize(
-                    originalScan,
-                    new SessionHolder().getConnectorSession(),
-                    variableAllocator,
-                    idAllocator);
-            fail("Expected PrestoException to be thrown");
-        }
-        catch (PrestoException e) {
-            assertEquals(e.getErrorCode(), CLP_UNSUPPORTED_METADATA_PROJECTION.toErrorCode());
-            assertTrue(e.getMessage().contains(columnName),
-                    "Exception message should contain the column name: " + columnName);
+        // Verify that the optimizer completes successfully and skips the range-bound column
+        PlanNode optimized = optimizer.optimize(
+                originalScan,
+                new SessionHolder().getConnectorSession(),
+                variableAllocator,
+                idAllocator);
+
+        TableScanNode rewrittenScan = (TableScanNode) optimized;
+
+        // Verify that the layout is NOT present (since the only metadata column was range-bound and skipped)
+        if (rewrittenScan.getTable().getLayout().isPresent()) {
+            ClpTableLayoutHandle layout = (ClpTableLayoutHandle) rewrittenScan.getTable().getLayout().get();
+            Set<String> metadataProjections = layout.getOrInitializeSplitMetadataColumnNames();
+            assertTrue(metadataProjections.isEmpty(),
+                    "Range-bound columns should be skipped from metadata projection");
         }
     }
 }

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/optimization/TestClpComputePushDown.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/optimization/TestClpComputePushDown.java
@@ -53,8 +53,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertTrue;
 
 @Test(singleThreaded = true)


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

Eliminates the need to duplicate metadata column definitions by automatically merging metadata columns from split-filter.json into the table schema. Users now only need to define metadata columns once in the split metadata configuration file.

Before: Users had to define metadata columns in two places:
```
  # split-filter.json
  {
    "default.logs": {
      "metaColumns": {
        "file_name": { "type": "VARCHAR" },
        "begin_timestamp": { "type": "BIGINT" }
      }
    }
  }

  # table-schema.yml
  file_name: 3
  begin_timestamp: 0
  log_message: 3
```

  After: Define once in split-filter.json, automatically merged:
```
  # split-filter.json same as before
  # table-schema.yml
  log_message: 3
```

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [ ] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [ ] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [ ] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
