### PR TITLE
refactor: Add customized code for Pinot-variant split provider.

### DIFF
--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpPinotSplitProvider.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpPinotSplitProvider.java
@@ -220,7 +220,7 @@ public class ClpPinotSplitProvider
                     tableName,
                     metadataColumnNames,
                     metadataFilterQuery.orElse("1 = 1"));
-            List<Map<String, JsonNode>> splitRows = getQueryResult(pinotSqlQueryEndpointUrl, splitQuery);
+            List<Map<String, JsonNode>> splitRows = getQueryResult(splitQuery);
 
             for (Map<String, JsonNode> row : splitRows) {
                 JsonNode tpathNode = row.get("tpath");
@@ -302,7 +302,7 @@ public class ClpPinotSplitProvider
     protected List<ArchiveMeta> fetchArchiveMeta(String query, ClpTopNSpec.Ordering ordering)
     {
         ImmutableList.Builder<ArchiveMeta> archiveMetas = new ImmutableList.Builder<>();
-        List<Map<String, JsonNode>> results = getQueryResult(pinotSqlQueryEndpointUrl, query);
+        List<Map<String, JsonNode>> results = getQueryResult(query);
         for (Map<String, JsonNode> row : results) {
             JsonNode idNode = row.get("tpath");
             JsonNode lowerNode = row.get("creationtime");
@@ -337,7 +337,7 @@ public class ClpPinotSplitProvider
      * @param order ASC (earliest first) or DESC (latest first)
      * @return archives that must be scanned
      */
-    protected static List<ArchiveMeta> selectTopNArchives(List<ArchiveMeta> archives, long limit, ClpTopNSpec.Order order)
+    protected List<ArchiveMeta> selectTopNArchives(List<ArchiveMeta> archives, long limit, ClpTopNSpec.Order order)
     {
         if (archives == null || archives.isEmpty() || limit <= 0) {
             return ImmutableList.of();
@@ -487,17 +487,16 @@ public class ClpPinotSplitProvider
     /**
      * Executes a SQL query against a Pinot database via HTTP POST and returns the results as a list of row maps.
      *
-     * @param url the Pinot broker HTTP endpoint URL
      * @param sql the SQL query string to execute
      * @return a list where each element represents one row from the query results. Each row is a map that allows
      *         looking up the column value of that row through the column name (e.g., map.get("columnName") returns
      *         the value for that column for the row as a JsonNode). Returns an empty list if the query fails or
      *         encounters an error.
      */
-    protected static List<Map<String, JsonNode>> getQueryResult(URL url, String sql)
+    protected List<Map<String, JsonNode>> getQueryResult(String sql)
     {
         try {
-            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            HttpURLConnection conn = (HttpURLConnection) pinotSqlQueryEndpointUrl.openConnection();
             conn.setRequestMethod("POST");
             conn.setRequestProperty("Content-Type", "application/json");
             conn.setRequestProperty("Accept", "application/json");

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpUberPinotSplitMetadataExpressionConverter.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpUberPinotSplitMetadataExpressionConverter.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.plugin.clp.split;
 
 import com.facebook.presto.common.function.OperatorType;
+import com.facebook.presto.common.type.Type;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.function.FunctionHandle;
@@ -75,6 +76,10 @@ public class ClpUberPinotSplitMetadataExpressionConverter
             if (operatorType.isComparisonOperator() && operatorType != IS_DISTINCT_FROM) {
                 String variableName = node.getArguments().get(0).accept(this, null);
                 String literalString = node.getArguments().get(1).accept(this, null);
+
+                Type columnType = node.getArguments().get(0).getType();
+                Type literalType = node.getArguments().get(1).getType();
+                literalString = coerceLiteralToColumnType(literalString, columnType, literalType);
 
                 String rewritten = rewriteComparisonWithBounds(variableName, operatorType, literalString);
                 if (rewritten != null) {

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpUberPinotSplitProvider.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpUberPinotSplitProvider.java
@@ -218,6 +218,11 @@ public class ClpUberPinotSplitProvider
         return String.format("rta.logging.%s", tableName);
     }
 
+    /**
+     * Adds Uber-specific HTTP headers required for Neutrino service authentication.
+     *
+     * @param conn the HTTP connection to add headers to
+     */
     protected void addCustomQueryRequestHeader(HttpURLConnection conn)
     {
         conn.setRequestProperty("RPC-Service", "neutrino-logging");
@@ -227,13 +232,11 @@ public class ClpUberPinotSplitProvider
     }
 
     /**
-     * Executes a SQL query against a Pinot database via HTTP POST and returns the results as a list of row maps.
-     *
-     * @param sql the SQL query string to execute
-     * @return a list where each element represents one row from the query results. Each row is a map that allows
-     *         looking up the column value of that row through the column name (e.g., map.get("columnName") returns
-     *         the value for that column for the row as a JsonNode). Returns an empty list if the query fails or
-     *         encounters an error.
+     * {@inheritDoc}
+     * <p>
+     * This Uber-specific implementation sends the SQL query as plain text to the Neutrino
+     * endpoint and parses the response using {@link #parseQueryResponse(JsonNode)}.
+     * </p>
      */
     @Override
     protected List<Map<String, JsonNode>> getQueryResult(String sql)

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpUberPinotSplitProvider.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpUberPinotSplitProvider.java
@@ -37,7 +37,12 @@ import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 import static com.facebook.presto.plugin.clp.ClpErrorCode.CLP_MANDATORY_COLUMN_NOT_IN_FILTER;
 import static java.lang.String.format;

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpUberPinotSplitProvider.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpUberPinotSplitProvider.java
@@ -23,21 +23,26 @@ import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.function.FunctionMetadataManager;
 import com.facebook.presto.spi.function.StandardFunctionResolution;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 import javax.inject.Inject;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
 
 import static com.facebook.presto.plugin.clp.ClpErrorCode.CLP_MANDATORY_COLUMN_NOT_IN_FILTER;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
  * Uber-specific implementation of CLP Pinot split provider.
@@ -112,7 +117,7 @@ public class ClpUberPinotSplitProvider
                     tableName,
                     metadataColumnNames,
                     metadataFilterQuery.orElse("1 = 1"));
-            List<Map<String, JsonNode>> splitRows = getQueryResult(pinotSqlQueryEndpointUrl, splitQuery);
+            List<Map<String, JsonNode>> splitRows = getQueryResult(splitQuery);
 
             for (Map<String, JsonNode> row : splitRows) {
                 String splitPath = row.get("tpath").asText();
@@ -150,7 +155,7 @@ public class ClpUberPinotSplitProvider
     @Override
     protected URL buildPinotSqlQueryEndpointUrl(ClpConfig config) throws MalformedURLException
     {
-        return new URL(config.getMetadataDbUrl() + "/v1/globalStatements");
+        return new URL(config.getMetadataDbUrl() + "/v1/globalStatement");
     }
 
     /**
@@ -206,5 +211,116 @@ public class ClpUberPinotSplitProvider
     protected String buildUberTableName(String tableName)
     {
         return String.format("rta.logging.%s", tableName);
+    }
+
+    protected void addCustomQueryRequestHeader(HttpURLConnection conn)
+    {
+        conn.setRequestProperty("RPC-Service", "neutrino-logging");
+        conn.setRequestProperty("RPC-Caller", "logging-terrablob-connector");
+        conn.setRequestProperty("Content-Type", "text/plain");
+        conn.setRequestProperty("Accept", "text/plain");
+    }
+
+    /**
+     * Executes a SQL query against a Pinot database via HTTP POST and returns the results as a list of row maps.
+     *
+     * @param sql the SQL query string to execute
+     * @return a list where each element represents one row from the query results. Each row is a map that allows
+     *         looking up the column value of that row through the column name (e.g., map.get("columnName") returns
+     *         the value for that column for the row as a JsonNode). Returns an empty list if the query fails or
+     *         encounters an error.
+     */
+    @Override
+    protected List<Map<String, JsonNode>> getQueryResult(String sql)
+    {
+        try {
+            HttpURLConnection conn = (HttpURLConnection) pinotSqlQueryEndpointUrl.openConnection();
+            conn.setRequestMethod("POST");
+            conn.setDoOutput(true);
+            conn.setConnectTimeout((int) SECONDS.toMillis(5));
+            conn.setReadTimeout((int) SECONDS.toMillis(30));
+            addCustomQueryRequestHeader(conn);
+
+            log.info("Executing Pinot query: %s", sql);
+            ObjectMapper mapper = new ObjectMapper();
+            String body = sql;
+            try (OutputStream os = conn.getOutputStream()) {
+                os.write(body.getBytes(StandardCharsets.UTF_8));
+            }
+
+            int code = conn.getResponseCode();
+            InputStream is = (code >= 200 && code < 300) ? conn.getInputStream() : conn.getErrorStream();
+            if (is == null) {
+                throw new IOException("Pinot HTTP " + code + " with empty body");
+            }
+
+            JsonNode root;
+            try (InputStream in = is) {
+                root = mapper.readTree(in);
+            }
+
+            return parseQueryResponse(root);
+        }
+        catch (IOException e) {
+            log.error(e, "IO error executing Pinot query: %s", sql);
+            return Collections.emptyList();
+        }
+        catch (Exception e) {
+            log.error(e, "Unexpected error executing Pinot query: %s", sql);
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * Parses the JSON response from an Uber Neutrino query into a list of row maps.
+     * <p>
+     * The Uber Neutrino response format differs from standard Pinot:
+     * <ul>
+     *   <li><b>columns</b>: Array of column definitions, each containing "name", "type", and "typeSignature"</li>
+     *   <li><b>data</b>: Array of row arrays (equivalent to Pinot's "rows")</li>
+     * </ul>
+     * </p>
+     *
+     * @param root the root JSON node of the query response
+     * @return a list of maps where each map represents a row with column names as keys
+     * @throws IllegalStateException if the response is missing required fields
+     */
+    @VisibleForTesting
+    protected List<Map<String, JsonNode>> parseQueryResponse(JsonNode root)
+    {
+        JsonNode columnsNode = root.get("columns");
+        if (columnsNode == null) {
+            throw new IllegalStateException("Uber query response missing 'columns' field");
+        }
+
+        JsonNode dataNode = root.get("data");
+        if (dataNode == null) {
+            throw new IllegalStateException("Uber query response missing 'data' field");
+        }
+
+        ImmutableList.Builder<String> columnNamesBuilder = ImmutableList.builder();
+        for (Iterator<JsonNode> it = columnsNode.elements(); it.hasNext(); ) {
+            JsonNode columnDef = it.next();
+            JsonNode nameNode = columnDef.get("name");
+            if (nameNode == null) {
+                throw new IllegalStateException("Column definition missing 'name' field");
+            }
+            columnNamesBuilder.add(nameNode.asText());
+        }
+        List<String> columnNames = columnNamesBuilder.build();
+
+        ImmutableList.Builder<Map<String, JsonNode>> resultBuilder = ImmutableList.builder();
+        for (Iterator<JsonNode> it = dataNode.elements(); it.hasNext(); ) {
+            JsonNode row = it.next();
+            ImmutableMap.Builder<String, JsonNode> rowBuilder = ImmutableMap.builder();
+            for (int i = 0; i < columnNames.size(); i++) {
+                rowBuilder.put(columnNames.get(i), row.get(i));
+            }
+            resultBuilder.add(rowBuilder.build());
+        }
+
+        List<Map<String, JsonNode>> results = resultBuilder.build();
+        log.debug("Number of results: %s", results.size());
+        return results;
     }
 }

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpUberPinotSplitProvider.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpUberPinotSplitProvider.java
@@ -322,7 +322,10 @@ public class ClpUberPinotSplitProvider
             JsonNode row = it.next();
             ImmutableMap.Builder<String, JsonNode> rowBuilder = ImmutableMap.builder();
             for (int i = 0; i < columnNames.size(); i++) {
-                rowBuilder.put(columnNames.get(i), row.get(i));
+                JsonNode val = row.get(i);
+                if (val != null) {
+                    rowBuilder.put(columnNames.get(i), val);
+                }
             }
             resultBuilder.add(rowBuilder.build());
         }

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/split/TestClpUberPinotSplitProvider.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/split/TestClpUberPinotSplitProvider.java
@@ -17,6 +17,8 @@ import com.facebook.presto.plugin.clp.ClpConfig;
 import com.facebook.presto.plugin.clp.ClpTableHandle;
 import com.facebook.presto.plugin.clp.TestClpQueryBase;
 import com.facebook.presto.spi.SchemaTableName;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -24,8 +26,10 @@ import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
-import static org.testng.Assert.assertEquals;
+import static com.facebook.presto.testing.assertions.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
@@ -68,10 +72,10 @@ public class TestClpUberPinotSplitProvider
         URL result = (URL) method.invoke(splitProvider, config);
 
         assertNotNull(result);
-        assertEquals(result.toString(), "https://neutrino.uber.com/v1/globalStatements");
+        assertEquals(result.toString(), "https://neutrino.uber.com/v1/globalStatement");
         assertEquals(result.getProtocol(), "https");
         assertEquals(result.getHost(), "neutrino.uber.com");
-        assertEquals(result.getPath(), "/v1/globalStatements");
+        assertEquals(result.getPath(), "/v1/globalStatement");
     }
 
     /**
@@ -86,17 +90,17 @@ public class TestClpUberPinotSplitProvider
         // Test with trailing slash
         config.setMetadataDbUrl("https://neutrino.uber.com/");
         URL result = (URL) method.invoke(splitProvider, config);
-        assertEquals(result.toString(), "https://neutrino.uber.com//v1/globalStatements");
+        assertEquals(result.toString(), "https://neutrino.uber.com//v1/globalStatement");
 
         // Test without protocol (should work as URL constructor handles it)
         config.setMetadataDbUrl("http://neutrino-dev.uber.com");
         result = (URL) method.invoke(splitProvider, config);
-        assertEquals(result.toString(), "http://neutrino-dev.uber.com/v1/globalStatements");
+        assertEquals(result.toString(), "http://neutrino-dev.uber.com/v1/globalStatement");
 
         // Test with port
         config.setMetadataDbUrl("https://neutrino.uber.com:8080");
         result = (URL) method.invoke(splitProvider, config);
-        assertEquals(result.toString(), "https://neutrino.uber.com:8080/v1/globalStatements");
+        assertEquals(result.toString(), "https://neutrino.uber.com:8080/v1/globalStatement");
     }
 
     /**
@@ -257,5 +261,79 @@ public class TestClpUberPinotSplitProvider
                 standardFunctionResolution,
                 new ClpSplitMetadataConfig(newConfig, functionAndTypeManager));
         assertNotNull(newProvider);
+    }
+
+    /**
+     * Test parsing of Uber Neutrino query response format.
+     * Verifies that the JSON response with "columns" and "data" fields is correctly
+     * parsed into a list of row maps.
+     */
+    @Test
+    public void testParseQueryResponse() throws Exception
+    {
+        // Sample JSON in Uber Neutrino response format
+        String jsonResponse = String.join("\n",
+                "{",
+                "  'id': '20251211_200011_71046_z3qq5',",
+                "  'infoUri': '//localhost:5436/ui/query.html?20251211_200011_71046_z3qq5',",
+                "  'columns': [",
+                "    {",
+                "      'name': 'tpath',",
+                "      'type': 'varchar',",
+                "      'typeSignature': {",
+                "        'rawType': 'varchar',",
+                "        'typeArguments': [],",
+                "        'literalArguments': [],",
+                "        'arguments': [{'kind': 'LONG_LITERAL', 'value': 2147483647}]",
+                "      }",
+                "    },",
+                "    {",
+                "      'name': '_timestampMillis',",
+                "      'type': 'bigint',",
+                "      'typeSignature': {",
+                "        'rawType': 'bigint',",
+                "        'typeArguments': [],",
+                "        'literalArguments': [],",
+                "        'arguments': []",
+                "      }",
+                "    }",
+                "  ],",
+                "  'data': [",
+                "    ['/prod/logging/athena/table_a/dca/archive1.clp.zst', 1765483211084],",
+                "    ['/prod/logging/athena/table_b/dca/archive2.clp.zst', 1765483211043],",
+                "    ['/prod/logging/athena/table_c/dca/archive3.clp.zst', 1765483211043]",
+                "  ]",
+                "}").replace('\'', '"');
+
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode root = mapper.readTree(jsonResponse);
+
+        List<Map<String, JsonNode>> results = splitProvider.parseQueryResponse(root);
+
+        // Verify correct number of rows
+        assertEquals(results.size(), 3);
+
+        // Verify first row
+        Map<String, JsonNode> row0 = results.get(0);
+        assertEquals(row0.size(), 2);
+        assertEquals(row0.get("tpath").asText(), "/prod/logging/athena/table_a/dca/archive1.clp.zst");
+        assertEquals(row0.get("_timestampMillis").asLong(), 1765483211084L);
+
+        // Verify second row
+        Map<String, JsonNode> row1 = results.get(1);
+        assertEquals(row1.get("tpath").asText(), "/prod/logging/athena/table_b/dca/archive2.clp.zst");
+        assertEquals(row1.get("_timestampMillis").asLong(), 1765483211043L);
+
+        // Verify third row
+        Map<String, JsonNode> row2 = results.get(2);
+        assertEquals(row2.get("tpath").asText(), "/prod/logging/athena/table_c/dca/archive3.clp.zst");
+        assertEquals(row2.get("_timestampMillis").asLong(), 1765483211043L);
+
+        // Verify that non-existent columns return null
+        for (Map<String, JsonNode> row : results) {
+            assertEquals(row.get("nonExistentColumn"), null);
+            assertEquals(row.get("id"), null);
+            assertEquals(row.get("infoUri"), null);
+        }
     }
 }

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/split/TestClpUberPinotSplitProvider.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/split/TestClpUberPinotSplitProvider.java
@@ -310,21 +310,21 @@ public class TestClpUberPinotSplitProvider
 
         List<Map<String, JsonNode>> results = splitProvider.parseQueryResponse(root);
 
-        // Verify correct number of rows
+        // Verify the correct number of rows
         assertEquals(results.size(), 3);
 
-        // Verify first row
+        // Verify the first row
         Map<String, JsonNode> row0 = results.get(0);
         assertEquals(row0.size(), 2);
         assertEquals(row0.get("tpath").asText(), "/prod/logging/athena/table_a/dca/archive1.clp.zst");
         assertEquals(row0.get("_timestampMillis").asLong(), 1765483211084L);
 
-        // Verify second row
+        // Verify the second row
         Map<String, JsonNode> row1 = results.get(1);
         assertEquals(row1.get("tpath").asText(), "/prod/logging/athena/table_b/dca/archive2.clp.zst");
         assertEquals(row1.get("_timestampMillis").asLong(), 1765483211043L);
 
-        // Verify third row
+        // Verify the third row
         Map<String, JsonNode> row2 = results.get(2);
         assertEquals(row2.get("tpath").asText(), "/prod/logging/athena/table_c/dca/archive3.clp.zst");
         assertEquals(row2.get("_timestampMillis").asLong(), 1765483211043L);

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/split/TestClpUberPinotSplitProvider.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/split/TestClpUberPinotSplitProvider.java
@@ -274,8 +274,8 @@ public class TestClpUberPinotSplitProvider
         // Sample JSON in Uber Neutrino response format
         String jsonResponse = String.join("\n",
                 "{",
-                "  'id': '20251211_200011_71046_z3qq5',",
-                "  'infoUri': '//localhost:5436/ui/query.html?20251211_200011_71046_z3qq5',",
+                "  'id': '12345',",
+                "  'uri': '//localhost:5436/query.html?12345',",
                 "  'columns': [",
                 "    {",
                 "      'name': 'tpath',",
@@ -299,9 +299,9 @@ public class TestClpUberPinotSplitProvider
                 "    }",
                 "  ],",
                 "  'data': [",
-                "    ['/prod/logging/athena/table_a/dca/archive1.clp.zst', 1765483211084],",
-                "    ['/prod/logging/athena/table_b/dca/archive2.clp.zst', 1765483211043],",
-                "    ['/prod/logging/athena/table_c/dca/archive3.clp.zst', 1765483211043]",
+                "    ['/path/to/table_a/archive1.clp.zst', 1765483211084],",
+                "    ['/path/to/table_b/archive2.clp.zst', 1765483211043],",
+                "    ['/path/to/table_c/archive3.clp.zst', 1765483211043]",
                 "  ]",
                 "}").replace('\'', '"');
 
@@ -316,24 +316,24 @@ public class TestClpUberPinotSplitProvider
         // Verify the first row
         Map<String, JsonNode> row0 = results.get(0);
         assertEquals(row0.size(), 2);
-        assertEquals(row0.get("tpath").asText(), "/prod/logging/athena/table_a/dca/archive1.clp.zst");
+        assertEquals(row0.get("tpath").asText(), "/path/to/table_a/archive1.clp.zst");
         assertEquals(row0.get("_timestampMillis").asLong(), 1765483211084L);
 
         // Verify the second row
         Map<String, JsonNode> row1 = results.get(1);
-        assertEquals(row1.get("tpath").asText(), "/prod/logging/athena/table_b/dca/archive2.clp.zst");
+        assertEquals(row1.get("tpath").asText(), "/path/to/table_b/archive2.clp.zst");
         assertEquals(row1.get("_timestampMillis").asLong(), 1765483211043L);
 
         // Verify the third row
         Map<String, JsonNode> row2 = results.get(2);
-        assertEquals(row2.get("tpath").asText(), "/prod/logging/athena/table_c/dca/archive3.clp.zst");
+        assertEquals(row2.get("tpath").asText(), "/path/to/table_c/archive3.clp.zst");
         assertEquals(row2.get("_timestampMillis").asLong(), 1765483211043L);
 
         // Verify that non-existent columns return null
         for (Map<String, JsonNode> row : results) {
             assertEquals(row.get("nonExistentColumn"), null);
             assertEquals(row.get("id"), null);
-            assertEquals(row.get("infoUri"), null);
+            assertEquals(row.get("uri"), null);
         }
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR adds customized code for the Pinot-variant split provider to handle format constraints imposed by the environment.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [ ] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [ ] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [ ] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

All unit tests with the new unit test created from the input of the Pinot-variant environment.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored internal query handling to use instance-level methods instead of static utilities for improved architectural consistency.
  * Enhanced HTTP request handling with custom headers and improved timeout management.
  * Updated query endpoint path format for improved compatibility.

* **Tests**
  * Updated test suite to reflect endpoint URL changes and added coverage for response parsing logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->