### PR TITLE
fix:  Retrieve latest row from append-only Pinot using LASTWITHTIME deduplication.

### DIFF
--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpPinotSplitProvider.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpPinotSplitProvider.java
@@ -65,7 +65,7 @@ public class ClpPinotSplitProvider
 {
     private static final String SQL_SELECT_SPLITS_TEMPLATE = "SELECT %s FROM %s WHERE 1 = 1 AND (%s) GROUP BY tpath LIMIT 999999";
 
-    private static final String DEDUPLICATION_COLUMN = "'lastmodifiedtime'";
+    private static final String DEDUPLICATION_COLUMN = "lastmodifiedtime";
 
     private final ClpConfig config;
 

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpPinotSplitProvider.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpPinotSplitProvider.java
@@ -220,7 +220,7 @@ public class ClpPinotSplitProvider
                     tableName,
                     metadataColumnNames,
                     metadataFilterQuery.orElse("1 = 1"));
-            List<Map<String, JsonNode>> splitRows = getQueryResult(pinotSqlQueryEndpointUrl, splitQuery);
+            List<Map<String, JsonNode>> splitRows = getQueryResult(splitQuery);
 
             for (Map<String, JsonNode> row : splitRows) {
                 JsonNode tpathNode = row.get("tpath");
@@ -302,7 +302,7 @@ public class ClpPinotSplitProvider
     protected List<ArchiveMeta> fetchArchiveMeta(String query, ClpTopNSpec.Ordering ordering)
     {
         ImmutableList.Builder<ArchiveMeta> archiveMetas = new ImmutableList.Builder<>();
-        List<Map<String, JsonNode>> results = getQueryResult(pinotSqlQueryEndpointUrl, query);
+        List<Map<String, JsonNode>> results = getQueryResult(query);
         for (Map<String, JsonNode> row : results) {
             JsonNode idNode = row.get("tpath");
             JsonNode lowerNode = row.get("creationtime");
@@ -337,7 +337,7 @@ public class ClpPinotSplitProvider
      * @param order ASC (earliest first) or DESC (latest first)
      * @return archives that must be scanned
      */
-    protected static List<ArchiveMeta> selectTopNArchives(List<ArchiveMeta> archives, long limit, ClpTopNSpec.Order order)
+    protected List<ArchiveMeta> selectTopNArchives(List<ArchiveMeta> archives, long limit, ClpTopNSpec.Order order)
     {
         if (archives == null || archives.isEmpty() || limit <= 0) {
             return ImmutableList.of();
@@ -487,17 +487,16 @@ public class ClpPinotSplitProvider
     /**
      * Executes a SQL query against a Pinot database via HTTP POST and returns the results as a list of row maps.
      *
-     * @param url the Pinot broker HTTP endpoint URL
      * @param sql the SQL query string to execute
      * @return a list where each element represents one row from the query results. Each row is a map that allows
      *         looking up the column value of that row through the column name (e.g., map.get("columnName") returns
      *         the value for that column for the row as a JsonNode). Returns an empty list if the query fails or
      *         encounters an error.
      */
-    protected static List<Map<String, JsonNode>> getQueryResult(URL url, String sql)
+    protected List<Map<String, JsonNode>> getQueryResult(String sql)
     {
         try {
-            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            HttpURLConnection conn = (HttpURLConnection) pinotSqlQueryEndpointUrl.openConnection();
             conn.setRequestMethod("POST");
             conn.setRequestProperty("Content-Type", "application/json");
             conn.setRequestProperty("Accept", "application/json");

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpPinotSplitProvider.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpPinotSplitProvider.java
@@ -63,8 +63,11 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 public class ClpPinotSplitProvider
         implements ClpSplitProvider
 {
-    private static final String SQL_SELECT_SPLITS_TEMPLATE = "SELECT %s FROM %s WHERE 1 = 1 AND (%s) LIMIT 999999";
+    private static final String SQL_SELECT_SPLITS_TEMPLATE = "SELECT %s FROM %s WHERE 1 = 1 AND (%s) GROUP BY tpath LIMIT 999999";
     private static final String SQL_SELECT_SPLITS_TEMPLATE_WITH_TOPN = "SELECT tpath, creationtime, lastmodifiedtime, num_messages FROM %s WHERE 1 = 1 AND (%s) LIMIT 999999";
+
+    private static final String DEDUPLICATION_COLUMN = "'lastmodifiedtime'";
+
     private final ClpConfig config;
 
     protected static final Logger log = Logger.get(ClpPinotSplitProvider.class);
@@ -449,25 +452,47 @@ public class ClpPinotSplitProvider
     }
 
     /**
-     * Factory method for building split selection SQL queries.
-     * Exposed for testing purposes.
+     * Returns the timestamp column reference used for LASTWITHTIME deduplication.
+     * Subclasses can override this to use a different timestamp column.
+     *
+     * @return the timestamp column reference with appropriate SQL quoting
+     */
+    protected String getDeduplicationColumn()
+    {
+        return DEDUPLICATION_COLUMN;
+    }
+
+    /**
+     * Builds a SQL query for split selection with deduplication using LASTWITHTIME.
+     * <p>
+     * Pinot uses an append-only data model where UPDATE operations don't modify existing
+     * rows but instead append new rows with updated values. This method constructs queries
+     * that use {@code LASTWITHTIME} aggregation with {@code GROUP BY tpath} to retrieve
+     * only the latest version of each record.
+     * </p>
      *
      * @param tableName the Pinot table name
+     * @param metadataProject the list of metadata columns to project
      * @param filterSql the filter SQL expression
-     * @return the complete SQL query for selecting splits
+     * @return the complete SQL query with deduplication for selecting splits
      */
     @VisibleForTesting
     protected String buildSplitSelectionQuery(String tableName, List<String> metadataProject, String filterSql)
     {
         Set<String> allProjections = new LinkedHashSet<>();
         allProjections.addAll(requiredProjectionColumns);
-        allProjections.addAll(metadataProject);
 
-        String metadataColumns = allProjections.isEmpty()
+        // Build LASTWITHTIME expressions for each metadata column
+        for (String column : metadataProject) {
+            allProjections.add(
+                    format("LASTWITHTIME(%s, %s, 'long') AS %s", column, getDeduplicationColumn(), column));
+        }
+
+        String projectionClause = allProjections.isEmpty()
                 ? ""
                 : String.join(", ", allProjections);
 
-        return format(SQL_SELECT_SPLITS_TEMPLATE, metadataColumns, tableName, filterSql);
+        return format(SQL_SELECT_SPLITS_TEMPLATE, projectionClause, tableName, filterSql);
     }
 
     /**

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpPinotSplitProvider.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpPinotSplitProvider.java
@@ -64,7 +64,6 @@ public class ClpPinotSplitProvider
         implements ClpSplitProvider
 {
     private static final String SQL_SELECT_SPLITS_TEMPLATE = "SELECT %s FROM %s WHERE 1 = 1 AND (%s) GROUP BY tpath LIMIT 999999";
-    private static final String SQL_SELECT_SPLITS_TEMPLATE_WITH_TOPN = "SELECT tpath, creationtime, lastmodifiedtime, num_messages FROM %s WHERE 1 = 1 AND (%s) LIMIT 999999";
 
     private static final String DEDUPLICATION_COLUMN = "'lastmodifiedtime'";
 
@@ -496,17 +495,23 @@ public class ClpPinotSplitProvider
     }
 
     /**
-     * Factory method for building split metadata SQL queries.
-     * Exposed for testing purposes.
+     * Builds a SQL query for TopN split selection with deduplication using LASTWITHTIME.
+     * <p>
+     * Similar to {@link #buildSplitSelectionQuery}, this method uses {@code LASTWITHTIME}
+     * aggregation with {@code GROUP BY tpath} to retrieve only the latest version of each record.
+     * The projected columns (creationtime, lastmodifiedtime, num_messages) are required for
+     * TopN archive selection logic.
+     * </p>
      *
      * @param tableName the Pinot table name
      * @param filterSql the filter SQL expression
-     * @return the complete SQL query for selecting split metadata
+     * @return the complete SQL query with deduplication for selecting split metadata
      */
     @VisibleForTesting
     protected String buildSplitSelectionQueryWithTopN(String tableName, String filterSql)
     {
-        return format(SQL_SELECT_SPLITS_TEMPLATE_WITH_TOPN, tableName, filterSql);
+        List<String> topNColumns = Arrays.asList("creationtime", "lastmodifiedtime", "num_messages");
+        return buildSplitSelectionQuery(tableName, topNColumns, filterSql);
     }
 
     /**

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpUberPinotSplitMetadataExpressionConverter.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpUberPinotSplitMetadataExpressionConverter.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.plugin.clp.split;
 
 import com.facebook.presto.common.function.OperatorType;
+import com.facebook.presto.common.type.Type;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.function.FunctionHandle;
@@ -75,6 +76,10 @@ public class ClpUberPinotSplitMetadataExpressionConverter
             if (operatorType.isComparisonOperator() && operatorType != IS_DISTINCT_FROM) {
                 String variableName = node.getArguments().get(0).accept(this, null);
                 String literalString = node.getArguments().get(1).accept(this, null);
+
+                Type columnType = node.getArguments().get(0).getType();
+                Type literalType = node.getArguments().get(1).getType();
+                literalString = coerceLiteralToColumnType(literalString, columnType, literalType);
 
                 String rewritten = rewriteComparisonWithBounds(variableName, operatorType, literalString);
                 if (rewritten != null) {

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpUberPinotSplitProvider.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpUberPinotSplitProvider.java
@@ -57,12 +57,6 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  * customizes the SQL query endpoint URL to use Neutrino's global statements API instead of
  * the standard Pinot query endpoint.
  * </p>
- * <p>
- * This implementation also handles Pinot's append-only data model where UPDATE operations
- * don't modify existing rows but instead append new rows with updated values. To retrieve
- * only the latest version of each record, this class uses the {@code LASTWITHTIME} aggregation
- * function with {@code GROUP BY tpath} to deduplicate rows by their unique identifier.
- * </p>
  */
 public class ClpUberPinotSplitProvider
         extends ClpPinotSplitProvider

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpUberPinotSplitProvider.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpUberPinotSplitProvider.java
@@ -61,8 +61,8 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 public class ClpUberPinotSplitProvider
         extends ClpPinotSplitProvider
 {
-    private static final String SQL_SELECT_SPLITS_TEMPLATE_WITH_DEDUP =
-            "SELECT tpath, %s FROM %s WHERE 1 = 1 AND (%s) GROUP BY tpath LIMIT 999999";
+    private static final String DEDUPLICATION_COLUMN = "\"_timestampMillis\"";
+
     /**
      * Constructs an Uber CLP Pinot split provider with the given configuration.
      *
@@ -338,35 +338,16 @@ public class ClpUberPinotSplitProvider
     }
 
     /**
-     * Builds a SQL query for split selection with deduplication using LASTWITHTIME.
-     * <p>
-     * Pinot uses an append-only data model where UPDATE operations don't modify existing
-     * rows but instead append new rows with updated values. This method constructs queries
-     * that use {@code LASTWITHTIME} aggregation with {@code GROUP BY tpath} to retrieve
-     * only the latest version of each record.
-     * </p>
+     * Returns the timestamp column reference used for LASTWITHTIME deduplication.
+     * Uber uses "_timestampMillis" (with double quotes for identifier quoting)
+     * instead of the default "lastmodifiedtime".
      *
-     * @param tableName the Pinot table name
-     * @param metadataProject the list of metadata columns to project
-     * @param filterSql the filter SQL expression
-     * @return the complete SQL query with deduplication for selecting splits
+     * @return the timestamp column reference for Uber's Pinot infrastructure
      */
     @Override
-    @VisibleForTesting
-    protected String buildSplitSelectionQuery(String tableName, List<String> metadataProject, String filterSql)
+    protected String getDeduplicationColumn()
     {
-        // Build LASTWITHTIME expressions for each metadata column
-        List<String> lastWithTimeProjections = new ArrayList<>();
-        for (String column : metadataProject) {
-            lastWithTimeProjections.add(
-                    format("LASTWITHTIME(%s, \"_timestampMillis\", 'long') AS %s", column, column));
-        }
-
-        String projectionClause = lastWithTimeProjections.isEmpty()
-                ? ""
-                : String.join(", ", lastWithTimeProjections);
-
-        return format(SQL_SELECT_SPLITS_TEMPLATE_WITH_DEDUP, projectionClause, tableName, filterSql);
+        return DEDUPLICATION_COLUMN;
     }
 
     /**

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpUberPinotSplitProvider.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpUberPinotSplitProvider.java
@@ -218,6 +218,11 @@ public class ClpUberPinotSplitProvider
         return String.format("rta.logging.%s", tableName);
     }
 
+    /**
+     * Adds Uber-specific HTTP headers required for Neutrino service authentication.
+     *
+     * @param conn the HTTP connection to add headers to
+     */
     protected void addCustomQueryRequestHeader(HttpURLConnection conn)
     {
         conn.setRequestProperty("RPC-Service", "neutrino-logging");
@@ -227,13 +232,11 @@ public class ClpUberPinotSplitProvider
     }
 
     /**
-     * Executes a SQL query against a Pinot database via HTTP POST and returns the results as a list of row maps.
-     *
-     * @param sql the SQL query string to execute
-     * @return a list where each element represents one row from the query results. Each row is a map that allows
-     *         looking up the column value of that row through the column name (e.g., map.get("columnName") returns
-     *         the value for that column for the row as a JsonNode). Returns an empty list if the query fails or
-     *         encounters an error.
+     * {@inheritDoc}
+     * <p>
+     * This Uber-specific implementation sends the SQL query as plain text to the Neutrino
+     * endpoint and parses the response using {@link #parseQueryResponse(JsonNode)}.
+     * </p>
      */
     @Override
     protected List<Map<String, JsonNode>> getQueryResult(String sql)

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpUberPinotSplitProvider.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpUberPinotSplitProvider.java
@@ -37,7 +37,12 @@ import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 import static com.facebook.presto.plugin.clp.ClpErrorCode.CLP_MANDATORY_COLUMN_NOT_IN_FILTER;
 import static java.lang.String.format;

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpUberPinotSplitProvider.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpUberPinotSplitProvider.java
@@ -23,21 +23,26 @@ import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.function.FunctionMetadataManager;
 import com.facebook.presto.spi.function.StandardFunctionResolution;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 import javax.inject.Inject;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
 
 import static com.facebook.presto.plugin.clp.ClpErrorCode.CLP_MANDATORY_COLUMN_NOT_IN_FILTER;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
  * Uber-specific implementation of CLP Pinot split provider.
@@ -112,7 +117,7 @@ public class ClpUberPinotSplitProvider
                     tableName,
                     metadataColumnNames,
                     metadataFilterQuery.orElse("1 = 1"));
-            List<Map<String, JsonNode>> splitRows = getQueryResult(pinotSqlQueryEndpointUrl, splitQuery);
+            List<Map<String, JsonNode>> splitRows = getQueryResult(splitQuery);
 
             for (Map<String, JsonNode> row : splitRows) {
                 String splitPath = row.get("tpath").asText();
@@ -150,7 +155,7 @@ public class ClpUberPinotSplitProvider
     @Override
     protected URL buildPinotSqlQueryEndpointUrl(ClpConfig config) throws MalformedURLException
     {
-        return new URL(config.getMetadataDbUrl() + "/v1/globalStatements");
+        return new URL(config.getMetadataDbUrl() + "/v1/globalStatement");
     }
 
     /**
@@ -206,5 +211,116 @@ public class ClpUberPinotSplitProvider
     protected String buildUberTableName(String tableName)
     {
         return String.format("rta.logging.%s", tableName);
+    }
+
+    protected void addCustomQueryRequestHeader(HttpURLConnection conn)
+    {
+        conn.setRequestProperty("RPC-Service", "neutrino-logging");
+        conn.setRequestProperty("RPC-Caller", "logging-terrablob-connector");
+        conn.setRequestProperty("Content-Type", "text/plain");
+        conn.setRequestProperty("Accept", "text/plain");
+    }
+
+    /**
+     * Executes a SQL query against a Pinot database via HTTP POST and returns the results as a list of row maps.
+     *
+     * @param sql the SQL query string to execute
+     * @return a list where each element represents one row from the query results. Each row is a map that allows
+     *         looking up the column value of that row through the column name (e.g., map.get("columnName") returns
+     *         the value for that column for the row as a JsonNode). Returns an empty list if the query fails or
+     *         encounters an error.
+     */
+    @Override
+    protected List<Map<String, JsonNode>> getQueryResult(String sql)
+    {
+        try {
+            HttpURLConnection conn = (HttpURLConnection) pinotSqlQueryEndpointUrl.openConnection();
+            conn.setRequestMethod("POST");
+            conn.setDoOutput(true);
+            conn.setConnectTimeout((int) SECONDS.toMillis(5));
+            conn.setReadTimeout((int) SECONDS.toMillis(30));
+            addCustomQueryRequestHeader(conn);
+
+            log.info("Executing Pinot query: %s", sql);
+            ObjectMapper mapper = new ObjectMapper();
+            String body = sql;
+            try (OutputStream os = conn.getOutputStream()) {
+                os.write(body.getBytes(StandardCharsets.UTF_8));
+            }
+
+            int code = conn.getResponseCode();
+            InputStream is = (code >= 200 && code < 300) ? conn.getInputStream() : conn.getErrorStream();
+            if (is == null) {
+                throw new IOException("Pinot HTTP " + code + " with empty body");
+            }
+
+            JsonNode root;
+            try (InputStream in = is) {
+                root = mapper.readTree(in);
+            }
+
+            return parseQueryResponse(root);
+        }
+        catch (IOException e) {
+            log.error(e, "IO error executing Pinot query: %s", sql);
+            return Collections.emptyList();
+        }
+        catch (Exception e) {
+            log.error(e, "Unexpected error executing Pinot query: %s", sql);
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * Parses the JSON response from an Uber Neutrino query into a list of row maps.
+     * <p>
+     * The Uber Neutrino response format differs from standard Pinot:
+     * <ul>
+     *   <li><b>columns</b>: Array of column definitions, each containing "name", "type", and "typeSignature"</li>
+     *   <li><b>data</b>: Array of row arrays (equivalent to Pinot's "rows")</li>
+     * </ul>
+     * </p>
+     *
+     * @param root the root JSON node of the query response
+     * @return a list of maps where each map represents a row with column names as keys
+     * @throws IllegalStateException if the response is missing required fields
+     */
+    @VisibleForTesting
+    protected List<Map<String, JsonNode>> parseQueryResponse(JsonNode root)
+    {
+        JsonNode columnsNode = root.get("columns");
+        if (columnsNode == null) {
+            throw new IllegalStateException("Uber query response missing 'columns' field");
+        }
+
+        JsonNode dataNode = root.get("data");
+        if (dataNode == null) {
+            throw new IllegalStateException("Uber query response missing 'data' field");
+        }
+
+        ImmutableList.Builder<String> columnNamesBuilder = ImmutableList.builder();
+        for (Iterator<JsonNode> it = columnsNode.elements(); it.hasNext(); ) {
+            JsonNode columnDef = it.next();
+            JsonNode nameNode = columnDef.get("name");
+            if (nameNode == null) {
+                throw new IllegalStateException("Column definition missing 'name' field");
+            }
+            columnNamesBuilder.add(nameNode.asText());
+        }
+        List<String> columnNames = columnNamesBuilder.build();
+
+        ImmutableList.Builder<Map<String, JsonNode>> resultBuilder = ImmutableList.builder();
+        for (Iterator<JsonNode> it = dataNode.elements(); it.hasNext(); ) {
+            JsonNode row = it.next();
+            ImmutableMap.Builder<String, JsonNode> rowBuilder = ImmutableMap.builder();
+            for (int i = 0; i < columnNames.size(); i++) {
+                rowBuilder.put(columnNames.get(i), row.get(i));
+            }
+            resultBuilder.add(rowBuilder.build());
+        }
+
+        List<Map<String, JsonNode>> results = resultBuilder.build();
+        log.debug("Number of results: %s", results.size());
+        return results;
     }
 }

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpUberPinotSplitProvider.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpUberPinotSplitProvider.java
@@ -337,13 +337,6 @@ public class ClpUberPinotSplitProvider
         return results;
     }
 
-    /**
-     * Returns the timestamp column reference used for LASTWITHTIME deduplication.
-     * Uber uses "_timestampMillis" (with double quotes for identifier quoting)
-     * instead of the default "lastmodifiedtime".
-     *
-     * @return the timestamp column reference for Uber's Pinot infrastructure
-     */
     @Override
     protected String getDeduplicationColumn()
     {

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpUberPinotSplitProvider.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpUberPinotSplitProvider.java
@@ -57,10 +57,18 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  * customizes the SQL query endpoint URL to use Neutrino's global statements API instead of
  * the standard Pinot query endpoint.
  * </p>
+ * <p>
+ * This implementation also handles Pinot's append-only data model where UPDATE operations
+ * don't modify existing rows but instead append new rows with updated values. To retrieve
+ * only the latest version of each record, this class uses the {@code LASTWITHTIME} aggregation
+ * function with {@code GROUP BY tpath} to deduplicate rows by their unique identifier.
+ * </p>
  */
 public class ClpUberPinotSplitProvider
         extends ClpPinotSplitProvider
 {
+    private static final String SQL_SELECT_SPLITS_TEMPLATE_WITH_DEDUP =
+            "SELECT tpath, %s FROM %s WHERE 1 = 1 AND (%s) GROUP BY tpath LIMIT 999999";
     /**
      * Constructs an Uber CLP Pinot split provider with the given configuration.
      *
@@ -333,5 +341,48 @@ public class ClpUberPinotSplitProvider
         List<Map<String, JsonNode>> results = resultBuilder.build();
         log.debug("Number of results: %s", results.size());
         return results;
+    }
+
+    /**
+     * Builds a SQL query for split selection with deduplication using LASTWITHTIME.
+     * <p>
+     * Pinot uses an append-only data model where UPDATE operations don't modify existing
+     * rows but instead append new rows with updated values. This method constructs queries
+     * that use {@code LASTWITHTIME} aggregation with {@code GROUP BY tpath} to retrieve
+     * only the latest version of each record.
+     * </p>
+     *
+     * @param tableName the Pinot table name
+     * @param metadataProject the list of metadata columns to project
+     * @param filterSql the filter SQL expression
+     * @return the complete SQL query with deduplication for selecting splits
+     */
+    @Override
+    @VisibleForTesting
+    protected String buildSplitSelectionQuery(String tableName, List<String> metadataProject, String filterSql)
+    {
+        // Build LASTWITHTIME expressions for each metadata column
+        List<String> lastWithTimeProjections = new ArrayList<>();
+        for (String column : metadataProject) {
+            lastWithTimeProjections.add(
+                    format("LASTWITHTIME(%s, \"_timestampMillis\", 'long') AS %s", column, column));
+        }
+
+        String projectionClause = lastWithTimeProjections.isEmpty()
+                ? ""
+                : String.join(", ", lastWithTimeProjections);
+
+        return format(SQL_SELECT_SPLITS_TEMPLATE_WITH_DEDUP, projectionClause, tableName, filterSql);
+    }
+
+    /**
+     * TopN optimization is not currently supported for Uber Pinot queries.
+     *
+     * @throws UnsupportedOperationException always
+     */
+    @Override
+    protected String buildSplitSelectionQueryWithTopN(String tableName, String filterSql)
+    {
+        throw new UnsupportedOperationException("TopN optimization is not supported for Uber Pinot queries");
     }
 }

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpUberPinotSplitProvider.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpUberPinotSplitProvider.java
@@ -322,7 +322,10 @@ public class ClpUberPinotSplitProvider
             JsonNode row = it.next();
             ImmutableMap.Builder<String, JsonNode> rowBuilder = ImmutableMap.builder();
             for (int i = 0; i < columnNames.size(); i++) {
-                rowBuilder.put(columnNames.get(i), row.get(i));
+                JsonNode val = row.get(i);
+                if (val != null) {
+                    rowBuilder.put(columnNames.get(i), val);
+                }
             }
             resultBuilder.add(rowBuilder.build());
         }

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/mockdb/ClpMockPinotDatabase.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/mockdb/ClpMockPinotDatabase.java
@@ -212,7 +212,7 @@ public class ClpMockPinotDatabase
     }
 
     /**
-     * Executes the H2 query and formats the result as Uber Neutrino JSON response.
+     * Executes the H2 query and formats the result as Neutrino JSON response.
      */
     private String executeQueryAndFormat(String query) throws SQLException, IOException
     {

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/mockdb/ClpMockPinotDatabase.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/mockdb/ClpMockPinotDatabase.java
@@ -1,0 +1,295 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.clp.mockdb;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.lang.String.format;
+import static org.testng.Assert.fail;
+
+/**
+ * Mock Pinot database for testing LASTWITHTIME deduplication queries.
+ * Uses H2 as the backing store and an HTTP server to simulate the Pinot/Neutrino API.
+ * Translates LASTWITHTIME queries into equivalent H2 SQL for deduplication.
+ */
+public class ClpMockPinotDatabase
+{
+    // DB_CLOSE_DELAY=-1 keeps the in-memory database alive as long as the JVM is running
+    private static final String H2_URL_TEMPLATE = "jdbc:h2:mem:%s;MODE=MySQL;DATABASE_TO_UPPER=FALSE;DB_CLOSE_DELAY=-1";
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private final String h2Url;
+    private final HttpServer httpServer;
+    private final int port;
+    private final String tableName;
+
+    private ClpMockPinotDatabase(String h2Url, HttpServer httpServer, int port, String tableName)
+    {
+        this.h2Url = h2Url;
+        this.httpServer = httpServer;
+        this.port = port;
+        this.tableName = tableName;
+    }
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    public void start()
+    {
+        httpServer.start();
+    }
+
+    public void stop()
+    {
+        httpServer.stop(0);
+    }
+
+    public int getPort()
+    {
+        return port;
+    }
+
+    public String getUrl()
+    {
+        return "http://localhost:" + port;
+    }
+
+    /**
+     * Inserts a row into the mock Pinot table.
+     * Multiple rows with the same tpath but different _timestampMillis simulate Pinot's append-only model.
+     */
+    public void insertRow(String tpath, String hostname, long creationtime, long numMessages, long timestampMillis)
+    {
+        String sql = format(
+                "INSERT INTO %s (tpath, hostname, creationtime, num_messages, _timestampMillis) VALUES (?, ?, ?, ?, ?)",
+                tableName);
+        try (Connection conn = DriverManager.getConnection(h2Url);
+                PreparedStatement pstmt = conn.prepareStatement(sql)) {
+            pstmt.setString(1, tpath);
+            pstmt.setString(2, hostname);
+            pstmt.setLong(3, creationtime);
+            pstmt.setLong(4, numMessages);
+            pstmt.setLong(5, timestampMillis);
+            pstmt.executeUpdate();
+        }
+        catch (SQLException e) {
+            fail("Failed to insert row: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Handles incoming HTTP requests, translating LASTWITHTIME queries to H2 SQL.
+     */
+    private void handleRequest(HttpExchange exchange) throws IOException
+    {
+        StringBuilder body = new StringBuilder();
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(exchange.getRequestBody(), StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                body.append(line);
+            }
+        }
+
+        String query = body.toString();
+        String h2Query = translateToH2Query(query);
+
+        try {
+            String jsonResponse = executeQueryAndFormat(h2Query);
+            byte[] responseBytes = jsonResponse.getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, responseBytes.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(responseBytes);
+            }
+        }
+        catch (SQLException e) {
+            String error = "{\"error\": \"" + e.getMessage() + "\"}";
+            byte[] responseBytes = error.getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(500, responseBytes.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(responseBytes);
+            }
+        }
+    }
+
+    /**
+     * Translates a Pinot query with LASTWITHTIME to an equivalent H2 query.
+     * LASTWITHTIME(col, "_timestampMillis", 'long') is translated to a subquery that gets the latest value.
+     */
+    private String translateToH2Query(String pinotQuery)
+    {
+        // For H2, we simulate LASTWITHTIME by using a subquery to get the row with max _timestampMillis per tpath
+        // Original: SELECT tpath, LASTWITHTIME(hostname, "_timestampMillis", 'long') AS hostname FROM table GROUP BY tpath
+        // H2 equivalent: SELECT t.tpath, t.hostname FROM table t
+        //                INNER JOIN (SELECT tpath, MAX(_timestampMillis) as max_ts FROM table GROUP BY tpath) m
+        //                ON t.tpath = m.tpath AND t._timestampMillis = m.max_ts
+
+        // Extract columns from LASTWITHTIME expressions
+        Pattern lastWithTimePattern = Pattern.compile(
+                "LASTWITHTIME\\s*\\(\\s*(\\w+)\\s*,\\s*\"_timestampMillis\"\\s*,\\s*'long'\\s*\\)\\s+AS\\s+(\\w+)",
+                Pattern.CASE_INSENSITIVE);
+
+        // Check if query has LASTWITHTIME
+        if (!pinotQuery.toUpperCase().contains("LASTWITHTIME")) {
+            return pinotQuery;
+        }
+
+        // Extract table name from query
+        Pattern fromPattern = Pattern.compile("FROM\\s+([\\w.]+)", Pattern.CASE_INSENSITIVE);
+        Matcher fromMatcher = fromPattern.matcher(pinotQuery);
+        String queryTableName = tableName;
+        if (fromMatcher.find()) {
+            queryTableName = fromMatcher.group(1);
+        }
+
+        // Extract WHERE clause
+        Pattern wherePattern = Pattern.compile("WHERE\\s+(.+?)\\s+GROUP BY", Pattern.CASE_INSENSITIVE);
+        Matcher whereMatcher = wherePattern.matcher(pinotQuery);
+        String whereClause = "1 = 1";
+        if (whereMatcher.find()) {
+            whereClause = whereMatcher.group(1);
+        }
+
+        // Extract columns
+        List<String> columns = new ArrayList<>();
+        columns.add("tpath");
+        Matcher colMatcher = lastWithTimePattern.matcher(pinotQuery);
+        while (colMatcher.find()) {
+            columns.add(colMatcher.group(1));
+        }
+
+        // Build H2 query using subquery for deduplication
+        StringBuilder h2Query = new StringBuilder();
+        h2Query.append("SELECT ");
+        for (int i = 0; i < columns.size(); i++) {
+            if (i > 0) {
+                h2Query.append(", ");
+            }
+            h2Query.append("t.").append(columns.get(i));
+        }
+        h2Query.append(" FROM ").append(tableName).append(" t ");
+        h2Query.append("INNER JOIN (SELECT tpath, MAX(_timestampMillis) as max_ts FROM ");
+        h2Query.append(tableName).append(" WHERE ").append(whereClause);
+        h2Query.append(" GROUP BY tpath) m ");
+        h2Query.append("ON t.tpath = m.tpath AND t._timestampMillis = m.max_ts");
+
+        return h2Query.toString();
+    }
+
+    /**
+     * Executes the H2 query and formats the result as Uber Neutrino JSON response.
+     */
+    private String executeQueryAndFormat(String query) throws SQLException, IOException
+    {
+        try (Connection conn = DriverManager.getConnection(h2Url);
+                Statement stmt = conn.createStatement();
+                ResultSet rs = stmt.executeQuery(query)) {
+            ObjectNode root = OBJECT_MAPPER.createObjectNode();
+            ArrayNode columns = OBJECT_MAPPER.createArrayNode();
+            ArrayNode data = OBJECT_MAPPER.createArrayNode();
+
+            int columnCount = rs.getMetaData().getColumnCount();
+            for (int i = 1; i <= columnCount; i++) {
+                ObjectNode col = OBJECT_MAPPER.createObjectNode();
+                col.put("name", rs.getMetaData().getColumnName(i));
+                col.put("type", rs.getMetaData().getColumnTypeName(i));
+                columns.add(col);
+            }
+
+            while (rs.next()) {
+                ArrayNode row = OBJECT_MAPPER.createArrayNode();
+                for (int i = 1; i <= columnCount; i++) {
+                    Object value = rs.getObject(i);
+                    if (value == null) {
+                        row.addNull();
+                    }
+                    else if (value instanceof Number) {
+                        row.add(((Number) value).longValue());
+                    }
+                    else {
+                        row.add(value.toString());
+                    }
+                }
+                data.add(row);
+            }
+
+            root.set("columns", columns);
+            root.set("data", data);
+            return OBJECT_MAPPER.writeValueAsString(root);
+        }
+    }
+
+    public static final class Builder
+    {
+        private String tableName = "test_table";
+
+        public Builder setTableName(String tableName)
+        {
+            this.tableName = tableName;
+            return this;
+        }
+
+        public ClpMockPinotDatabase build() throws IOException, SQLException
+        {
+            String dbName = UUID.randomUUID().toString();
+            String h2Url = format(H2_URL_TEMPLATE, dbName);
+
+            // Create the table
+            try (Connection conn = DriverManager.getConnection(h2Url);
+                    Statement stmt = conn.createStatement()) {
+                stmt.execute(format(
+                        "CREATE TABLE %s (" +
+                                "tpath VARCHAR(512) NOT NULL, " +
+                                "hostname VARCHAR(256), " +
+                                "creationtime BIGINT, " +
+                                "num_messages BIGINT, " +
+                                "_timestampMillis BIGINT NOT NULL)",
+                        tableName));
+            }
+
+            // Create HTTP server
+            HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+            int port = server.getAddress().getPort();
+
+            ClpMockPinotDatabase db = new ClpMockPinotDatabase(h2Url, server, port, tableName);
+            server.createContext("/v1/globalStatement", db::handleRequest);
+
+            return db;
+        }
+    }
+}

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/split/TestClpPinotSplitProvider.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/split/TestClpPinotSplitProvider.java
@@ -203,4 +203,24 @@ public class TestClpPinotSplitProvider
         assertTrue(query.contains("test_table"));
         assertTrue(query.contains("creationtime > 1000"));
     }
+
+    /**
+     * Test that buildSplitSelectionQueryWithTopN correctly wraps TopN columns with LASTWITHTIME.
+     * The TopN query should include creationtime, lastmodifiedtime, and num_messages columns
+     * aggregated using LASTWITHTIME for deduplication.
+     */
+    @Test
+    public void testBuildSplitSelectionQueryWithTopN()
+    {
+        String query = splitProvider.buildSplitSelectionQueryWithTopN(
+                "test_table", "creationtime > 1000");
+
+        assertTrue(query.contains("tpath"));
+        assertTrue(query.contains("LASTWITHTIME(creationtime, 'lastmodifiedtime', 'long') AS creationtime"));
+        assertTrue(query.contains("LASTWITHTIME(lastmodifiedtime, 'lastmodifiedtime', 'long') AS lastmodifiedtime"));
+        assertTrue(query.contains("LASTWITHTIME(num_messages, 'lastmodifiedtime', 'long') AS num_messages"));
+        assertTrue(query.contains("GROUP BY tpath"));
+        assertTrue(query.contains("test_table"));
+        assertTrue(query.contains("creationtime > 1000"));
+    }
 }

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/split/TestClpPinotSplitProvider.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/split/TestClpPinotSplitProvider.java
@@ -197,8 +197,8 @@ public class TestClpPinotSplitProvider
                 "test_table", metadataColumns, "creationtime > 1000");
 
         assertTrue(query.contains("tpath"));
-        assertTrue(query.contains("LASTWITHTIME(hostname, 'lastmodifiedtime', 'long') AS hostname"));
-        assertTrue(query.contains("LASTWITHTIME(creationtime, 'lastmodifiedtime', 'long') AS creationtime"));
+        assertTrue(query.contains("LASTWITHTIME(hostname, lastmodifiedtime, 'long') AS hostname"));
+        assertTrue(query.contains("LASTWITHTIME(creationtime, lastmodifiedtime, 'long') AS creationtime"));
         assertTrue(query.contains("GROUP BY tpath"));
         assertTrue(query.contains("test_table"));
         assertTrue(query.contains("creationtime > 1000"));
@@ -216,9 +216,9 @@ public class TestClpPinotSplitProvider
                 "test_table", "creationtime > 1000");
 
         assertTrue(query.contains("tpath"));
-        assertTrue(query.contains("LASTWITHTIME(creationtime, 'lastmodifiedtime', 'long') AS creationtime"));
-        assertTrue(query.contains("LASTWITHTIME(lastmodifiedtime, 'lastmodifiedtime', 'long') AS lastmodifiedtime"));
-        assertTrue(query.contains("LASTWITHTIME(num_messages, 'lastmodifiedtime', 'long') AS num_messages"));
+        assertTrue(query.contains("LASTWITHTIME(creationtime, lastmodifiedtime, 'long') AS creationtime"));
+        assertTrue(query.contains("LASTWITHTIME(lastmodifiedtime, lastmodifiedtime, 'long') AS lastmodifiedtime"));
+        assertTrue(query.contains("LASTWITHTIME(num_messages, lastmodifiedtime, 'long') AS num_messages"));
         assertTrue(query.contains("GROUP BY tpath"));
         assertTrue(query.contains("test_table"));
         assertTrue(query.contains("creationtime > 1000"));

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/split/TestClpPinotSplitProvider.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/split/TestClpPinotSplitProvider.java
@@ -31,6 +31,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -39,6 +40,7 @@ import java.util.Map;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 public class TestClpPinotSplitProvider
 {
@@ -178,5 +180,27 @@ public class TestClpPinotSplitProvider
             }
             throw e;
         }
+    }
+
+    /**
+     * Test that buildSplitSelectionQuery correctly wraps metadata columns with LASTWITHTIME.
+     * Each metadata column should be aggregated using LASTWITHTIME to get the latest value.
+     */
+    @Test
+    public void testBuildSplitSelectionQueryWithMetadataColumns()
+    {
+        List<String> metadataColumns = new ArrayList<>();
+        metadataColumns.add("hostname");
+        metadataColumns.add("creationtime");
+
+        String query = splitProvider.buildSplitSelectionQuery(
+                "test_table", metadataColumns, "creationtime > 1000");
+
+        assertTrue(query.contains("tpath"));
+        assertTrue(query.contains("LASTWITHTIME(hostname, 'lastmodifiedtime', 'long') AS hostname"));
+        assertTrue(query.contains("LASTWITHTIME(creationtime, 'lastmodifiedtime', 'long') AS creationtime"));
+        assertTrue(query.contains("GROUP BY tpath"));
+        assertTrue(query.contains("test_table"));
+        assertTrue(query.contains("creationtime > 1000"));
     }
 }

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/split/TestClpUberPinotSplitProvider.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/split/TestClpUberPinotSplitProvider.java
@@ -17,6 +17,8 @@ import com.facebook.presto.plugin.clp.ClpConfig;
 import com.facebook.presto.plugin.clp.ClpTableHandle;
 import com.facebook.presto.plugin.clp.TestClpQueryBase;
 import com.facebook.presto.spi.SchemaTableName;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -24,8 +26,10 @@ import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
-import static org.testng.Assert.assertEquals;
+import static com.facebook.presto.testing.assertions.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
@@ -68,10 +72,10 @@ public class TestClpUberPinotSplitProvider
         URL result = (URL) method.invoke(splitProvider, config);
 
         assertNotNull(result);
-        assertEquals(result.toString(), "https://neutrino.uber.com/v1/globalStatements");
+        assertEquals(result.toString(), "https://neutrino.uber.com/v1/globalStatement");
         assertEquals(result.getProtocol(), "https");
         assertEquals(result.getHost(), "neutrino.uber.com");
-        assertEquals(result.getPath(), "/v1/globalStatements");
+        assertEquals(result.getPath(), "/v1/globalStatement");
     }
 
     /**
@@ -86,17 +90,17 @@ public class TestClpUberPinotSplitProvider
         // Test with trailing slash
         config.setMetadataDbUrl("https://neutrino.uber.com/");
         URL result = (URL) method.invoke(splitProvider, config);
-        assertEquals(result.toString(), "https://neutrino.uber.com//v1/globalStatements");
+        assertEquals(result.toString(), "https://neutrino.uber.com//v1/globalStatement");
 
         // Test without protocol (should work as URL constructor handles it)
         config.setMetadataDbUrl("http://neutrino-dev.uber.com");
         result = (URL) method.invoke(splitProvider, config);
-        assertEquals(result.toString(), "http://neutrino-dev.uber.com/v1/globalStatements");
+        assertEquals(result.toString(), "http://neutrino-dev.uber.com/v1/globalStatement");
 
         // Test with port
         config.setMetadataDbUrl("https://neutrino.uber.com:8080");
         result = (URL) method.invoke(splitProvider, config);
-        assertEquals(result.toString(), "https://neutrino.uber.com:8080/v1/globalStatements");
+        assertEquals(result.toString(), "https://neutrino.uber.com:8080/v1/globalStatement");
     }
 
     /**
@@ -257,5 +261,79 @@ public class TestClpUberPinotSplitProvider
                 standardFunctionResolution,
                 new ClpSplitMetadataConfig(newConfig, functionAndTypeManager));
         assertNotNull(newProvider);
+    }
+
+    /**
+     * Test parsing of Uber Neutrino query response format.
+     * Verifies that the JSON response with "columns" and "data" fields is correctly
+     * parsed into a list of row maps.
+     */
+    @Test
+    public void testParseQueryResponse() throws Exception
+    {
+        // Sample JSON in Uber Neutrino response format
+        String jsonResponse = String.join("\n",
+                "{",
+                "  'id': '20251211_200011_71046_z3qq5',",
+                "  'infoUri': '//localhost:5436/ui/query.html?20251211_200011_71046_z3qq5',",
+                "  'columns': [",
+                "    {",
+                "      'name': 'tpath',",
+                "      'type': 'varchar',",
+                "      'typeSignature': {",
+                "        'rawType': 'varchar',",
+                "        'typeArguments': [],",
+                "        'literalArguments': [],",
+                "        'arguments': [{'kind': 'LONG_LITERAL', 'value': 2147483647}]",
+                "      }",
+                "    },",
+                "    {",
+                "      'name': '_timestampMillis',",
+                "      'type': 'bigint',",
+                "      'typeSignature': {",
+                "        'rawType': 'bigint',",
+                "        'typeArguments': [],",
+                "        'literalArguments': [],",
+                "        'arguments': []",
+                "      }",
+                "    }",
+                "  ],",
+                "  'data': [",
+                "    ['/prod/logging/athena/table_a/dca/archive1.clp.zst', 1765483211084],",
+                "    ['/prod/logging/athena/table_b/dca/archive2.clp.zst', 1765483211043],",
+                "    ['/prod/logging/athena/table_c/dca/archive3.clp.zst', 1765483211043]",
+                "  ]",
+                "}").replace('\'', '"');
+
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode root = mapper.readTree(jsonResponse);
+
+        List<Map<String, JsonNode>> results = splitProvider.parseQueryResponse(root);
+
+        // Verify correct number of rows
+        assertEquals(results.size(), 3);
+
+        // Verify first row
+        Map<String, JsonNode> row0 = results.get(0);
+        assertEquals(row0.size(), 2);
+        assertEquals(row0.get("tpath").asText(), "/prod/logging/athena/table_a/dca/archive1.clp.zst");
+        assertEquals(row0.get("_timestampMillis").asLong(), 1765483211084L);
+
+        // Verify second row
+        Map<String, JsonNode> row1 = results.get(1);
+        assertEquals(row1.get("tpath").asText(), "/prod/logging/athena/table_b/dca/archive2.clp.zst");
+        assertEquals(row1.get("_timestampMillis").asLong(), 1765483211043L);
+
+        // Verify third row
+        Map<String, JsonNode> row2 = results.get(2);
+        assertEquals(row2.get("tpath").asText(), "/prod/logging/athena/table_c/dca/archive3.clp.zst");
+        assertEquals(row2.get("_timestampMillis").asLong(), 1765483211043L);
+
+        // Verify that non-existent columns return null
+        for (Map<String, JsonNode> row : results) {
+            assertEquals(row.get("nonExistentColumn"), null);
+            assertEquals(row.get("id"), null);
+            assertEquals(row.get("infoUri"), null);
+        }
     }
 }

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/split/TestClpUberPinotSplitProvider.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/split/TestClpUberPinotSplitProvider.java
@@ -250,7 +250,6 @@ public class TestClpUberPinotSplitProvider
         splitProvider.buildSplitSelectionQueryWithTopN("rta.logging.events", "timestamp > 1000");
     }
 
-
     /**
      * Test configuration with different split provider types.
      */

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/split/TestClpUberPinotSplitProvider.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/split/TestClpUberPinotSplitProvider.java
@@ -310,21 +310,21 @@ public class TestClpUberPinotSplitProvider
 
         List<Map<String, JsonNode>> results = splitProvider.parseQueryResponse(root);
 
-        // Verify correct number of rows
+        // Verify the correct number of rows
         assertEquals(results.size(), 3);
 
-        // Verify first row
+        // Verify the first row
         Map<String, JsonNode> row0 = results.get(0);
         assertEquals(row0.size(), 2);
         assertEquals(row0.get("tpath").asText(), "/prod/logging/athena/table_a/dca/archive1.clp.zst");
         assertEquals(row0.get("_timestampMillis").asLong(), 1765483211084L);
 
-        // Verify second row
+        // Verify the second row
         Map<String, JsonNode> row1 = results.get(1);
         assertEquals(row1.get("tpath").asText(), "/prod/logging/athena/table_b/dca/archive2.clp.zst");
         assertEquals(row1.get("_timestampMillis").asLong(), 1765483211043L);
 
-        // Verify third row
+        // Verify the third row
         Map<String, JsonNode> row2 = results.get(2);
         assertEquals(row2.get("tpath").asText(), "/prod/logging/athena/table_c/dca/archive3.clp.zst");
         assertEquals(row2.get("_timestampMillis").asLong(), 1765483211043L);

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/split/TestClpUberPinotSplitProvider.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/split/TestClpUberPinotSplitProvider.java
@@ -219,24 +219,6 @@ public class TestClpUberPinotSplitProvider
     }
 
     /**
-     * Test that buildSplitSelectionQuery generates deduplication queries using LASTWITHTIME.
-     * Pinot's append-only model requires GROUP BY tpath with LASTWITHTIME aggregation
-     * to retrieve only the latest version of each record.
-     */
-    @Test
-    public void testBuildSplitSelectionQueryWithDeduplication()
-    {
-        String query = splitProvider.buildSplitSelectionQuery(
-                "rta.logging.logs", new ArrayList<>(), "status = 200");
-
-        assertTrue(query.contains("SELECT tpath"));
-        assertTrue(query.contains("rta.logging.logs"));
-        assertTrue(query.contains("status = 200"));
-        assertTrue(query.contains("GROUP BY tpath"));
-        assertTrue(query.contains("LIMIT 999999"));
-    }
-
-    /**
      * Test that buildSplitSelectionQuery correctly wraps metadata columns with LASTWITHTIME.
      * Each metadata column should be aggregated using LASTWITHTIME to get the latest value.
      */
@@ -268,49 +250,6 @@ public class TestClpUberPinotSplitProvider
         splitProvider.buildSplitSelectionQueryWithTopN("rta.logging.events", "timestamp > 1000");
     }
 
-    /**
-     * Test parsing of deduplicated query response from Pinot.
-     * Simulates a response where LASTWITHTIME has already deduplicated the rows,
-     * returning only the latest version of each tpath.
-     */
-    @Test
-    public void testParseDeduplicatedQueryResponse() throws Exception
-    {
-        // Simulates Pinot response after LASTWITHTIME deduplication:
-        // - archive1 has latest hostname="host-v2" (from timestamp 2000)
-        // - archive2 has latest hostname="host-b" (from timestamp 1500)
-        // Note: In real Pinot, duplicate rows would be aggregated by GROUP BY tpath
-        String jsonResponse = String.join("\n",
-                "{",
-                "  'columns': [",
-                "    {'name': 'tpath', 'type': 'varchar'},",
-                "    {'name': 'hostname', 'type': 'varchar'},",
-                "    {'name': 'creationtime', 'type': 'bigint'}",
-                "  ],",
-                "  'data': [",
-                "    ['/path/to/archive1.clp.zst', 'host-v2', 2000],",
-                "    ['/path/to/archive2.clp.zst', 'host-b', 1500]",
-                "  ]",
-                "}").replace('\'', '"');
-
-        ObjectMapper mapper = new ObjectMapper();
-        JsonNode root = mapper.readTree(jsonResponse);
-
-        List<Map<String, JsonNode>> results = splitProvider.parseQueryResponse(root);
-
-        // Verify deduplicated results: each tpath appears exactly once with latest values
-        assertEquals(results.size(), 2);
-
-        Map<String, JsonNode> row0 = results.get(0);
-        assertEquals(row0.get("tpath").asText(), "/path/to/archive1.clp.zst");
-        assertEquals(row0.get("hostname").asText(), "host-v2");
-        assertEquals(row0.get("creationtime").asLong(), 2000L);
-
-        Map<String, JsonNode> row1 = results.get(1);
-        assertEquals(row1.get("tpath").asText(), "/path/to/archive2.clp.zst");
-        assertEquals(row1.get("hostname").asText(), "host-b");
-        assertEquals(row1.get("creationtime").asLong(), 1500L);
-    }
 
     /**
      * Test configuration with different split provider types.
@@ -481,92 +420,6 @@ public class TestClpUberPinotSplitProvider
 
             // archive2 should have its only hostname value
             assertEquals(archive2Row.get("hostname").asText(), "host-b");
-        }
-        finally {
-            mockDb.stop();
-        }
-    }
-
-    /**
-     * Test deduplication with multiple metadata columns against mock database.
-     * Verifies that all columns are correctly deduplicated to their latest values.
-     */
-    @Test
-    public void testDeduplicationQueryWithMultipleColumnsAndMockDatabase() throws Exception
-    {
-        ClpMockPinotDatabase mockDb = ClpMockPinotDatabase.builder()
-                .setTableName("test_table")
-                .build();
-
-        // Insert multiple versions for archive1
-        mockDb.insertRow("/path/to/archive1.clp.zst", "host-v1", 1000, 100, 1000);
-        mockDb.insertRow("/path/to/archive1.clp.zst", "host-v2", 1100, 110, 1500);
-        mockDb.insertRow("/path/to/archive1.clp.zst", "host-v3", 1200, 120, 2000);  // Latest
-
-        // Insert multiple versions for archive2
-        mockDb.insertRow("/path/to/archive2.clp.zst", "host-a", 2000, 200, 1000);
-        mockDb.insertRow("/path/to/archive2.clp.zst", "host-b", 2500, 250, 3000);  // Latest
-
-        // Insert single version for archive3
-        mockDb.insertRow("/path/to/archive3.clp.zst", "host-c", 3000, 300, 2500);
-
-        mockDb.start();
-
-        try {
-            ClpConfig mockConfig = new ClpConfig();
-            mockConfig.setMetadataDbUrl(mockDb.getUrl());
-            mockConfig.setSplitProviderType(ClpConfig.SplitProviderType.PINOT_UBER);
-
-            ClpUberPinotSplitProvider mockSplitProvider = new ClpUberPinotSplitProvider(
-                    mockConfig,
-                    functionAndTypeManager,
-                    standardFunctionResolution,
-                    new ClpSplitMetadataConfig(mockConfig, functionAndTypeManager));
-
-            List<String> metadataColumns = new ArrayList<>();
-            metadataColumns.add("hostname");
-            metadataColumns.add("creationtime");
-            metadataColumns.add("num_messages");
-
-            String query = mockSplitProvider.buildSplitSelectionQuery(
-                    "test_table",
-                    metadataColumns,
-                    "1 = 1");
-
-            // Verify all columns are wrapped with LASTWITHTIME
-            assertTrue(query.contains("LASTWITHTIME(hostname, \"_timestampMillis\", 'long') AS hostname"));
-            assertTrue(query.contains("LASTWITHTIME(creationtime, \"_timestampMillis\", 'long') AS creationtime"));
-            assertTrue(query.contains("LASTWITHTIME(num_messages, \"_timestampMillis\", 'long') AS num_messages"));
-            assertTrue(query.contains("GROUP BY tpath"));
-
-            // Execute query against mock database
-            List<Map<String, JsonNode>> results = mockSplitProvider.getQueryResult(query);
-
-            // Should get 3 rows (one per unique tpath), not 6
-            assertEquals(results.size(), 3);
-
-            // Verify each archive has the LATEST values
-            for (Map<String, JsonNode> row : results) {
-                String tpath = row.get("tpath").asText();
-                if (tpath.contains("archive1")) {
-                    // archive1 latest: host-v3, creationtime=1200, num_messages=120
-                    assertEquals(row.get("hostname").asText(), "host-v3");
-                    assertEquals(row.get("creationtime").asLong(), 1200L);
-                    assertEquals(row.get("num_messages").asLong(), 120L);
-                }
-                else if (tpath.contains("archive2")) {
-                    // archive2 latest: host-b, creationtime=2500, num_messages=250
-                    assertEquals(row.get("hostname").asText(), "host-b");
-                    assertEquals(row.get("creationtime").asLong(), 2500L);
-                    assertEquals(row.get("num_messages").asLong(), 250L);
-                }
-                else if (tpath.contains("archive3")) {
-                    // archive3 only version: host-c, creationtime=3000, num_messages=300
-                    assertEquals(row.get("hostname").asText(), "host-c");
-                    assertEquals(row.get("creationtime").asLong(), 3000L);
-                    assertEquals(row.get("num_messages").asLong(), 300L);
-                }
-            }
         }
         finally {
             mockDb.stop();

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/split/TestClpUberPinotSplitProvider.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/split/TestClpUberPinotSplitProvider.java
@@ -16,6 +16,7 @@ package com.facebook.presto.plugin.clp.split;
 import com.facebook.presto.plugin.clp.ClpConfig;
 import com.facebook.presto.plugin.clp.ClpTableHandle;
 import com.facebook.presto.plugin.clp.TestClpQueryBase;
+import com.facebook.presto.plugin.clp.mockdb.ClpMockPinotDatabase;
 import com.facebook.presto.spi.SchemaTableName;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -218,27 +219,97 @@ public class TestClpUberPinotSplitProvider
     }
 
     /**
-     * Test SQL query building methods inherited from parent.
+     * Test that buildSplitSelectionQuery generates deduplication queries using LASTWITHTIME.
+     * Pinot's append-only model requires GROUP BY tpath with LASTWITHTIME aggregation
+     * to retrieve only the latest version of each record.
      */
     @Test
-    public void testInheritedSqlQueryMethods()
+    public void testBuildSplitSelectionQueryWithDeduplication()
     {
-        // Test buildSplitSelectionQuery (inherited from parent)
         String query = splitProvider.buildSplitSelectionQuery(
                 "rta.logging.logs", new ArrayList<>(), "status = 200");
+
+        assertTrue(query.contains("SELECT tpath"));
         assertTrue(query.contains("rta.logging.logs"));
         assertTrue(query.contains("status = 200"));
-        assertTrue(query.contains("SELECT"));
-        assertTrue(query.contains("tpath"));
+        assertTrue(query.contains("GROUP BY tpath"));
+        assertTrue(query.contains("LIMIT 999999"));
+    }
 
-        // Test buildSplitSelectionQueryWithTopN (inherited from parent)
-        String metaQuery = splitProvider.buildSplitSelectionQueryWithTopN("rta.logging.events", "timestamp > 1000");
-        assertTrue(metaQuery.contains("rta.logging.events"));
-        assertTrue(metaQuery.contains("timestamp > 1000"));
-        assertTrue(metaQuery.contains("tpath"));
-        assertTrue(metaQuery.contains("creationtime"));
-        assertTrue(metaQuery.contains("lastmodifiedtime"));
-        assertTrue(metaQuery.contains("num_messages"));
+    /**
+     * Test that buildSplitSelectionQuery correctly wraps metadata columns with LASTWITHTIME.
+     * Each metadata column should be aggregated using LASTWITHTIME to get the latest value.
+     */
+    @Test
+    public void testBuildSplitSelectionQueryWithMetadataColumns()
+    {
+        List<String> metadataColumns = new ArrayList<>();
+        metadataColumns.add("hostname");
+        metadataColumns.add("creationtime");
+
+        String query = splitProvider.buildSplitSelectionQuery(
+                "rta.logging.logs", metadataColumns, "creationtime > 1000");
+
+        assertTrue(query.contains("SELECT tpath"));
+        assertTrue(query.contains("LASTWITHTIME(hostname, \"_timestampMillis\", 'long') AS hostname"));
+        assertTrue(query.contains("LASTWITHTIME(creationtime, \"_timestampMillis\", 'long') AS creationtime"));
+        assertTrue(query.contains("GROUP BY tpath"));
+        assertTrue(query.contains("rta.logging.logs"));
+        assertTrue(query.contains("creationtime > 1000"));
+    }
+
+    /**
+     * Test that TopN queries throw UnsupportedOperationException.
+     * TopN optimization is currently disabled for Uber Pinot queries.
+     */
+    @Test(expectedExceptions = UnsupportedOperationException.class)
+    public void testBuildSplitSelectionQueryWithTopNThrowsException()
+    {
+        splitProvider.buildSplitSelectionQueryWithTopN("rta.logging.events", "timestamp > 1000");
+    }
+
+    /**
+     * Test parsing of deduplicated query response from Pinot.
+     * Simulates a response where LASTWITHTIME has already deduplicated the rows,
+     * returning only the latest version of each tpath.
+     */
+    @Test
+    public void testParseDeduplicatedQueryResponse() throws Exception
+    {
+        // Simulates Pinot response after LASTWITHTIME deduplication:
+        // - archive1 has latest hostname="host-v2" (from timestamp 2000)
+        // - archive2 has latest hostname="host-b" (from timestamp 1500)
+        // Note: In real Pinot, duplicate rows would be aggregated by GROUP BY tpath
+        String jsonResponse = String.join("\n",
+                "{",
+                "  'columns': [",
+                "    {'name': 'tpath', 'type': 'varchar'},",
+                "    {'name': 'hostname', 'type': 'varchar'},",
+                "    {'name': 'creationtime', 'type': 'bigint'}",
+                "  ],",
+                "  'data': [",
+                "    ['/path/to/archive1.clp.zst', 'host-v2', 2000],",
+                "    ['/path/to/archive2.clp.zst', 'host-b', 1500]",
+                "  ]",
+                "}").replace('\'', '"');
+
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode root = mapper.readTree(jsonResponse);
+
+        List<Map<String, JsonNode>> results = splitProvider.parseQueryResponse(root);
+
+        // Verify deduplicated results: each tpath appears exactly once with latest values
+        assertEquals(results.size(), 2);
+
+        Map<String, JsonNode> row0 = results.get(0);
+        assertEquals(row0.get("tpath").asText(), "/path/to/archive1.clp.zst");
+        assertEquals(row0.get("hostname").asText(), "host-v2");
+        assertEquals(row0.get("creationtime").asLong(), 2000L);
+
+        Map<String, JsonNode> row1 = results.get(1);
+        assertEquals(row1.get("tpath").asText(), "/path/to/archive2.clp.zst");
+        assertEquals(row1.get("hostname").asText(), "host-b");
+        assertEquals(row1.get("creationtime").asLong(), 1500L);
     }
 
     /**
@@ -334,6 +405,171 @@ public class TestClpUberPinotSplitProvider
             assertEquals(row.get("nonExistentColumn"), null);
             assertEquals(row.get("id"), null);
             assertEquals(row.get("uri"), null);
+        }
+    }
+
+    /**
+     * Test deduplication query against a mock Pinot database with duplicate rows.
+     * Inserts multiple versions of the same tpath with different timestamps,
+     * then verifies that the query returns only the latest version.
+     */
+    @Test
+    public void testDeduplicationQueryWithMockDatabase() throws Exception
+    {
+        ClpMockPinotDatabase mockDb = ClpMockPinotDatabase.builder()
+                .setTableName("test_table")
+                .build();
+
+        // Insert duplicate rows for archive1 (simulating Pinot's append-only model)
+        // archive1 v1: old data with timestamp 1000
+        mockDb.insertRow("/path/to/archive1.clp.zst", "host-old", 1000, 100, 1000);
+        // archive1 v2: updated data with timestamp 2000 (latest)
+        mockDb.insertRow("/path/to/archive1.clp.zst", "host-new", 1500, 150, 2000);
+
+        // Insert single row for archive2
+        mockDb.insertRow("/path/to/archive2.clp.zst", "host-b", 1200, 200, 1500);
+
+        mockDb.start();
+
+        try {
+            ClpConfig mockConfig = new ClpConfig();
+            mockConfig.setMetadataDbUrl(mockDb.getUrl());
+            mockConfig.setSplitProviderType(ClpConfig.SplitProviderType.PINOT_UBER);
+
+            ClpUberPinotSplitProvider mockSplitProvider = new ClpUberPinotSplitProvider(
+                    mockConfig,
+                    functionAndTypeManager,
+                    standardFunctionResolution,
+                    new ClpSplitMetadataConfig(mockConfig, functionAndTypeManager));
+
+            List<String> metadataColumns = new ArrayList<>();
+            metadataColumns.add("hostname");
+
+            String query = mockSplitProvider.buildSplitSelectionQuery(
+                    "test_table",
+                    metadataColumns,
+                    "1 = 1");
+
+            // Verify query format includes LASTWITHTIME and GROUP BY
+            assertTrue(query.contains("LASTWITHTIME(hostname"));
+            assertTrue(query.contains("GROUP BY tpath"));
+
+            // Execute the query against mock database
+            List<Map<String, JsonNode>> results = mockSplitProvider.getQueryResult(query);
+
+            // Should get 2 rows (deduplicated), not 3
+            assertEquals(results.size(), 2);
+
+            // Find archive1 row and verify it has the LATEST hostname value
+            Map<String, JsonNode> archive1Row = null;
+            Map<String, JsonNode> archive2Row = null;
+            for (Map<String, JsonNode> row : results) {
+                String tpath = row.get("tpath").asText();
+                if (tpath.contains("archive1")) {
+                    archive1Row = row;
+                }
+                else if (tpath.contains("archive2")) {
+                    archive2Row = row;
+                }
+            }
+
+            assertNotNull(archive1Row, "archive1 row should exist");
+            assertNotNull(archive2Row, "archive2 row should exist");
+
+            // archive1 should have hostname from the LATEST version (timestamp 2000)
+            assertEquals(archive1Row.get("hostname").asText(), "host-new");
+
+            // archive2 should have its only hostname value
+            assertEquals(archive2Row.get("hostname").asText(), "host-b");
+        }
+        finally {
+            mockDb.stop();
+        }
+    }
+
+    /**
+     * Test deduplication with multiple metadata columns against mock database.
+     * Verifies that all columns are correctly deduplicated to their latest values.
+     */
+    @Test
+    public void testDeduplicationQueryWithMultipleColumnsAndMockDatabase() throws Exception
+    {
+        ClpMockPinotDatabase mockDb = ClpMockPinotDatabase.builder()
+                .setTableName("test_table")
+                .build();
+
+        // Insert multiple versions for archive1
+        mockDb.insertRow("/path/to/archive1.clp.zst", "host-v1", 1000, 100, 1000);
+        mockDb.insertRow("/path/to/archive1.clp.zst", "host-v2", 1100, 110, 1500);
+        mockDb.insertRow("/path/to/archive1.clp.zst", "host-v3", 1200, 120, 2000);  // Latest
+
+        // Insert multiple versions for archive2
+        mockDb.insertRow("/path/to/archive2.clp.zst", "host-a", 2000, 200, 1000);
+        mockDb.insertRow("/path/to/archive2.clp.zst", "host-b", 2500, 250, 3000);  // Latest
+
+        // Insert single version for archive3
+        mockDb.insertRow("/path/to/archive3.clp.zst", "host-c", 3000, 300, 2500);
+
+        mockDb.start();
+
+        try {
+            ClpConfig mockConfig = new ClpConfig();
+            mockConfig.setMetadataDbUrl(mockDb.getUrl());
+            mockConfig.setSplitProviderType(ClpConfig.SplitProviderType.PINOT_UBER);
+
+            ClpUberPinotSplitProvider mockSplitProvider = new ClpUberPinotSplitProvider(
+                    mockConfig,
+                    functionAndTypeManager,
+                    standardFunctionResolution,
+                    new ClpSplitMetadataConfig(mockConfig, functionAndTypeManager));
+
+            List<String> metadataColumns = new ArrayList<>();
+            metadataColumns.add("hostname");
+            metadataColumns.add("creationtime");
+            metadataColumns.add("num_messages");
+
+            String query = mockSplitProvider.buildSplitSelectionQuery(
+                    "test_table",
+                    metadataColumns,
+                    "1 = 1");
+
+            // Verify all columns are wrapped with LASTWITHTIME
+            assertTrue(query.contains("LASTWITHTIME(hostname, \"_timestampMillis\", 'long') AS hostname"));
+            assertTrue(query.contains("LASTWITHTIME(creationtime, \"_timestampMillis\", 'long') AS creationtime"));
+            assertTrue(query.contains("LASTWITHTIME(num_messages, \"_timestampMillis\", 'long') AS num_messages"));
+            assertTrue(query.contains("GROUP BY tpath"));
+
+            // Execute query against mock database
+            List<Map<String, JsonNode>> results = mockSplitProvider.getQueryResult(query);
+
+            // Should get 3 rows (one per unique tpath), not 6
+            assertEquals(results.size(), 3);
+
+            // Verify each archive has the LATEST values
+            for (Map<String, JsonNode> row : results) {
+                String tpath = row.get("tpath").asText();
+                if (tpath.contains("archive1")) {
+                    // archive1 latest: host-v3, creationtime=1200, num_messages=120
+                    assertEquals(row.get("hostname").asText(), "host-v3");
+                    assertEquals(row.get("creationtime").asLong(), 1200L);
+                    assertEquals(row.get("num_messages").asLong(), 120L);
+                }
+                else if (tpath.contains("archive2")) {
+                    // archive2 latest: host-b, creationtime=2500, num_messages=250
+                    assertEquals(row.get("hostname").asText(), "host-b");
+                    assertEquals(row.get("creationtime").asLong(), 2500L);
+                    assertEquals(row.get("num_messages").asLong(), 250L);
+                }
+                else if (tpath.contains("archive3")) {
+                    // archive3 only version: host-c, creationtime=3000, num_messages=300
+                    assertEquals(row.get("hostname").asText(), "host-c");
+                    assertEquals(row.get("creationtime").asLong(), 3000L);
+                    assertEquals(row.get("num_messages").asLong(), 300L);
+                }
+            }
+        }
+        finally {
+            mockDb.stop();
         }
     }
 }

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/split/TestClpUberPinotSplitProvider.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/split/TestClpUberPinotSplitProvider.java
@@ -274,8 +274,8 @@ public class TestClpUberPinotSplitProvider
         // Sample JSON in Uber Neutrino response format
         String jsonResponse = String.join("\n",
                 "{",
-                "  'id': '20251211_200011_71046_z3qq5',",
-                "  'infoUri': '//localhost:5436/ui/query.html?20251211_200011_71046_z3qq5',",
+                "  'id': '12345',",
+                "  'uri': '//localhost:5436/query.html?12345',",
                 "  'columns': [",
                 "    {",
                 "      'name': 'tpath',",
@@ -299,9 +299,9 @@ public class TestClpUberPinotSplitProvider
                 "    }",
                 "  ],",
                 "  'data': [",
-                "    ['/prod/logging/athena/table_a/dca/archive1.clp.zst', 1765483211084],",
-                "    ['/prod/logging/athena/table_b/dca/archive2.clp.zst', 1765483211043],",
-                "    ['/prod/logging/athena/table_c/dca/archive3.clp.zst', 1765483211043]",
+                "    ['/path/to/table_a/archive1.clp.zst', 1765483211084],",
+                "    ['/path/to/table_b/archive2.clp.zst', 1765483211043],",
+                "    ['/path/to/table_c/archive3.clp.zst', 1765483211043]",
                 "  ]",
                 "}").replace('\'', '"');
 
@@ -316,24 +316,24 @@ public class TestClpUberPinotSplitProvider
         // Verify the first row
         Map<String, JsonNode> row0 = results.get(0);
         assertEquals(row0.size(), 2);
-        assertEquals(row0.get("tpath").asText(), "/prod/logging/athena/table_a/dca/archive1.clp.zst");
+        assertEquals(row0.get("tpath").asText(), "/path/to/table_a/archive1.clp.zst");
         assertEquals(row0.get("_timestampMillis").asLong(), 1765483211084L);
 
         // Verify the second row
         Map<String, JsonNode> row1 = results.get(1);
-        assertEquals(row1.get("tpath").asText(), "/prod/logging/athena/table_b/dca/archive2.clp.zst");
+        assertEquals(row1.get("tpath").asText(), "/path/to/table_b/archive2.clp.zst");
         assertEquals(row1.get("_timestampMillis").asLong(), 1765483211043L);
 
         // Verify the third row
         Map<String, JsonNode> row2 = results.get(2);
-        assertEquals(row2.get("tpath").asText(), "/prod/logging/athena/table_c/dca/archive3.clp.zst");
+        assertEquals(row2.get("tpath").asText(), "/path/to/table_c/archive3.clp.zst");
         assertEquals(row2.get("_timestampMillis").asLong(), 1765483211043L);
 
         // Verify that non-existent columns return null
         for (Map<String, JsonNode> row : results) {
             assertEquals(row.get("nonExistentColumn"), null);
             assertEquals(row.get("id"), null);
-            assertEquals(row.get("infoUri"), null);
+            assertEquals(row.get("uri"), null);
         }
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR fixes https://github.com/y-scope/presto/issues/105.

 Pinot uses an append-only data model where UPDATE operations append new rows rather than modifying existing ones. Both ClpPinotSplitProvider and ClpUberPinotSplitProvider need to deduplicate rows using LASTWITHTIME
  aggregation with GROUP BY tpath when querying the metadata database.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [ ] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [ ] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [ ] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

All unit tests.

E2E test:

Query with TopN:
```
SELECT CLP_GET_JSON_STRING() AS event FROM clp.DEFAULT.cockroachdb_ir 
WHERE
ts > CAST(
    to_unixtime(
        date_add('year', -15, current_timestamp)
    ) * 1000 AS BIGINT
) ORDER BY ts DESC limit 100
```

The resulting Pinot SQL query: 
`SELECT tpath, LASTWITHTIME(creationtime, lastmodifiedtime, 'long') AS creationtime, LASTWITHTIME(lastmodifiedtime, lastmodifiedtime, 'long') AS lastmodifiedtime, LASTWITHTIME(num_messages, lastmodifiedtime, 'long') AS num_messages FROM cockroachdb_ir WHERE 1 = 1 AND (lastmodifiedtime > '1292624133412') GROUP BY tpath LIMIT 999999`



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
