### PR TITLE
feat: Add Terrablob storage URL prefix support for customized Pinot split provider.

### DIFF
--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpConfig.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpConfig.java
@@ -36,6 +36,7 @@ public class ClpConfig
     private String splitMetadataConfigPath;
     private String metadataYamlPath;
     private SplitProviderType splitProviderType = SplitProviderType.MYSQL;
+    private String uberTerrablobStorageBaseUrl;
 
     public boolean isPolymorphicTypeEnabled()
     {
@@ -184,6 +185,18 @@ public class ClpConfig
     public ClpConfig setSplitProviderType(SplitProviderType splitProviderType)
     {
         this.splitProviderType = splitProviderType;
+        return this;
+    }
+
+    public String getUberTerrablobStorageBaseUrl()
+    {
+        return uberTerrablobStorageBaseUrl;
+    }
+
+    @Config("clp.uber-terrablob-storage-base-url")
+    public ClpConfig setUberTerrablobStorageBaseUrl(String uberTerrablobStorageBaseUrl)
+    {
+        this.uberTerrablobStorageBaseUrl = uberTerrablobStorageBaseUrl;
         return this;
     }
 

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpPinotSplitProvider.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpPinotSplitProvider.java
@@ -65,7 +65,7 @@ public class ClpPinotSplitProvider
 {
     private static final String SQL_SELECT_SPLITS_TEMPLATE = "SELECT %s FROM %s WHERE 1 = 1 AND (%s) LIMIT 999999";
     private static final String SQL_SELECT_SPLITS_TEMPLATE_WITH_TOPN = "SELECT tpath, creationtime, lastmodifiedtime, num_messages FROM %s WHERE 1 = 1 AND (%s) LIMIT 999999";
-    private final ClpConfig config;
+    protected final ClpConfig config;
 
     protected static final Logger log = Logger.get(ClpPinotSplitProvider.class);
     protected final URL pinotSqlQueryEndpointUrl;

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpUberPinotSplitProvider.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpUberPinotSplitProvider.java
@@ -155,7 +155,11 @@ public class ClpUberPinotSplitProvider
             List<Map<String, JsonNode>> splitRows = getQueryResult(splitQuery);
 
             for (Map<String, JsonNode> row : splitRows) {
-                String splitPath = buildFullSplitPath(row.get("tpath").asText());
+                JsonNode tpathNode = row.get("tpath");
+                if (tpathNode == null || tpathNode.isNull()) {
+                    throw new RuntimeException("Missing required 'tpath' field in split metadata row");
+                }
+                String splitPath = buildFullSplitPath(tpathNode.asText());
                 Map<String, Object> metadataColumns = extractMetadataColumns(row, metadataColumnNames, schemaTableName);
 
                 splits.add(new ClpSplit(

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpUberPinotSplitProvider.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpUberPinotSplitProvider.java
@@ -76,6 +76,36 @@ public class ClpUberPinotSplitProvider
         super(config, functionManager, functionResolution, metadataConfig);
     }
 
+    /**
+     * Constructs the full split path by prepending the Terrablob storage URL prefix to the relative file path.
+     *
+     * @param relativePath the relative file path from the metadata database
+     * @return the full split path with protocol, host, and port prefix
+     * @throws IllegalArgumentException if the base URL is null, empty, or malformed
+     */
+    private String buildFullSplitPath(String relativePath)
+    {
+        String baseUrl = config.getUberTerrablobStorageBaseUrl();
+        if (baseUrl == null || baseUrl.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Terrablob storage base URL (clp.uber-terrablob-storage-base-url) must be configured for Uber" +
+                            " Pinot split provider");
+        }
+
+        try {
+            URL url = new URL(baseUrl);
+            int port = url.getPort();
+            if (port == -1) {
+                return url.getProtocol() + "://" + url.getHost() + relativePath;
+            }
+            return url.getProtocol() + "://" + url.getHost() + ":" + port + relativePath;
+        }
+        catch (MalformedURLException e) {
+            throw new IllegalArgumentException(
+                    format("Invalid Terrablob storage base URL: %s", baseUrl), e);
+        }
+    }
+
     @Override
     public List<ClpSplit> listSplits(ClpTableLayoutHandle clpTableLayoutHandle)
     {
@@ -109,7 +139,7 @@ public class ClpUberPinotSplitProvider
                 List<ArchiveMeta> selected = selectTopNArchives(archiveMetaList, topNSpec.getLimit(), ordering.getOrder());
 
                 for (ArchiveMeta a : selected) {
-                    String splitPath = a.id;
+                    String splitPath = buildFullSplitPath(a.id);
                     splits.add(new ClpSplit(splitPath, determineSplitType(splitPath), clpTableLayoutHandle.getKqlQuery(), Optional.empty()));
                 }
                 List<ClpSplit> filteredSplits = splits.build();
@@ -125,7 +155,7 @@ public class ClpUberPinotSplitProvider
             List<Map<String, JsonNode>> splitRows = getQueryResult(splitQuery);
 
             for (Map<String, JsonNode> row : splitRows) {
-                String splitPath = row.get("tpath").asText();
+                String splitPath = buildFullSplitPath(row.get("tpath").asText());
                 Map<String, Object> metadataColumns = extractMetadataColumns(row, metadataColumnNames, schemaTableName);
 
                 splits.add(new ClpSplit(

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/split/TestClpUberPinotSplitProvider.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/split/TestClpUberPinotSplitProvider.java
@@ -264,6 +264,57 @@ public class TestClpUberPinotSplitProvider
     }
 
     /**
+     * Test that buildFullSplitPath correctly constructs the full path with URL prefix.
+     */
+    @Test
+    public void testBuildFullSplitPath() throws Exception
+    {
+        // Create a config with Terrablob storage base URL configured
+        ClpConfig testConfig = new ClpConfig();
+        testConfig.setMetadataDbUrl("https://neutrino.uber.com");
+        testConfig.setSplitProviderType(ClpConfig.SplitProviderType.PINOT_UBER);
+        testConfig.setUberTerrablobStorageBaseUrl("http://localhost:19617");
+
+        ClpUberPinotSplitProvider testProvider = new ClpUberPinotSplitProvider(
+                testConfig,
+                functionAndTypeManager,
+                standardFunctionResolution,
+                new ClpSplitMetadataConfig(testConfig, functionAndTypeManager));
+
+        Method method = ClpUberPinotSplitProvider.class.getDeclaredMethod("buildFullSplitPath", String.class);
+        method.setAccessible(true);
+
+        // Test with a typical relative path
+        String result = (String) method.invoke(testProvider, "/data/archives/table1/ir001.clp.zst");
+        assertEquals(result, "http://localhost:19617/data/archives/table1/ir001.clp.zst");
+
+        // Test with base URL without explicit port (should omit port in result)
+        testConfig.setUberTerrablobStorageBaseUrl("http://terrablob.uber.com");
+        result = (String) method.invoke(testProvider, "/ir.clp.zst");
+        assertEquals(result, "http://terrablob.uber.com/ir.clp.zst");
+    }
+
+    /**
+     * Test that buildFullSplitPath throws the exception when base URL is not configured.
+     */
+    @Test
+    public void testBuildFullSplitPathMissingConfig() throws Exception
+    {
+        Method method = ClpUberPinotSplitProvider.class.getDeclaredMethod("buildFullSplitPath", String.class);
+        method.setAccessible(true);
+
+        // config from setUp() does not have Terrablob URL configured
+        try {
+            method.invoke(splitProvider, "/some/path");
+            fail("Expected IllegalArgumentException for missing Terrablob storage base URL");
+        }
+        catch (Exception e) {
+            assertTrue(e.getCause() instanceof IllegalArgumentException);
+            assertTrue(e.getCause().getMessage().contains("clp.uber-terrablob-storage-base-url"));
+        }
+    }
+
+    /**
      * Test parsing of Uber Neutrino query response format.
      * Verifies that the JSON response with "columns" and "data" fields is correctly
      * parsed into a list of row maps.


### PR DESCRIPTION
- Add `clp.uber-terrablob-storage-base-url` configuration option to specify the Terrablob storage service URL.
- Update `ClpUberPinotSplitProvider` to prepend the protocol, host, and port when constructing split path.
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

See multiline PR title.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

All unit tests

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new configuration option to specify the Uber Terrablob storage base URL, enabling automatic full path construction for split providers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->