### PR TITLE
fix: Disable TopN feature in customized Pinot split provider.

### DIFF
--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpUberPinotSplitProvider.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpUberPinotSplitProvider.java
@@ -17,7 +17,6 @@ import com.facebook.presto.plugin.clp.ClpConfig;
 import com.facebook.presto.plugin.clp.ClpSplit;
 import com.facebook.presto.plugin.clp.ClpTableHandle;
 import com.facebook.presto.plugin.clp.ClpTableLayoutHandle;
-import com.facebook.presto.plugin.clp.optimization.ClpTopNSpec;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.function.FunctionMetadataManager;
@@ -110,7 +109,6 @@ public class ClpUberPinotSplitProvider
     public List<ClpSplit> listSplits(ClpTableLayoutHandle clpTableLayoutHandle)
     {
         ClpTableHandle clpTableHandle = clpTableLayoutHandle.getTable();
-        Optional<ClpTopNSpec> topNSpecOptional = clpTableLayoutHandle.getTopN();
         String tableName = inferMetadataTableName(clpTableHandle);
         Optional<String> metadataFilterQuery = Optional.empty();
 
@@ -130,22 +128,6 @@ public class ClpUberPinotSplitProvider
 
         try {
             ImmutableList.Builder<ClpSplit> splits = new ImmutableList.Builder<>();
-            if (topNSpecOptional.isPresent()) {
-                ClpTopNSpec topNSpec = topNSpecOptional.get();
-                ClpTopNSpec.Ordering ordering = topNSpec.getOrderings().get(0);
-
-                String splitMetaQuery = buildSplitSelectionQueryWithTopN(tableName, metadataFilterQuery.orElse("1 = 1"));
-                List<ArchiveMeta> archiveMetaList = fetchArchiveMeta(splitMetaQuery, ordering);
-                List<ArchiveMeta> selected = selectTopNArchives(archiveMetaList, topNSpec.getLimit(), ordering.getOrder());
-
-                for (ArchiveMeta a : selected) {
-                    String splitPath = buildFullSplitPath(a.id);
-                    splits.add(new ClpSplit(splitPath, determineSplitType(splitPath), clpTableLayoutHandle.getKqlQuery(), Optional.empty()));
-                }
-                List<ClpSplit> filteredSplits = splits.build();
-                log.debug("Number of topN filtered splits: %s", filteredSplits.size());
-                return filteredSplits;
-            }
             List<String> metadataColumnNames = new ArrayList<>(
                     clpTableLayoutHandle.getOrInitializeSplitMetadataColumnNames());
             String splitQuery = buildSplitSelectionQuery(


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

As PR title suggests. This is because num_messages column is not propagated in the customized Pinot metadata database.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [ ] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [ ] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [ ] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

E2E: 
Running below query
```
SELECT CLP_GET_JSON_STRING() AS event FROM clp.DEFAULT.cockroachdb_ir 
WHERE
ts > CAST(
    to_unixtime(
        date_add('year', -15, current_timestamp)
    ) * 1000 AS BIGINT
) ORDER BY ts DESC limit 100
```

The Pinot SQL is 
`Executing Pinot query: SELECT tpath FROM rta.logging.cockroachdb_ir WHERE 1 = 1 AND (lastmodifiedtime > '1292618907379') LIMIT 999999`

This does not trigger TopN.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
