### PR TITLE
 fix: Skip tpath column in LASTWITHTIME projection for customized Pinot split provider

### DIFF
--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpUberPinotSplitProvider.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpUberPinotSplitProvider.java
@@ -376,7 +376,9 @@ public class ClpUberPinotSplitProvider
         // Build LASTWITHTIME expressions for each metadata column
         Set<String> lastWithTimeProjections = new LinkedHashSet<>();
         for (String column : metadataProject) {
-            if (column.equals("tpath")) continue;
+            if (column.equals("tpath")) {
+                continue;
+            }
             lastWithTimeProjections.add(
                     format(", LASTWITHTIME(%s, \"_timestampMillis\", 'string') AS %s", column, column));
         }

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpUberPinotSplitProvider.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpUberPinotSplitProvider.java
@@ -63,7 +63,7 @@ public class ClpUberPinotSplitProvider
         extends ClpPinotSplitProvider
 {
     private static final String SQL_SELECT_SPLITS_TEMPLATE_WITH_DEDUP =
-            "SELECT tpath, %s FROM %s WHERE 1 = 1 AND (%s) GROUP BY tpath LIMIT 999999";
+            "SELECT tpath %s FROM %s WHERE 1 = 1 AND (%s) GROUP BY tpath LIMIT 999999";
     /**
      * Constructs an Uber CLP Pinot split provider with the given configuration.
      *
@@ -374,15 +374,16 @@ public class ClpUberPinotSplitProvider
     protected String buildSplitSelectionQuery(String tableName, List<String> metadataProject, String filterSql)
     {
         // Build LASTWITHTIME expressions for each metadata column
-        Set<String> lastWithTimeProjections = new LinkedHashSet<>(metadataProject);
+        Set<String> lastWithTimeProjections = new LinkedHashSet<>();
         for (String column : metadataProject) {
+            if (column.equals("tpath")) continue;
             lastWithTimeProjections.add(
-                    format("LASTWITHTIME(%s, \"_timestampMillis\", 'string') AS %s", column, column));
+                    format(", LASTWITHTIME(%s, \"_timestampMillis\", 'string') AS %s", column, column));
         }
 
         String projectionClause = lastWithTimeProjections.isEmpty()
                 ? ""
-                : String.join(", ", lastWithTimeProjections);
+                : String.join("", lastWithTimeProjections);
 
         return format(SQL_SELECT_SPLITS_TEMPLATE_WITH_DEDUP, projectionClause, tableName, filterSql);
     }

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/split/TestClpUberPinotSplitProvider.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/split/TestClpUberPinotSplitProvider.java
@@ -225,19 +225,30 @@ public class TestClpUberPinotSplitProvider
     @Test
     public void testBuildSplitSelectionQueryWithMetadataColumns()
     {
-        List<String> metadataColumns = new ArrayList<>();
-        metadataColumns.add("hostname");
-        metadataColumns.add("creationtime");
+        // Test case 1: No metadata projection (empty list)
+        List<String> emptyColumns = new ArrayList<>();
+        String queryNoMetadata = splitProvider.buildSplitSelectionQuery(
+                "rta.logging.logs", emptyColumns, "1 = 1");
+        assertEquals(queryNoMetadata,
+                "SELECT tpath  FROM rta.logging.logs WHERE 1 = 1 AND (1 = 1) GROUP BY tpath LIMIT 999999");
 
-        String query = splitProvider.buildSplitSelectionQuery(
-                "rta.logging.logs", metadataColumns, "creationtime > 1000");
+        // Test case 2: Metadata projection with tpath (tpath should be skipped)
+        List<String> columnsWithTpath = new ArrayList<>();
+        columnsWithTpath.add("tpath");
+        columnsWithTpath.add("hostname");
+        String queryWithTpath = splitProvider.buildSplitSelectionQuery(
+                "rta.logging.logs", columnsWithTpath, "creationtime > 1000");
+        assertEquals(queryWithTpath,
+                "SELECT tpath , LASTWITHTIME(hostname, \"_timestampMillis\", 'string') AS hostname FROM rta.logging.logs WHERE 1 = 1 AND (creationtime > 1000) GROUP BY tpath LIMIT 999999");
 
-        assertTrue(query.contains("SELECT tpath"));
-        assertTrue(query.contains("LASTWITHTIME(hostname, \"_timestampMillis\", 'string') AS hostname"));
-        assertTrue(query.contains("LASTWITHTIME(creationtime, \"_timestampMillis\", 'string') AS creationtime"));
-        assertTrue(query.contains("GROUP BY tpath"));
-        assertTrue(query.contains("rta.logging.logs"));
-        assertTrue(query.contains("creationtime > 1000"));
+        // Test case 3: Projection with repeated column (duplicates should be removed)
+        List<String> columnsWithDuplicate = new ArrayList<>();
+        columnsWithDuplicate.add("hostname");
+        columnsWithDuplicate.add("hostname");
+        String queryWithDuplicate = splitProvider.buildSplitSelectionQuery(
+                "rta.logging.logs", columnsWithDuplicate, "1 = 1");
+        assertEquals(queryWithDuplicate,
+                "SELECT tpath , LASTWITHTIME(hostname, \"_timestampMillis\", 'string') AS hostname FROM rta.logging.logs WHERE 1 = 1 AND (1 = 1) GROUP BY tpath LIMIT 999999");
     }
 
     /**


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

Currently, tpath is already presented in the sql template; therefore, when a metadata projection column contains tpath, we wrap it with LASTWITHTIME.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [ ] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [ ] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [ ] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

All unit tests.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
