### PR TITLE
ci: use conditional runner selection for self-hosted vs GitHub-hosted

### DIFF
--- a/.github/workflows/create-builder-image.yml
+++ b/.github/workflows/create-builder-image.yml
@@ -98,7 +98,12 @@ jobs:
     # For same-repo, no environment (runs automatically)
     # NOTE: Create "builder-image" environment in GitHub repo settings with required reviewers
     environment: ${{ needs.check-builder-image.outputs.is-fork == 'true' && 'builder-image' || '' }}
-    runs-on: [self-hosted, cores=32]
+    runs-on: >-
+      ${{
+        github.repository_owner == 'y-scope'
+        && fromJSON('["self-hosted", "x64", "cores=32", "ubuntu-noble"]')
+        || 'ubuntu-latest'
+      }}
     timeout-minutes: 180
     # Concurrency control: prevent duplicate builds of the same image
     concurrency:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -44,7 +44,12 @@ jobs:
   # Parallelized by test category for faster execution
   integration-e2e-java:
     name: "integration-e2e-java (${{ matrix.group }})"
-    runs-on: self-hosted
+    runs-on: &runner >-
+      ${{
+        github.repository_owner == 'y-scope'
+        && fromJSON('["self-hosted", "x64", "ubuntu-noble"]')
+        || 'ubuntu-latest'
+      }}
     timeout-minutes: 180
     strategy:
       fail-fast: false
@@ -204,7 +209,7 @@ jobs:
   # Tests: Test*.java in presto-native-tests module with storage format matrix
   integration-storage-java:
     name: "integration-storage-java"
-    runs-on: self-hosted
+    runs-on: *runner
     timeout-minutes: 180
     container:
       image: ${{ inputs.builder-image }}
@@ -332,7 +337,7 @@ jobs:
   # Tests: Test*.java in presto-native-sidecar-plugin module
   integration-sidecar-java:
     name: "integration-sidecar-java"
-    runs-on: self-hosted
+    runs-on: *runner
     timeout-minutes: 180
     container:
       image: ${{ inputs.builder-image }}

--- a/.github/workflows/presto-build.yml
+++ b/.github/workflows/presto-build.yml
@@ -76,7 +76,12 @@ jobs:
   # --------------------------------------------------------------------------
   build:
     name: "presto-build"
-    runs-on: self-hosted
+    runs-on: &runner >-
+      ${{
+        github.repository_owner == 'y-scope'
+        && fromJSON('["self-hosted", "x64", "ubuntu-noble"]')
+        || 'ubuntu-latest'
+      }}
     timeout-minutes: 45
     container:
       image: ${{ inputs.builder-image }}
@@ -149,7 +154,7 @@ jobs:
     name: "presto-image"
     needs: build  # Wait for build job to complete and upload artifacts
     if: inputs.should-build-image && inputs.should-upload-artifacts
-    runs-on: self-hosted
+    runs-on: *runner
     steps:
       # Sparse checkout: Only fetch the docker/ directory (not entire repo)
       # This is faster when we only need specific files

--- a/.github/workflows/prestocpp-linux-build-and-unit-test.yml
+++ b/.github/workflows/prestocpp-linux-build-and-unit-test.yml
@@ -48,7 +48,12 @@ jobs:
   # Builds the prestocpp binary, runs unit tests, and uploads artifacts.
   prestocpp-linux-build-and-test:
     name: "prestocpp-linux-build-and-test"
-    runs-on: self-hosted
+    runs-on: &runner >-
+      ${{
+        github.repository_owner == 'y-scope'
+        && fromJSON('["self-hosted", "x64", "ubuntu-noble"]')
+        || 'ubuntu-latest'
+      }}
     timeout-minutes: 180
     container:
       image: ${{ inputs.builder-image }}
@@ -118,7 +123,7 @@ jobs:
   prestissimo-image:
     name: "prestissimo-image"
     needs: prestocpp-linux-build-and-test
-    runs-on: self-hosted
+    runs-on: *runner
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,12 @@ on:
 jobs:
   test:
     name: "presto-tests"
-    runs-on: self-hosted
+    runs-on: &runner >-
+      ${{
+        github.repository_owner == 'y-scope'
+        && fromJSON('["self-hosted", "x64", "ubuntu-noble"]')
+        || 'ubuntu-latest'
+      }}
     strategy:
       fail-fast: false  # Continue other jobs even if one fails
       matrix:


### PR DESCRIPTION
# Description

Use YAML anchor pattern to dynamically select runners based on repository owner:
- y-scope org: use self-hosted runners with `["self-hosted", "x64", "ubuntu-noble"]` labels
- Other forks: fall back to `ubuntu-latest` GitHub-hosted runners

This allows forks to run CI without requiring self-hosted runner infrastructure.

## Why `fromJSON()` is needed

GitHub Actions expressions don't support native array literals. When using a conditional expression like:

```yaml
runs-on: ${{ condition && ["self-hosted", "x64"] || 'ubuntu-latest' }}
```

The array syntax inside `${{ }}` is not valid. However, `runs-on` can accept an array, so we use `fromJSON()` to parse a JSON string into an actual array:

```yaml
runs-on: ${{ condition && fromJSON('["self-hosted", "x64"]') || 'ubuntu-latest' }}
```

## Files changed

- `.github/workflows/tests.yml`
- `.github/workflows/integration-tests.yml`
- `.github/workflows/presto-build.yml`
- `.github/workflows/prestocpp-linux-build-and-unit-test.yml`
- `.github/workflows/create-builder-image.yml`

# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

- Verified YAML syntax is valid
- Pattern follows y-scope/clp PR #1775 implementation

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html