### PR TITLE
Refactor: Remove customer-specific terminology in Pinot split provider.

### DIFF
--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpConfig.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpConfig.java
@@ -15,7 +15,9 @@ package com.facebook.presto.plugin.clp;
 
 import com.facebook.airlift.configuration.Config;
 import com.facebook.presto.spi.PrestoException;
+import com.google.common.collect.ImmutableMap;
 
+import java.util.Map;
 import java.util.regex.Pattern;
 
 public class ClpConfig
@@ -36,7 +38,10 @@ public class ClpConfig
     private String splitMetadataConfigPath;
     private String metadataYamlPath;
     private SplitProviderType splitProviderType = SplitProviderType.MYSQL;
-    private String uberTerrablobStorageBaseUrl;
+    private String customStorageBaseUrl;
+    private Map<String, String> customHttpHeaders = ImmutableMap.of();
+    private String customTableNamePrefix;
+    private String customApiEndpointPath;
 
     public boolean isPolymorphicTypeEnabled()
     {
@@ -188,15 +193,78 @@ public class ClpConfig
         return this;
     }
 
-    public String getUberTerrablobStorageBaseUrl()
+    public String getCustomStorageBaseUrl()
     {
-        return uberTerrablobStorageBaseUrl;
+        return customStorageBaseUrl;
     }
 
-    @Config("clp.uber-terrablob-storage-base-url")
-    public ClpConfig setUberTerrablobStorageBaseUrl(String uberTerrablobStorageBaseUrl)
+    @Config("clp.custom-metadata-storage-base-url")
+    public ClpConfig setCustomStorageBaseUrl(String customStorageBaseUrl)
     {
-        this.uberTerrablobStorageBaseUrl = uberTerrablobStorageBaseUrl;
+        this.customStorageBaseUrl = customStorageBaseUrl;
+        return this;
+    }
+
+    public Map<String, String> getCustomHttpHeaders()
+    {
+        return customHttpHeaders;
+    }
+
+    /**
+     * Sets custom HTTP headers for the custom Pinot split provider.
+     * <p>
+     * Format: comma-separated key:value pairs, e.g., "Header1:Value1,Header2:Value2"
+     * </p>
+     */
+    @Config("clp.custom-metadata-http-headers")
+    public ClpConfig setCustomHttpHeaders(String customHttpHeaders)
+    {
+        if (customHttpHeaders == null || customHttpHeaders.trim().isEmpty()) {
+            this.customHttpHeaders = ImmutableMap.of();
+            return this;
+        }
+
+        ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+        for (String pair : customHttpHeaders.split(",")) {
+            String trimmedPair = pair.trim();
+            if (trimmedPair.isEmpty()) {
+                continue;
+            }
+            int colonIndex = trimmedPair.indexOf(':');
+            if (colonIndex <= 0 || colonIndex >= trimmedPair.length() - 1) {
+                throw new PrestoException(
+                        ClpErrorCode.CLP_UNSUPPORTED_CONFIG_OPTION,
+                        "Invalid custom HTTP header format: '" + trimmedPair + "'. Expected format: 'Header-Name:Header-Value'");
+            }
+            String key = trimmedPair.substring(0, colonIndex).trim();
+            String value = trimmedPair.substring(colonIndex + 1).trim();
+            builder.put(key, value);
+        }
+        this.customHttpHeaders = builder.build();
+        return this;
+    }
+
+    public String getCustomTableNamePrefix()
+    {
+        return customTableNamePrefix;
+    }
+
+    @Config("clp.custom-metadata-table-name-prefix")
+    public ClpConfig setCustomTableNamePrefix(String customTableNamePrefix)
+    {
+        this.customTableNamePrefix = customTableNamePrefix;
+        return this;
+    }
+
+    public String getCustomApiEndpointPath()
+    {
+        return customApiEndpointPath;
+    }
+
+    @Config("clp.custom-metadata-api-endpoint-path")
+    public ClpConfig setCustomApiEndpointPath(String customApiEndpointPath)
+    {
+        this.customApiEndpointPath = customApiEndpointPath;
         return this;
     }
 
@@ -210,6 +278,6 @@ public class ClpConfig
     {
         MYSQL,
         PINOT,
-        PINOT_UBER
+        PINOT_CUSTOM
     }
 }

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpModule.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpModule.java
@@ -17,11 +17,11 @@ import com.facebook.airlift.configuration.AbstractConfigurationAwareModule;
 import com.facebook.presto.plugin.clp.metadata.ClpMetadataProvider;
 import com.facebook.presto.plugin.clp.metadata.ClpMySqlMetadataProvider;
 import com.facebook.presto.plugin.clp.metadata.ClpYamlMetadataProvider;
+import com.facebook.presto.plugin.clp.split.ClpCustomPinotSplitProvider;
 import com.facebook.presto.plugin.clp.split.ClpMySqlSplitProvider;
 import com.facebook.presto.plugin.clp.split.ClpPinotSplitProvider;
 import com.facebook.presto.plugin.clp.split.ClpSplitMetadataConfig;
 import com.facebook.presto.plugin.clp.split.ClpSplitProvider;
-import com.facebook.presto.plugin.clp.split.ClpUberPinotSplitProvider;
 import com.facebook.presto.spi.PrestoException;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Binder;
@@ -49,7 +49,7 @@ public class ClpModule
             ImmutableMap.<SplitProviderType, Class<? extends ClpSplitProvider>>builder()
                     .put(SplitProviderType.MYSQL, ClpMySqlSplitProvider.class)
                     .put(SplitProviderType.PINOT, ClpPinotSplitProvider.class)
-                    .put(SplitProviderType.PINOT_UBER, ClpUberPinotSplitProvider.class)
+                    .put(SplitProviderType.PINOT_CUSTOM, ClpCustomPinotSplitProvider.class)
                     .build();
 
     @Override

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpCustomPinotSplitMetadataExpressionConverter.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpCustomPinotSplitMetadataExpressionConverter.java
@@ -44,10 +44,10 @@ import static java.lang.String.format;
  *       expression.</li>
  * </ul>
  */
-public class ClpUberPinotSplitMetadataExpressionConverter
+public class ClpCustomPinotSplitMetadataExpressionConverter
         extends ClpMySqlSplitMetadataExpressionConverter
 {
-    public ClpUberPinotSplitMetadataExpressionConverter(
+    public ClpCustomPinotSplitMetadataExpressionConverter(
             FunctionMetadataManager functionManager,
             StandardFunctionResolution functionResolution,
             ClpSplitMetadataConfig metadataConfig,

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpCustomPinotSplitProvider.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpCustomPinotSplitProvider.java
@@ -52,24 +52,13 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
  * Customized implementation of CLP Pinot split provider.
- * <p>
- * NOTE: "U" is a coded name for the customer this implementation was developed for.
- * </p>
- * <p>
- * This implementation customizes the SQL query endpoint URL to use a cross-region routing
- * and aggregation service's global statements API instead of the standard Pinot query endpoint.
- * </p>
  */
 public class ClpCustomPinotSplitProvider
         extends ClpPinotSplitProvider
 {
     private static final String SQL_SELECT_SPLITS_TEMPLATE_WITH_DEDUP =
             "SELECT tpath %s FROM %s WHERE 1 = 1 AND (%s) GROUP BY tpath LIMIT 999999";
-    /**
-     * Constructs a custom CLP Pinot split provider with the given configuration.
-     *
-     * @param config the CLP configuration
-     */
+
     @Inject
     public ClpCustomPinotSplitProvider(
             ClpConfig config,
@@ -196,10 +185,10 @@ public class ClpCustomPinotSplitProvider
      * it will be prepended to the table name. Otherwise, the table name is used as-is.
      * </p>
      * <p>
-     * Examples with prefix "rta.logging.":
+     * Examples with prefix "metadata.service":
      * <ul>
-     *   <li>Schema: "default", Table: "logs" → Pinot table: "rta.logging.logs"</li>
-     *   <li>Schema: "production", Table: "events" → Pinot table: "rta.logging.events"</li>
+     *   <li>Schema: "default", Table: "logs" → Pinot table: "metadata.service.logs"</li>
+     *   <li>Schema: "production", Table: "events" → Pinot table: "metadata.service.events"</li>
      * </ul>
      * </p>
      *

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpCustomPinotSplitProvider.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpCustomPinotSplitProvider.java
@@ -51,26 +51,27 @@ import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
- * Uber-specific implementation of CLP Pinot split provider.
+ * Customized implementation of CLP Pinot split provider.
  * <p>
- * At Uber, Pinot is accessed through Neutrino, a cross-region routing and aggregation service
- * that provides a unified interface for querying distributed Pinot clusters. This implementation
- * customizes the SQL query endpoint URL to use Neutrino's global statements API instead of
- * the standard Pinot query endpoint.
+ * NOTE: "U" is a coded name for the customer this implementation was developed for.
+ * </p>
+ * <p>
+ * This implementation customizes the SQL query endpoint URL to use a cross-region routing
+ * and aggregation service's global statements API instead of the standard Pinot query endpoint.
  * </p>
  */
-public class ClpUberPinotSplitProvider
+public class ClpCustomPinotSplitProvider
         extends ClpPinotSplitProvider
 {
     private static final String SQL_SELECT_SPLITS_TEMPLATE_WITH_DEDUP =
             "SELECT tpath %s FROM %s WHERE 1 = 1 AND (%s) GROUP BY tpath LIMIT 999999";
     /**
-     * Constructs an Uber CLP Pinot split provider with the given configuration.
+     * Constructs a custom CLP Pinot split provider with the given configuration.
      *
      * @param config the CLP configuration
      */
     @Inject
-    public ClpUberPinotSplitProvider(
+    public ClpCustomPinotSplitProvider(
             ClpConfig config,
             FunctionMetadataManager functionManager,
             StandardFunctionResolution functionResolution,
@@ -80,7 +81,7 @@ public class ClpUberPinotSplitProvider
     }
 
     /**
-     * Constructs the full split path by prepending the Terrablob storage URL prefix to the relative file path.
+     * Constructs the full split path by prepending the storage URL prefix to the relative file path.
      *
      * @param relativePath the relative file path from the metadata database
      * @return the full split path with protocol, host, and port prefix
@@ -88,10 +89,10 @@ public class ClpUberPinotSplitProvider
      */
     private String buildFullSplitPath(String relativePath)
     {
-        String baseUrl = config.getUberTerrablobStorageBaseUrl();
+        String baseUrl = config.getCustomStorageBaseUrl();
         if (baseUrl == null || baseUrl.isEmpty()) {
             throw new IllegalArgumentException(
-                    "Terrablob storage base URL (clp.uber-terrablob-storage-base-url) must be configured for Uber" +
+                    "Custom storage base URL (clp.custom-metadata-storage-base-url) must be configured for custom" +
                             " Pinot split provider");
         }
 
@@ -105,7 +106,7 @@ public class ClpUberPinotSplitProvider
         }
         catch (MalformedURLException e) {
             throw new IllegalArgumentException(
-                    format("Invalid Terrablob storage base URL: %s", baseUrl), e);
+                    format("Invalid custom storage base URL: %s", baseUrl), e);
         }
     }
 
@@ -118,8 +119,8 @@ public class ClpUberPinotSplitProvider
 
         SchemaTableName schemaTableName = clpTableHandle.getSchemaTableName();
         if (clpTableLayoutHandle.getMetadataExpression() != null) {
-            ClpUberPinotSplitMetadataExpressionConverter converter =
-                    new ClpUberPinotSplitMetadataExpressionConverter(
+            ClpCustomPinotSplitMetadataExpressionConverter converter =
+                    new ClpCustomPinotSplitMetadataExpressionConverter(
                             functionManager,
                             functionResolution,
                             metadataConfig,
@@ -166,51 +167,44 @@ public class ClpUberPinotSplitProvider
     }
 
     /**
-     * Constructs the Neutrino SQL query endpoint URL for Uber's Pinot infrastructure.
+     * Constructs the SQL query endpoint URL for the custom Pinot infrastructure.
      * <p>
      * Instead of using Pinot's standard {@code /query/sql} endpoint, this method constructs
-     * a URL pointing to Neutrino's {@code /v1/globalStatements} endpoint, which provides
-     * cross-region query routing and aggregation capabilities.
+     * a URL using the configured API endpoint path.
      * </p>
      *
-     * @param config the CLP configuration containing the base Neutrino service URL
-     * @return the Neutrino global statements endpoint URL
+     * @param config the CLP configuration containing the base service URL and endpoint path
+     * @return the custom API endpoint URL
      * @throws MalformedURLException if the constructed URL is invalid
+     * @throws IllegalArgumentException if the API endpoint path is not configured
      */
     @Override
     protected URL buildPinotSqlQueryEndpointUrl(ClpConfig config) throws MalformedURLException
     {
-        return new URL(config.getMetadataDbUrl() + "/v1/globalStatement");
+        String endpointPath = config.getCustomApiEndpointPath();
+        if (endpointPath == null || endpointPath.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Custom API endpoint path (clp.custom-metadata-api-endpoint-path) must be configured for custom Pinot split provider");
+        }
+        return new URL(config.getMetadataDbUrl() + endpointPath);
     }
 
     /**
-     * Infers the Uber-specific Pinot metadata table name from the CLP table handle.
+     * Infers the custom Pinot metadata table name from the CLP table handle.
      * <p>
-     * At Uber, Pinot tables are organized under a specific namespace hierarchy.
-     * All logging-related metadata tables are prefixed with {@code "rta.logging."}
-     * to identify them within Uber's multi-tenant Pinot infrastructure. This prefix
-     * represents:
-     * <ul>
-     *   <li><b>rta</b>: Real-Time Analytics platform namespace</li>
-     *   <li><b>logging</b>: The logging subsystem within RTA</li>
-     * </ul>
+     * If a table name prefix is configured via {@code clp.custom-metadata-table-name-prefix},
+     * it will be prepended to the table name. Otherwise, the table name is used as-is.
      * </p>
      * <p>
-     * Unlike the standard Pinot implementation where schemas can affect table naming,
-     * Uber's approach uses a flat namespace where all logging tables share the same
-     * prefix regardless of the schema being queried.
-     * </p>
-     * <p>
-     * Examples:
+     * Examples with prefix "rta.logging.":
      * <ul>
      *   <li>Schema: "default", Table: "logs" → Pinot table: "rta.logging.logs"</li>
      *   <li>Schema: "production", Table: "events" → Pinot table: "rta.logging.events"</li>
-     *   <li>Schema: "staging", Table: "metrics" → Pinot table: "rta.logging.metrics"</li>
      * </ul>
      * </p>
      *
      * @param tableHandle the CLP table handle containing schema and table information
-     * @return the fully-qualified Pinot metadata table name with Uber's namespace prefix
+     * @return the Pinot metadata table name, optionally with configured prefix
      * @throws NullPointerException if tableHandle is null
      */
     @Override
@@ -218,43 +212,39 @@ public class ClpUberPinotSplitProvider
     {
         requireNonNull(tableHandle, "tableHandle is null");
         SchemaTableName schemaTableName = tableHandle.getSchemaTableName();
-
-        // Uber's Pinot tables use a fixed namespace prefix for all logging tables
-        // Format: rta.logging.<table_name>
         String tableName = schemaTableName.getTableName();
-        return buildUberTableName(tableName);
+
+        String prefix = config.getCustomTableNamePrefix();
+        if (prefix == null || prefix.isEmpty()) {
+            return tableName;
+        }
+        // Automatically append dot if not present
+        if (!prefix.endsWith(".")) {
+            prefix = prefix + ".";
+        }
+        return prefix + tableName;
     }
 
     /**
-     * Factory method for building Uber-specific table names.
-     * Exposed for testing purposes.
-     *
-     * @param tableName the base table name
-     * @return the fully-qualified Uber Pinot table name
-     */
-    @VisibleForTesting
-    protected String buildUberTableName(String tableName)
-    {
-        return String.format("rta.logging.%s", tableName);
-    }
-
-    /**
-     * Adds Uber-specific HTTP headers required for Neutrino service authentication.
+     * Adds custom HTTP headers from configuration.
+     * <p>
+     * Headers are configured via the {@code clp.custom-metadata-http-headers} property
+     * as comma-separated key:value pairs.
+     * </p>
      *
      * @param conn the HTTP connection to add headers to
      */
     protected void addCustomQueryRequestHeader(HttpURLConnection conn)
     {
-        conn.setRequestProperty("RPC-Service", "neutrino-logging");
-        conn.setRequestProperty("RPC-Caller", "logging-terrablob-connector");
-        conn.setRequestProperty("Content-Type", "text/plain");
-        conn.setRequestProperty("Accept", "text/plain");
+        for (Map.Entry<String, String> header : config.getCustomHttpHeaders().entrySet()) {
+            conn.setRequestProperty(header.getKey(), header.getValue());
+        }
     }
 
     /**
      * {@inheritDoc}
      * <p>
-     * This Uber-specific implementation sends the SQL query as plain text to the Neutrino
+     * This custom implementation sends the SQL query as plain text to the service
      * endpoint and parses the response using {@link #parseQueryResponse(JsonNode)}.
      * </p>
      */
@@ -300,9 +290,9 @@ public class ClpUberPinotSplitProvider
     }
 
     /**
-     * Parses the JSON response from an Uber Neutrino query into a list of row maps.
+     * Parses the JSON response from a custom query into a list of row maps.
      * <p>
-     * The Uber Neutrino response format differs from standard Pinot:
+     * The custom response format differs from standard Pinot:
      * <ul>
      *   <li><b>columns</b>: Array of column definitions, each containing "name", "type", and "typeSignature"</li>
      *   <li><b>data</b>: Array of row arrays (equivalent to Pinot's "rows")</li>
@@ -318,12 +308,12 @@ public class ClpUberPinotSplitProvider
     {
         JsonNode columnsNode = root.get("columns");
         if (columnsNode == null) {
-            throw new IllegalStateException("Uber query response missing 'columns' field");
+            throw new IllegalStateException("Custom query response missing 'columns' field");
         }
 
         JsonNode dataNode = root.get("data");
         if (dataNode == null) {
-            throw new IllegalStateException("Uber query response missing 'data' field");
+            throw new IllegalStateException("Custom query response missing 'data' field");
         }
 
         ImmutableList.Builder<String> columnNamesBuilder = ImmutableList.builder();

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/mockdb/ClpMockPinotDatabase.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/mockdb/ClpMockPinotDatabase.java
@@ -42,7 +42,7 @@ import static org.testng.Assert.fail;
 
 /**
  * Mock Pinot database for testing LASTWITHTIME deduplication queries.
- * Uses H2 as the backing store and an HTTP server to simulate the Pinot/Neutrino API.
+ * Uses H2 as the backing store and an HTTP server to simulate a custom Pinot API.
  * Translates LASTWITHTIME queries into equivalent H2 SQL for deduplication.
  */
 public class ClpMockPinotDatabase
@@ -92,7 +92,7 @@ public class ClpMockPinotDatabase
     /**
      * Inserts a row into the mock Pinot table.
      * Multiple rows with the same tpath but different _timestampMillis simulate Pinot's append-only model.
-     * All columns are stored as strings to match Uber's Pinot schema.
+     * All columns are stored as strings to match the custom Pinot schema.
      */
     public void insertRow(String tpath, String hostname, String creationtime, String numMessages, String timestampMillis)
     {
@@ -213,7 +213,7 @@ public class ClpMockPinotDatabase
     }
 
     /**
-     * Executes the H2 query and formats the result as Neutrino JSON response.
+     * Executes the H2 query and formats the result as custom JSON response.
      */
     private String executeQueryAndFormat(String query) throws SQLException, IOException
     {
@@ -270,7 +270,7 @@ public class ClpMockPinotDatabase
             String dbName = UUID.randomUUID().toString();
             String h2Url = format(H2_URL_TEMPLATE, dbName);
 
-            // Create the table with all VARCHAR columns to match Uber's Pinot schema
+            // Create the table with all VARCHAR columns to match the custom Pinot schema
             try (Connection conn = DriverManager.getConnection(h2Url);
                     Statement stmt = conn.createStatement()) {
                 stmt.execute(format(

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/mockdb/ClpMockPinotDatabase.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/mockdb/ClpMockPinotDatabase.java
@@ -288,7 +288,7 @@ public class ClpMockPinotDatabase
             int port = server.getAddress().getPort();
 
             ClpMockPinotDatabase db = new ClpMockPinotDatabase(h2Url, server, port, tableName);
-            server.createContext("/v1/globalStatement", db::handleRequest);
+            server.createContext("/api/v1/query", db::handleRequest);
 
             return db;
         }

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/split/TestClpCustomPinotSplitMetadataExpressionConverter.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/split/TestClpCustomPinotSplitMetadataExpressionConverter.java
@@ -33,17 +33,15 @@ import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static org.testng.Assert.assertEquals;
 
 /**
- * Unit tests for ClpUberPinotSplitFilterProvider.
- * Tests Uber-specific TEXT_MATCH transformations in addition to inherited
- * range mapping functionality.
+ * Unit tests for ClpCustomPinotSplitMetadataExpressionConverter.
  */
 @Test(singleThreaded = true)
-public class TestClpUberPinotSplitMetadataExpressionConverter
+public class TestClpCustomPinotSplitMetadataExpressionConverter
         extends TestClpQueryBase
 {
     private TypeProvider typeProvider;
     private ClpSplitMetadataConfig splitMetadataConfig;
-    private ClpUberPinotSplitMetadataExpressionConverter defaultConverter;
+    private ClpCustomPinotSplitMetadataExpressionConverter defaultConverter;
 
     @BeforeMethod
     public void setUp() throws IOException, URISyntaxException
@@ -70,7 +68,7 @@ public class TestClpUberPinotSplitMetadataExpressionConverter
         splitMetadataConfig = new ClpSplitMetadataConfig(config, functionAndTypeManager);
 
         SchemaTableName table = new SchemaTableName("default", "table_1");
-        defaultConverter = new ClpUberPinotSplitMetadataExpressionConverter(
+        defaultConverter = new ClpCustomPinotSplitMetadataExpressionConverter(
                 functionAndTypeManager,
                 standardFunctionResolution,
                 splitMetadataConfig,
@@ -79,7 +77,7 @@ public class TestClpUberPinotSplitMetadataExpressionConverter
 
     /**
      * Test TEXT_MATCH transformation for simple equality predicates.
-     * Verifies that Uber-specific TEXT_MATCH transformations are applied.
+     * Verifies that TEXT_MATCH transformations are applied.
      */
     @Test
     public void testTextMatchTransformationSimpleEquality()
@@ -100,17 +98,17 @@ public class TestClpUberPinotSplitMetadataExpressionConverter
     @Test
     public void testTextMatchTransformationStringLiterals()
     {
-        assertMatch("\"hostname\" = 'uber-server1'",
-                "TEXT_MATCH(\"__mergedTextIndex\", '/uber-server1:hostname/')");
+        assertMatch("\"hostname\" = 'server1'",
+                "TEXT_MATCH(\"__mergedTextIndex\", '/server1:hostname/')");
 
-        assertMatch("\"service\" = 'uber.logging.service'",
-                "TEXT_MATCH(\"__mergedTextIndex\", '/uber.logging.service:service/')");
+        assertMatch("\"service\" = 'logging.service'",
+                "TEXT_MATCH(\"__mergedTextIndex\", '/logging.service:service/')");
 
         assertMatch("\"service\" = ''",
                 "TEXT_MATCH(\"__mergedTextIndex\", '/:service/')");
 
-        assertMatch("\"service\" = 'Hello Uber World'",
-                "TEXT_MATCH(\"__mergedTextIndex\", '/Hello Uber World:service/')");
+        assertMatch("\"service\" = 'Hello World'",
+                "TEXT_MATCH(\"__mergedTextIndex\", '/Hello World:service/')");
     }
 
     /**
@@ -136,12 +134,12 @@ public class TestClpUberPinotSplitMetadataExpressionConverter
                 "(end_timestamp >= 1000) AND (TEXT_MATCH(\"__mergedTextIndex\", '/200:status_code/'))");
 
         assertMatch(
-                "(\"hostname\" = 'uber1' AND \"service\" = 'logging')",
-                "(TEXT_MATCH(\"__mergedTextIndex\", '/uber1:hostname/')) AND (TEXT_MATCH(\"__mergedTextIndex\", '/logging:service/'))");
+                "(\"hostname\" = 'host1' AND \"service\" = 'logging')",
+                "(TEXT_MATCH(\"__mergedTextIndex\", '/host1:hostname/')) AND (TEXT_MATCH(\"__mergedTextIndex\", '/logging:service/'))");
 
         assertMatch(
-                "((\"msg.timestamp\" <= 2000 AND \"hostname\" = 'uber2') OR \"status_code\" = 404)",
-                "((begin_timestamp <= 2000) AND (TEXT_MATCH(\"__mergedTextIndex\", '/uber2:hostname/'))) OR (TEXT_MATCH(\"__mergedTextIndex\", '/404:status_code/'))");
+                "((\"msg.timestamp\" <= 2000 AND \"hostname\" = 'host2') OR \"status_code\" = 404)",
+                "((begin_timestamp <= 2000) AND (TEXT_MATCH(\"__mergedTextIndex\", '/host2:hostname/'))) OR (TEXT_MATCH(\"__mergedTextIndex\", '/404:status_code/'))");
     }
 
 //    /**

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/split/TestClpCustomPinotSplitProvider.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/split/TestClpCustomPinotSplitProvider.java
@@ -51,8 +51,8 @@ public class TestClpCustomPinotSplitProvider
         config = new ClpConfig();
         config.setMetadataDbUrl("https://pinot-service.example.com");
         config.setSplitProviderType(ClpConfig.SplitProviderType.PINOT_CUSTOM);
-        config.setCustomTableNamePrefix("rta.logging");
-        config.setCustomApiEndpointPath("/v1/globalStatement");
+        config.setCustomTableNamePrefix("metadata.service");
+        config.setCustomApiEndpointPath("/api/v1/query");
         config.setCustomHttpHeaders("RPC-Service:test-service,RPC-Caller:test-caller,Content-Type:text/plain");
         splitProvider = new ClpCustomPinotSplitProvider(
                 config,
@@ -74,10 +74,10 @@ public class TestClpCustomPinotSplitProvider
         URL result = (URL) method.invoke(splitProvider, config);
 
         assertNotNull(result);
-        assertEquals(result.toString(), "https://pinot-service.example.com/v1/globalStatement");
+        assertEquals(result.toString(), "https://pinot-service.example.com/api/v1/query");
         assertEquals(result.getProtocol(), "https");
         assertEquals(result.getHost(), "pinot-service.example.com");
-        assertEquals(result.getPath(), "/v1/globalStatement");
+        assertEquals(result.getPath(), "/api/v1/query");
     }
 
     /**
@@ -92,17 +92,17 @@ public class TestClpCustomPinotSplitProvider
         // Test with trailing slash
         config.setMetadataDbUrl("https://pinot-service.example.com/");
         URL result = (URL) method.invoke(splitProvider, config);
-        assertEquals(result.toString(), "https://pinot-service.example.com//v1/globalStatement");
+        assertEquals(result.toString(), "https://pinot-service.example.com//api/v1/query");
 
         // Test without protocol (should work as URL constructor handles it)
         config.setMetadataDbUrl("http://pinot-dev.example.com");
         result = (URL) method.invoke(splitProvider, config);
-        assertEquals(result.toString(), "http://pinot-dev.example.com/v1/globalStatement");
+        assertEquals(result.toString(), "http://pinot-dev.example.com/api/v1/query");
 
         // Test with port
         config.setMetadataDbUrl("https://pinot-service.example.com:8080");
         result = (URL) method.invoke(splitProvider, config);
-        assertEquals(result.toString(), "https://pinot-service.example.com:8080/v1/globalStatement");
+        assertEquals(result.toString(), "https://pinot-service.example.com:8080/api/v1/query");
     }
 
     /**
@@ -135,7 +135,7 @@ public class TestClpCustomPinotSplitProvider
 
         String result = splitProvider.inferMetadataTableName(tableHandle);
 
-        assertEquals(result, "rta.logging.logs");
+        assertEquals(result, "metadata.service.logs");
     }
 
     /**
@@ -148,17 +148,17 @@ public class TestClpCustomPinotSplitProvider
         // Test with default schema
         SchemaTableName schemaTableName1 = new SchemaTableName("default", "events");
         ClpTableHandle tableHandle1 = new ClpTableHandle(schemaTableName1, "test");
-        assertEquals(splitProvider.inferMetadataTableName(tableHandle1), "rta.logging.events");
+        assertEquals(splitProvider.inferMetadataTableName(tableHandle1), "metadata.service.events");
 
         // Test with production schema - should produce same result
         SchemaTableName schemaTableName2 = new SchemaTableName("production", "events");
         ClpTableHandle tableHandle2 = new ClpTableHandle(schemaTableName2, "test");
-        assertEquals(splitProvider.inferMetadataTableName(tableHandle2), "rta.logging.events");
+        assertEquals(splitProvider.inferMetadataTableName(tableHandle2), "metadata.service.events");
 
         // Test with staging schema
         SchemaTableName schemaTableName3 = new SchemaTableName("staging", "metrics");
         ClpTableHandle tableHandle3 = new ClpTableHandle(schemaTableName3, "test");
-        assertEquals(splitProvider.inferMetadataTableName(tableHandle3), "rta.logging.metrics");
+        assertEquals(splitProvider.inferMetadataTableName(tableHandle3), "metadata.service.metrics");
     }
 
     /**
@@ -170,17 +170,17 @@ public class TestClpCustomPinotSplitProvider
         // Test with underscore
         SchemaTableName schemaTableName1 = new SchemaTableName("default", "user_logs");
         ClpTableHandle tableHandle1 = new ClpTableHandle(schemaTableName1, "test");
-        assertEquals(splitProvider.inferMetadataTableName(tableHandle1), "rta.logging.user_logs");
+        assertEquals(splitProvider.inferMetadataTableName(tableHandle1), "metadata.service.user_logs");
 
         // Test with hyphen
         SchemaTableName schemaTableName2 = new SchemaTableName("default", "app-logs");
         ClpTableHandle tableHandle2 = new ClpTableHandle(schemaTableName2, "test");
-        assertEquals(splitProvider.inferMetadataTableName(tableHandle2), "rta.logging.app-logs");
+        assertEquals(splitProvider.inferMetadataTableName(tableHandle2), "metadata.service.app-logs");
 
         // Test with numbers
         SchemaTableName schemaTableName3 = new SchemaTableName("default", "logs2024");
         ClpTableHandle tableHandle3 = new ClpTableHandle(schemaTableName3, "test");
-        assertEquals(splitProvider.inferMetadataTableName(tableHandle3), "rta.logging.logs2024");
+        assertEquals(splitProvider.inferMetadataTableName(tableHandle3), "metadata.service.logs2024");
     }
 
     /**
@@ -216,27 +216,27 @@ public class TestClpCustomPinotSplitProvider
         // Test case 1: No metadata projection (empty list)
         List<String> emptyColumns = new ArrayList<>();
         String queryNoMetadata = splitProvider.buildSplitSelectionQuery(
-                "rta.logging.logs", emptyColumns, "1 = 1");
+                "metadata.service.logs", emptyColumns, "1 = 1");
         assertEquals(queryNoMetadata,
-                "SELECT tpath  FROM rta.logging.logs WHERE 1 = 1 AND (1 = 1) GROUP BY tpath LIMIT 999999");
+                "SELECT tpath  FROM metadata.service.logs WHERE 1 = 1 AND (1 = 1) GROUP BY tpath LIMIT 999999");
 
         // Test case 2: Metadata projection with tpath (tpath should be skipped)
         List<String> columnsWithTpath = new ArrayList<>();
         columnsWithTpath.add("tpath");
         columnsWithTpath.add("hostname");
         String queryWithTpath = splitProvider.buildSplitSelectionQuery(
-                "rta.logging.logs", columnsWithTpath, "creationtime > 1000");
+                "metadata.service.logs", columnsWithTpath, "creationtime > 1000");
         assertEquals(queryWithTpath,
-                "SELECT tpath , LASTWITHTIME(hostname, \"_timestampMillis\", 'string') AS hostname FROM rta.logging.logs WHERE 1 = 1 AND (creationtime > 1000) GROUP BY tpath LIMIT 999999");
+                "SELECT tpath , LASTWITHTIME(hostname, \"_timestampMillis\", 'string') AS hostname FROM metadata.service.logs WHERE 1 = 1 AND (creationtime > 1000) GROUP BY tpath LIMIT 999999");
 
         // Test case 3: Projection with repeated column (duplicates should be removed)
         List<String> columnsWithDuplicate = new ArrayList<>();
         columnsWithDuplicate.add("hostname");
         columnsWithDuplicate.add("hostname");
         String queryWithDuplicate = splitProvider.buildSplitSelectionQuery(
-                "rta.logging.logs", columnsWithDuplicate, "1 = 1");
+                "metadata.service.logs", columnsWithDuplicate, "1 = 1");
         assertEquals(queryWithDuplicate,
-                "SELECT tpath , LASTWITHTIME(hostname, \"_timestampMillis\", 'string') AS hostname FROM rta.logging.logs WHERE 1 = 1 AND (1 = 1) GROUP BY tpath LIMIT 999999");
+                "SELECT tpath , LASTWITHTIME(hostname, \"_timestampMillis\", 'string') AS hostname FROM metadata.service.logs WHERE 1 = 1 AND (1 = 1) GROUP BY tpath LIMIT 999999");
     }
 
     /**
@@ -420,7 +420,7 @@ public class TestClpCustomPinotSplitProvider
             ClpConfig mockConfig = new ClpConfig();
             mockConfig.setMetadataDbUrl(mockDb.getUrl());
             mockConfig.setSplitProviderType(ClpConfig.SplitProviderType.PINOT_CUSTOM);
-            mockConfig.setCustomApiEndpointPath("/v1/globalStatement");
+            mockConfig.setCustomApiEndpointPath("/api/v1/query");
 
             ClpCustomPinotSplitProvider mockSplitProvider = new ClpCustomPinotSplitProvider(
                     mockConfig,

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/split/TestClpCustomPinotSplitProvider.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/split/TestClpCustomPinotSplitProvider.java
@@ -36,24 +36,25 @@ import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 /**
- * Unit tests for ClpUberPinotSplitProvider.
- * Tests Uber-specific customizations including Neutrino endpoint URL construction
- * and RTA table name prefixing.
+ * Unit tests for ClpCustomPinotSplitProvider.
  */
 @Test(singleThreaded = true)
-public class TestClpUberPinotSplitProvider
+public class TestClpCustomPinotSplitProvider
         extends TestClpQueryBase
 {
-    private ClpUberPinotSplitProvider splitProvider;
+    private ClpCustomPinotSplitProvider splitProvider;
     private ClpConfig config;
 
     @BeforeMethod
     public void setUp()
     {
         config = new ClpConfig();
-        config.setMetadataDbUrl("https://neutrino.uber.com");
-        config.setSplitProviderType(ClpConfig.SplitProviderType.PINOT_UBER);
-        splitProvider = new ClpUberPinotSplitProvider(
+        config.setMetadataDbUrl("https://pinot-service.example.com");
+        config.setSplitProviderType(ClpConfig.SplitProviderType.PINOT_CUSTOM);
+        config.setCustomTableNamePrefix("rta.logging");
+        config.setCustomApiEndpointPath("/v1/globalStatement");
+        config.setCustomHttpHeaders("RPC-Service:test-service,RPC-Caller:test-caller,Content-Type:text/plain");
+        splitProvider = new ClpCustomPinotSplitProvider(
                 config,
                 functionAndTypeManager,
                 standardFunctionResolution,
@@ -61,21 +62,21 @@ public class TestClpUberPinotSplitProvider
     }
 
     /**
-     * Test that the Neutrino endpoint URL is correctly constructed.
+     * Test that the custom endpoint URL is correctly constructed.
      */
     @Test
     public void testBuildPinotSqlQueryEndpointUrl() throws Exception
     {
         // Use reflection to access the protected method
-        Method method = ClpUberPinotSplitProvider.class.getDeclaredMethod("buildPinotSqlQueryEndpointUrl", ClpConfig.class);
+        Method method = ClpCustomPinotSplitProvider.class.getDeclaredMethod("buildPinotSqlQueryEndpointUrl", ClpConfig.class);
         method.setAccessible(true);
 
         URL result = (URL) method.invoke(splitProvider, config);
 
         assertNotNull(result);
-        assertEquals(result.toString(), "https://neutrino.uber.com/v1/globalStatement");
+        assertEquals(result.toString(), "https://pinot-service.example.com/v1/globalStatement");
         assertEquals(result.getProtocol(), "https");
-        assertEquals(result.getHost(), "neutrino.uber.com");
+        assertEquals(result.getHost(), "pinot-service.example.com");
         assertEquals(result.getPath(), "/v1/globalStatement");
     }
 
@@ -85,23 +86,23 @@ public class TestClpUberPinotSplitProvider
     @Test
     public void testBuildPinotSqlQueryEndpointUrlVariations() throws Exception
     {
-        Method method = ClpUberPinotSplitProvider.class.getDeclaredMethod("buildPinotSqlQueryEndpointUrl", ClpConfig.class);
+        Method method = ClpCustomPinotSplitProvider.class.getDeclaredMethod("buildPinotSqlQueryEndpointUrl", ClpConfig.class);
         method.setAccessible(true);
 
         // Test with trailing slash
-        config.setMetadataDbUrl("https://neutrino.uber.com/");
+        config.setMetadataDbUrl("https://pinot-service.example.com/");
         URL result = (URL) method.invoke(splitProvider, config);
-        assertEquals(result.toString(), "https://neutrino.uber.com//v1/globalStatement");
+        assertEquals(result.toString(), "https://pinot-service.example.com//v1/globalStatement");
 
         // Test without protocol (should work as URL constructor handles it)
-        config.setMetadataDbUrl("http://neutrino-dev.uber.com");
+        config.setMetadataDbUrl("http://pinot-dev.example.com");
         result = (URL) method.invoke(splitProvider, config);
-        assertEquals(result.toString(), "http://neutrino-dev.uber.com/v1/globalStatement");
+        assertEquals(result.toString(), "http://pinot-dev.example.com/v1/globalStatement");
 
         // Test with port
-        config.setMetadataDbUrl("https://neutrino.uber.com:8080");
+        config.setMetadataDbUrl("https://pinot-service.example.com:8080");
         result = (URL) method.invoke(splitProvider, config);
-        assertEquals(result.toString(), "https://neutrino.uber.com:8080/v1/globalStatement");
+        assertEquals(result.toString(), "https://pinot-service.example.com:8080/v1/globalStatement");
     }
 
     /**
@@ -110,7 +111,7 @@ public class TestClpUberPinotSplitProvider
     @Test
     public void testBuildPinotSqlQueryEndpointUrlInvalid() throws Exception
     {
-        Method method = ClpUberPinotSplitProvider.class.getDeclaredMethod("buildPinotSqlQueryEndpointUrl", ClpConfig.class);
+        Method method = ClpCustomPinotSplitProvider.class.getDeclaredMethod("buildPinotSqlQueryEndpointUrl", ClpConfig.class);
         method.setAccessible(true);
 
         config.setMetadataDbUrl("not a valid url");
@@ -124,10 +125,10 @@ public class TestClpUberPinotSplitProvider
     }
 
     /**
-     * Test that table names are correctly prefixed with "rta.logging."
+     * Test that table names are correctly prefixed when prefix is configured.
      */
     @Test
-    public void testInferMetadataTableName()
+    public void testInferMetadataTableNameWithPrefix()
     {
         SchemaTableName schemaTableName = new SchemaTableName("default", "logs");
         ClpTableHandle tableHandle = new ClpTableHandle(schemaTableName, "test");
@@ -193,19 +194,6 @@ public class TestClpUberPinotSplitProvider
     }
 
     /**
-     * Test the factory method for building Uber table names.
-     */
-    @Test
-    public void testBuildUberTableName()
-    {
-        assertEquals(splitProvider.buildUberTableName("logs"), "rta.logging.logs");
-        assertEquals(splitProvider.buildUberTableName("events"), "rta.logging.events");
-        assertEquals(splitProvider.buildUberTableName("metrics"), "rta.logging.metrics");
-        assertEquals(splitProvider.buildUberTableName("user_activity"), "rta.logging.user_activity");
-        assertEquals(splitProvider.buildUberTableName("app-logs"), "rta.logging.app-logs");
-    }
-
-    /**
      * Test that the split provider is correctly instantiated with configuration.
      */
     @Test
@@ -252,25 +240,41 @@ public class TestClpUberPinotSplitProvider
     }
 
     /**
-     * Test configuration with different split provider types.
+     * Test that custom HTTP headers are correctly parsed from configuration.
      */
     @Test
-    public void testConfigurationTypes()
+    public void testCustomHttpHeadersParsing()
     {
-        // Test that the configuration is set correctly
-        assertEquals(config.getSplitProviderType(), ClpConfig.SplitProviderType.PINOT_UBER);
+        // Verify headers from setUp() are parsed correctly
+        Map<String, String> headers = config.getCustomHttpHeaders();
+        assertEquals(headers.size(), 3);
+        assertEquals(headers.get("RPC-Service"), "test-service");
+        assertEquals(headers.get("RPC-Caller"), "test-caller");
+        assertEquals(headers.get("Content-Type"), "text/plain");
 
-        // Create a new instance with different config to ensure isolation
-        ClpConfig newConfig = new ClpConfig();
-        newConfig.setMetadataDbUrl("https://other-neutrino.uber.com");
-        newConfig.setSplitProviderType(ClpConfig.SplitProviderType.PINOT_UBER);
+        // Test with different header configurations
+        ClpConfig testConfig = new ClpConfig();
 
-        ClpUberPinotSplitProvider newProvider = new ClpUberPinotSplitProvider(
-                newConfig,
-                functionAndTypeManager,
-                standardFunctionResolution,
-                new ClpSplitMetadataConfig(newConfig, functionAndTypeManager));
-        assertNotNull(newProvider);
+        // Test single header
+        testConfig.setCustomHttpHeaders("Authorization:Bearer token123");
+        Map<String, String> singleHeader = testConfig.getCustomHttpHeaders();
+        assertEquals(singleHeader.size(), 1);
+        assertEquals(singleHeader.get("Authorization"), "Bearer token123");
+
+        // Test headers with spaces around separators
+        testConfig.setCustomHttpHeaders("Header1:Value1 , Header2:Value2");
+        Map<String, String> spacedHeaders = testConfig.getCustomHttpHeaders();
+        assertEquals(spacedHeaders.size(), 2);
+        assertEquals(spacedHeaders.get("Header1"), "Value1");
+        assertEquals(spacedHeaders.get("Header2"), "Value2");
+
+        // Test empty headers
+        testConfig.setCustomHttpHeaders("");
+        assertTrue(testConfig.getCustomHttpHeaders().isEmpty());
+
+        // Test null headers
+        testConfig.setCustomHttpHeaders(null);
+        assertTrue(testConfig.getCustomHttpHeaders().isEmpty());
     }
 
     /**
@@ -279,29 +283,20 @@ public class TestClpUberPinotSplitProvider
     @Test
     public void testBuildFullSplitPath() throws Exception
     {
-        // Create a config with Terrablob storage base URL configured
-        ClpConfig testConfig = new ClpConfig();
-        testConfig.setMetadataDbUrl("https://neutrino.uber.com");
-        testConfig.setSplitProviderType(ClpConfig.SplitProviderType.PINOT_UBER);
-        testConfig.setUberTerrablobStorageBaseUrl("http://localhost:19617");
+        // Set custom storage base URL on existing config
+        config.setCustomStorageBaseUrl("http://localhost:19617");
 
-        ClpUberPinotSplitProvider testProvider = new ClpUberPinotSplitProvider(
-                testConfig,
-                functionAndTypeManager,
-                standardFunctionResolution,
-                new ClpSplitMetadataConfig(testConfig, functionAndTypeManager));
-
-        Method method = ClpUberPinotSplitProvider.class.getDeclaredMethod("buildFullSplitPath", String.class);
+        Method method = ClpCustomPinotSplitProvider.class.getDeclaredMethod("buildFullSplitPath", String.class);
         method.setAccessible(true);
 
         // Test with a typical relative path
-        String result = (String) method.invoke(testProvider, "/data/archives/table1/ir001.clp.zst");
+        String result = (String) method.invoke(splitProvider, "/data/archives/table1/ir001.clp.zst");
         assertEquals(result, "http://localhost:19617/data/archives/table1/ir001.clp.zst");
 
         // Test with base URL without explicit port (should omit port in result)
-        testConfig.setUberTerrablobStorageBaseUrl("http://terrablob.uber.com");
-        result = (String) method.invoke(testProvider, "/ir.clp.zst");
-        assertEquals(result, "http://terrablob.uber.com/ir.clp.zst");
+        config.setCustomStorageBaseUrl("http://storage.example.com");
+        result = (String) method.invoke(splitProvider, "/ir.clp.zst");
+        assertEquals(result, "http://storage.example.com/ir.clp.zst");
     }
 
     /**
@@ -310,29 +305,29 @@ public class TestClpUberPinotSplitProvider
     @Test
     public void testBuildFullSplitPathMissingConfig() throws Exception
     {
-        Method method = ClpUberPinotSplitProvider.class.getDeclaredMethod("buildFullSplitPath", String.class);
+        Method method = ClpCustomPinotSplitProvider.class.getDeclaredMethod("buildFullSplitPath", String.class);
         method.setAccessible(true);
 
-        // config from setUp() does not have Terrablob URL configured
+        // config from setUp() does not have custom storage URL configured
         try {
             method.invoke(splitProvider, "/some/path");
-            fail("Expected IllegalArgumentException for missing Terrablob storage base URL");
+            fail("Expected IllegalArgumentException for missing custom storage base URL");
         }
         catch (Exception e) {
             assertTrue(e.getCause() instanceof IllegalArgumentException);
-            assertTrue(e.getCause().getMessage().contains("clp.uber-terrablob-storage-base-url"));
+            assertTrue(e.getCause().getMessage().contains("clp.custom-metadata-storage-base-url"));
         }
     }
 
     /**
-     * Test parsing of Uber Neutrino query response format.
+     * Test parsing of custom query response format.
      * Verifies that the JSON response with "columns" and "data" fields is correctly
      * parsed into a list of row maps.
      */
     @Test
     public void testParseQueryResponse() throws Exception
     {
-        // Sample JSON in Uber Neutrino response format
+        // Sample JSON in custom response format
         String jsonResponse = String.join("\n",
                 "{",
                 "  'id': '12345',",
@@ -424,9 +419,10 @@ public class TestClpUberPinotSplitProvider
         try {
             ClpConfig mockConfig = new ClpConfig();
             mockConfig.setMetadataDbUrl(mockDb.getUrl());
-            mockConfig.setSplitProviderType(ClpConfig.SplitProviderType.PINOT_UBER);
+            mockConfig.setSplitProviderType(ClpConfig.SplitProviderType.PINOT_CUSTOM);
+            mockConfig.setCustomApiEndpointPath("/v1/globalStatement");
 
-            ClpUberPinotSplitProvider mockSplitProvider = new ClpUberPinotSplitProvider(
+            ClpCustomPinotSplitProvider mockSplitProvider = new ClpCustomPinotSplitProvider(
                     mockConfig,
                     functionAndTypeManager,
                     standardFunctionResolution,


### PR DESCRIPTION
- Renamed customer-specific classes and removed proprietary terminology from the CLP Pinot split provider to prepare for open-source release
- Made hardcoded configuration values provided by the customer configurable via properties file
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

  ### New Configuration Parameters
  | Parameter | Description |
  |-----------|-------------|
  | `clp.custom-metadata-storage-base-url` | Base URL for the storage service |
  | `clp.custom-metadata-http-headers` | Comma-separated `key:value` pairs for HTTP headers |
  | `clp.custom-metadata-table-name-prefix` | Prefix for Pinot table names |
  | `clp.custom-metadata-api-endpoint-path` | API endpoint path |

  ### Example Configuration
  ```properties
  clp.split-provider-type=pinot_custom
  clp.custom-metadata-storage-base-url=http://storage.example.com:19617
  clp.custom-metadata-table-name-prefix=table.prefix
  clp.custom-metadata-api-endpoint-path=/query/sql
  clp.custom-metadata-http-headers=RPC-Service:my-service,RPC-Caller:my-connector,Content-Type:text/plain,Accept:text/plain
```

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [ ] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [ ] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [ ] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
