### PR TITLE
Fix: Support for empty asRangeBoundOf field in range mapped metadata column

### DIFF
--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpFilterToKqlConverter.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpFilterToKqlConverter.java
@@ -156,7 +156,7 @@ public class ClpFilterToKqlConverter
      */
     private Map.Entry<String, Type> resolveExposedRangeBoundVariableAndType(String variableName, Type variableType)
     {
-        Map<String, String> exposedToRangeMapping = metadataConfig.getExposedToRangeWithDataBoundMapping(schemaTableName);
+        Map<String, String> exposedToRangeMapping = metadataConfig.getExposedToRangeMapping(schemaTableName);
         if (exposedToRangeMapping.containsKey(variableName)) {
             // Resolve to the actual data column name and retrieve its type from the table schema
             String dataColumnName = exposedToRangeMapping.get(variableName);
@@ -321,7 +321,7 @@ public class ClpFilterToKqlConverter
         boolean isMetadataColumn =
                 metadataConfig.getMetadataColumns(schemaTableName).keySet().contains(variable);
         boolean isExposedWithRangeBounds =
-                metadataConfig.getExposedToRangeWithDataBoundMapping(schemaTableName).containsKey(variable);
+                metadataConfig.getExposedToRangeMapping(schemaTableName).containsKey(variable);
 
         // Metadata columns must have constant bounds
         if (isMetadataColumn &&
@@ -579,7 +579,7 @@ public class ClpFilterToKqlConverter
     {
         boolean isMetadataColumn = metadataConfig.getMetadataColumns(schemaTableName).keySet().contains(variableName);
         boolean isExposedWithRangeBounds =
-                metadataConfig.getExposedToRangeWithDataBoundMapping(schemaTableName).containsKey(variableName);
+                metadataConfig.getExposedToRangeMapping(schemaTableName).containsKey(variableName);
 
         // split pruning
         CallExpression metadataExpression = null;

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpFilterToKqlConverter.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/optimization/ClpFilterToKqlConverter.java
@@ -156,7 +156,7 @@ public class ClpFilterToKqlConverter
      */
     private Map.Entry<String, Type> resolveExposedRangeBoundVariableAndType(String variableName, Type variableType)
     {
-        Map<String, String> exposedToRangeMapping = metadataConfig.getExposedToRangeMapping(schemaTableName);
+        Map<String, String> exposedToRangeMapping = metadataConfig.getExposedToRangeWithDataBoundMapping(schemaTableName);
         if (exposedToRangeMapping.containsKey(variableName)) {
             // Resolve to the actual data column name and retrieve its type from the table schema
             String dataColumnName = exposedToRangeMapping.get(variableName);
@@ -321,7 +321,7 @@ public class ClpFilterToKqlConverter
         boolean isMetadataColumn =
                 metadataConfig.getMetadataColumns(schemaTableName).keySet().contains(variable);
         boolean isExposedWithRangeBounds =
-                metadataConfig.getExposedToRangeMapping(schemaTableName).containsKey(variable);
+                metadataConfig.getExposedToRangeWithDataBoundMapping(schemaTableName).containsKey(variable);
 
         // Metadata columns must have constant bounds
         if (isMetadataColumn &&
@@ -579,7 +579,7 @@ public class ClpFilterToKqlConverter
     {
         boolean isMetadataColumn = metadataConfig.getMetadataColumns(schemaTableName).keySet().contains(variableName);
         boolean isExposedWithRangeBounds =
-                metadataConfig.getExposedToRangeMapping(schemaTableName).containsKey(variableName);
+                metadataConfig.getExposedToRangeWithDataBoundMapping(schemaTableName).containsKey(variableName);
 
         // split pruning
         CallExpression metadataExpression = null;

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpMySqlSplitMetadataExpressionConverter.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpMySqlSplitMetadataExpressionConverter.java
@@ -188,13 +188,10 @@ public class ClpMySqlSplitMetadataExpressionConverter
         String exposed = node.getName();
         seenRequired.add(exposed);
 
-        Map<String, String> exposedToRangeMapping = metadataConfig.getExposedToRangeMapping(schemaTableName);
-        String rangeMapped = exposedToRangeMapping.get(exposed);
-
         Map<String, String> exposedToOriginal = metadataConfig.getExposedToOriginalMapping(schemaTableName);
         String originalName = exposedToOriginal.getOrDefault(exposed, exposed);
 
-        return rangeMapped != null ? rangeMapped : originalName;
+        return metadataConfig.getExposedColumnsWithRangeBounds(schemaTableName).contains(exposed) ? exposed : originalName;
     }
 
     /**
@@ -246,7 +243,7 @@ public class ClpMySqlSplitMetadataExpressionConverter
      */
     protected String rewriteComparisonWithBounds(String variableName, OperatorType operator, String literal)
     {
-        Map<String, Map<String, String>> dataToMetadataBounds = metadataConfig.getDataColumnRangeMapping(schemaTableName);
+        Map<String, Map<String, String>> dataToMetadataBounds = metadataConfig.getExposedColumnRangeBoundsMapping(schemaTableName);
         Map<String, String> bounds = dataToMetadataBounds.get(variableName);
         if (bounds == null) {
             return null;

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpSplitMetadataConfig.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpSplitMetadataConfig.java
@@ -242,6 +242,28 @@ public class ClpSplitMetadataConfig
     }
 
     /**
+     * Returns a mapping from exposed column names to their associated range bound metadata columns.
+     * <p>
+     * Each entry maps an exposed column name to another map with keys {@code "lower"} and/or
+     * {@code "upper"}, representing the metadata column names that define those bounds.
+     *
+     * @param name the {@link SchemaTableName} of the target table
+     * @return a nested mapping from exposed column name → ("lower"/"upper" → metadata column name)
+     */
+    public Map<String, Map<String, String>> getExposedColumnRangeBoundsMapping(SchemaTableName name)
+    {
+        TableConfig cfg = getTableConfig(name);
+        Map<String, Map<String, String>> mapping = new HashMap<>();
+        for (MetaColumn c : cfg.metaColumns.values()) {
+            if (c.asRangeBoundOf != null || c.boundType != null) {
+                mapping.computeIfAbsent(c.exposedAs, k -> new HashMap<>())
+                        .put(c.boundType, c.name);
+            }
+        }
+        return mapping;
+    }
+
+    /**
      * @param name the {@link SchemaTableName} of the target table
      * @return a set of metadata column names that are used as range bounds
      */
@@ -261,7 +283,7 @@ public class ClpSplitMetadataConfig
      * @param name the {@link SchemaTableName} of the target table
      * @return a map from exposed column name → range bound data column name
      */
-    public Map<String, String> getExposedToRangeMapping(SchemaTableName name)
+    public Map<String, String> getExposedToRangeWithDataBoundMapping(SchemaTableName name)
     {
         TableConfig cfg = getTableConfig(name);
         Map<String, String> mapping = new HashMap<>();
@@ -271,6 +293,22 @@ public class ClpSplitMetadataConfig
             }
         }
         return mapping;
+    }
+
+    /**
+     * @param name the {@link SchemaTableName} of the target table
+     * @return a set of exposed column names that have range bounds configured
+     */
+    public Set<String> getExposedColumnsWithRangeBounds(SchemaTableName name)
+    {
+        TableConfig cfg = getTableConfig(name);
+        Set<String> result = new LinkedHashSet<>();
+        for (MetaColumn c : cfg.metaColumns.values()) {
+            if (c.asRangeBoundOf != null || c.boundType != null) {
+                result.add(c.exposedAs);
+            }
+        }
+        return result;
     }
 
     /**

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpSplitMetadataConfig.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/split/ClpSplitMetadataConfig.java
@@ -283,7 +283,7 @@ public class ClpSplitMetadataConfig
      * @param name the {@link SchemaTableName} of the target table
      * @return a map from exposed column name → range bound data column name
      */
-    public Map<String, String> getExposedToRangeWithDataBoundMapping(SchemaTableName name)
+    public Map<String, String> getExposedToRangeMapping(SchemaTableName name)
     {
         TableConfig cfg = getTableConfig(name);
         Map<String, String> mapping = new HashMap<>();

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/optimization/TestClpFilterToKql.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/optimization/TestClpFilterToKql.java
@@ -548,7 +548,7 @@ public class TestClpFilterToKql
                 .thenReturn(metadataColumnsMap);
         when(mockMetadataConfig.getDataColumnsWithRangeBounds(any(SchemaTableName.class)))
                 .thenReturn(dataColumnsWithRangeBounds);
-        when(mockMetadataConfig.getExposedToRangeMapping(any(SchemaTableName.class)))
+        when(mockMetadataConfig.getExposedToRangeWithDataBoundMapping(any(SchemaTableName.class)))
                 .thenReturn(exposedToRangeMapping);
 
         return pushDownExpression.accept(

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/optimization/TestClpFilterToKql.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/optimization/TestClpFilterToKql.java
@@ -414,6 +414,32 @@ public class TestClpFilterToKql
     }
 
     @Test
+    public void testNoRangeBoundMapping()
+    {
+        SessionHolder sessionHolder = new SessionHolder();
+
+        // Empty mappings - no range bound resolution should occur, no data push down using exposed name
+        Set<String> dataColumnsWithRangeBounds = ImmutableSet.of();
+        Map<String, String> exposedToRangeMapping = ImmutableMap.of();
+
+        testPushDownWithExposedRangeBound(
+                sessionHolder,
+                "timestampExposed >= '100'",
+                null,
+                null,
+                dataColumnsWithRangeBounds,
+                exposedToRangeMapping);
+
+        testPushDownWithExposedRangeBound(
+                sessionHolder,
+                "timestampExposed >= '100' AND valueExposed < 200",
+                null,
+                null,
+                dataColumnsWithRangeBounds,
+                exposedToRangeMapping);
+    }
+
+    @Test
     public void testClpWildcardUdf()
     {
         SessionHolder sessionHolder = new SessionHolder();
@@ -548,7 +574,7 @@ public class TestClpFilterToKql
                 .thenReturn(metadataColumnsMap);
         when(mockMetadataConfig.getDataColumnsWithRangeBounds(any(SchemaTableName.class)))
                 .thenReturn(dataColumnsWithRangeBounds);
-        when(mockMetadataConfig.getExposedToRangeWithDataBoundMapping(any(SchemaTableName.class)))
+        when(mockMetadataConfig.getExposedToRangeMapping(any(SchemaTableName.class)))
                 .thenReturn(exposedToRangeMapping);
 
         return pushDownExpression.accept(

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/split/TestClpSplitMetadataConfig.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/split/TestClpSplitMetadataConfig.java
@@ -94,8 +94,7 @@ public class TestClpSplitMetadataConfig
         assertEquals(columns, ImmutableMap.of(
                 "level", BIGINT,
                 "author", VARCHAR,
-                "begin_timestamp", BIGINT,
-                "end_timestamp", BIGINT,
+                "msg.timestamp", BIGINT,
                 "file_name", VARCHAR));
         Set<String> dataColumnsWithRangeBounds =
                 splitMetadataConfig.getDataColumnsWithRangeBounds(new SchemaTableName("default", "table_1"));

--- a/presto-clp/src/test/resources/test-mysql-split-metadata.json
+++ b/presto-clp/src/test/resources/test-mysql-split-metadata.json
@@ -20,14 +20,16 @@
         "filter": {
           "asRangeBoundOf": "msg.timestamp",
           "boundType": "lower"
-        }
+        },
+        "exposedAs": "msg.timestamp"
       },
       "end_timestamp": {
         "type": "BIGINT",
         "filter": {
           "asRangeBoundOf": "msg.timestamp",
           "boundType": "upper"
-        }
+        },
+        "exposedAs": "msg.timestamp"
       },
       "file_name": {
         "type": "VARCHAR"

--- a/presto-clp/src/test/resources/test-pinot-split-metadata.json
+++ b/presto-clp/src/test/resources/test-pinot-split-metadata.json
@@ -20,14 +20,16 @@
         "filter": {
           "asRangeBoundOf": "msg.timestamp",
           "boundType": "lower"
-        }
+        },
+        "exposedAs": "msg.timestamp"
       },
       "end_timestamp": {
         "type": "BIGINT",
         "filter": {
           "asRangeBoundOf": "msg.timestamp",
           "boundType": "upper"
-        }
+        },
+        "exposedAs": "msg.timestamp"
       },
       "status_code": {
         "type": "BIGINT"


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->



# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [ ] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [ ] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [ ] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
