### PR TITLE
fix: Restore presto-clp plugin in provisio for packaging the clp connector in the distributed tarball.

### DIFF
--- a/presto-server/src/main/provisio/presto.xml
+++ b/presto-server/src/main/provisio/presto.xml
@@ -239,6 +239,12 @@
         </artifact>
     </artifactSet>
 
+    <artifactSet to="plugin/presto-clp">
+        <artifact id="${project.groupId}:presto-clp:zip:${project.version}">
+            <unpack />
+        </artifact>
+    </artifactSet>
+
     <artifactSet to="plugin/presto-druid">
         <artifact id="${project.groupId}:presto-druid:zip:${project.version}">
             <unpack />


### PR DESCRIPTION


<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

## Problem

The presto-clp connector entry was accidentally dropped from presto-server/src/main/provisio/presto.xml during the upstream 0.297-edge10 integration (commit 8ab0c60360). This caused the coordinator to crash on startup with:

```
  No factory for connector clp (java.lang.IllegalArgumentException)
    at com.facebook.presto.metadata.StaticCatalogStore.loadCatalog
    at com.facebook.presto.server.PrestoServer.run
```
## Root cause

The build pipeline has three stages:

1. Maven compile — builds presto-clp jar file
2. Provisio assembly — reads presto-server/src/main/provisio/presto.xml to package all required jar files into presto-server-0.297-edge10.1-SNAPSHOT.tar.gz
3. Docker build — untars the tarball into /opt/presto-server/

The presto-clp jar file was still being compiled (step 1), but the missing presto.xml entry meant provisio never picked it up (step 2). The root cause is presto-server-0.297-edge10.1-SNAPSHOT.tar.gz misses presto-clp jar file.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

Validated locally by simulating the full pipeline end-to-end:

  1. Confirmed the existing presto-server-0.297-edge10.1-SNAPSHOT.tar.gz (built before this fix) had no plugin/presto-clp/ directory.
  2. Manually injected the built presto-clp-0.297-edge10.1-SNAPSHOT.zip into the tarball at plugin/presto-clp, mirroring exactly what provisio will produce after this fix.
  3. Built the coordinator Docker image from that patched tarball — equivalent to what CI's presto-coordinator-image job does.
  4. Verified the plugin is present in the image: find /opt/presto-server/plugin/presto-clp -name "*.jar" returns all expected JARs.
  5. Recreated the coordinator container from the new image and confirmed in logs:
    - Registering connector clp — plugin loaded successfully
    - Loading catalog clp — catalog initialized without error
    - SERVER STARTED — coordinator fully started, no crash
 
E2E Testing Infra:
  Built both Docker images locally from a branch combining the SIGSEGV fix (https://github.com/y-scope/presto/pull/151) and the CLP plugin packaging fix (this PR), using the same build steps and args as CI:

  1. Dependency image: Built from ubuntu-22.04-dependency.dockerfile
  2. Worker image: Built from prestissimo-runtime.dockerfile
  3. Coordinator image: Built from docker/Dockerfile using the Maven-produced presto-server-0.297-edge10.1-SNAPSHOT.tar.gz (verified presto-clp plugin is included in the tarball)

  E2E Test

  Started coordinator and worker containers using the locally built images with the existing docker-compose.yaml deployment configuration.

The below query returns expected result
```
 SELECT timestamp, CLP_GET_JSON_STRING()
  FROM clp.default.default
  WHERE "timestamp" >= TIMESTAMP '2023-03-27 00:41:39.863'
  LIMIT 100
```



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Presto server now includes the presto-clp plugin, automatically unpacked and available during server startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->