### PR TITLE
fix: Switch worker image build from GCC to Clang-17

### DIFF
--- a/presto-native-execution/scripts/dockerfiles/prestissimo-runtime.dockerfile
+++ b/presto-native-execution/scripts/dockerfiles/prestissimo-runtime.dockerfile
@@ -28,7 +28,9 @@ RUN mkdir -p /prestissimo /runtime-libraries
 COPY . /prestissimo/
 RUN --mount=type=cache,target=/root/.ccache,sharing=locked \
     /bin/bash -c 'if [[ "${EXTRA_CMAKE_FLAGS}" =~ -DPRESTO_ENABLE_CUDF=ON ]]; then unset CC; unset CXX; source /opt/rh/gcc-toolset-14/enable; fi && \
-    EXTRA_CMAKE_FLAGS=${EXTRA_CMAKE_FLAGS} \
+    export CC=/usr/bin/clang-17 && \
+    export CXX=/usr/bin/clang++-17 && \
+    EXTRA_CMAKE_FLAGS="${EXTRA_CMAKE_FLAGS} -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld-17 -DCMAKE_SHARED_LINKER_FLAGS=-fuse-ld=lld-17" \
     NUM_THREADS=${NUM_THREADS} make --directory="/prestissimo/" cmake-and-build BUILD_TYPE=${BUILD_TYPE} BUILD_DIR=${BUILD_DIR} BUILD_BASE_DIR=${BUILD_BASE_DIR} && \
     ccache -sz -v'
 RUN !(LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib:/usr/local/lib64 ldd /prestissimo/${BUILD_BASE_DIR}/${BUILD_DIR}/presto_cpp/main/presto_server  | grep "not found") && \

--- a/presto-native-execution/scripts/dockerfiles/ubuntu-22.04-dependency.dockerfile
+++ b/presto-native-execution/scripts/dockerfiles/ubuntu-22.04-dependency.dockerfile
@@ -43,3 +43,9 @@ RUN mkdir build && \
                  ../velox/scripts/setup-ubuntu.sh install_adapters && \
                  ../scripts/setup-adapters.sh ) && \
     rm -rf build
+
+# Install clang-17 and lld-17 to avoid GCC codegen bugs with proxygen in
+# release builds. See: https://github.com/prestodb/presto/issues/22995
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    clang-17 lld-17 && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION


<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

GCC (all tested versions: 11, 13) generates incorrect code in Release mode (-O3) for proxygen's HTTP session/transport handling, causing SIGSEGV at address 0x0 during worker-to-coordinator announcement.

The crash occurs in ResponseHandler::setTransaction() when calling txn_->getTransport().getCodec().getProtocol(). This is the same class of bug as prestodb/presto#22995, which was partially fixed upstream (PR #23531) but only for the createTransaction() code path.

Clang does not exhibit this codegen issue, which is why Meta/Facebook (who use Clang internally) never encountered it. The upstream CI e2e tests also pass because they build with GCC 12 on CentOS, which happens to not trigger this specific bug.

Changes:
- Install clang-17 and lld-17 in the Ubuntu dependency image
- Set CC/CXX to clang-17 and use lld-17 linker in the runtime image build step


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [ ] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [ ] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [ ] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build environment configurations to use clang-17 compiler and lld-17 linker with optimized linker flags across container images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->