### PR TITLE
fix: Guard getTransport() call in setTransaction for GCC.

### DIFF
--- a/presto-native-execution/presto_cpp/main/http/HttpClient.cpp
+++ b/presto-native-execution/presto_cpp/main/http/HttpClient.cpp
@@ -213,7 +213,11 @@ class ResponseHandler : public proxygen::HTTPTransactionHandler {
 
   void setTransaction(proxygen::HTTPTransaction* txn) noexcept override {
     txn_ = CHECK_NOTNULL(txn);
+// Skip this check for GCC to prevent SIGSEGV as described in the issue:
+// https://github.com/prestodb/presto/issues/22995
+#if defined(__clang__)
     protocol_ = txn_->getTransport().getCodec().getProtocol();
+#endif
     // Track connection usage via sequence number:
     // - seqNo == 0: First request on this connection
     // - seqNo > 0: Connection is being reused for subsequent requests


### PR DESCRIPTION


<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->


See https://github.com/y-scope/presto/issues/152 for complete background.

GCC generates incorrect code in Release mode (-O3) for `txn_->getTransport().getCodec().getProtocol()` in setTransaction(), causing SIGSEGV at address 0x0 during worker-to-coordinator HTTP connection. This is the same class of bug as prestodb/presto#22995.

The existing fix (PR #23531) only guarded the createTransaction() code path. This applies the same #if defined(__clang__) pattern to the setTransaction() code path added in the 0.297 integration.

The protocol_ field is std::optional and only used for a VLOG(2) debug log in onHeadersComplete(), so skipping the assignment on GCC has **no functional impact**.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

E2E Testing Infra:
  Built both Docker images locally from a branch combining the SIGSEGV fix (this PR) and the CLP plugin packaging fix (https://github.com/y-scope/presto/pull/149), using the same build steps and args as CI:

  1. Dependency image: Built from ubuntu-22.04-dependency.dockerfile
  2. Worker image: Built from prestissimo-runtime.dockerfile
  3. Coordinator image: Built from docker/Dockerfile using the Maven-produced presto-server-0.297-edge10.1-SNAPSHOT.tar.gz (verified presto-clp plugin is included in the tarball)

  E2E Test

  Started coordinator and worker containers using the locally built images with the existing docker-compose.yaml deployment configuration.

The below query returns expected result
```
 SELECT timestamp, CLP_GET_JSON_STRING()
  FROM clp.default.default
  WHERE "timestamp" >= TIMESTAMP '2023-03-27 00:41:39.863'
  LIMIT 100
```



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced HTTP client stability and reliability by addressing critical issues in idle session management and protocol handling operations. These targeted improvements eliminate unexpected application crashes occurring during specific runtime scenarios. The enhancements ensure consistent, dependable performance across all execution environments, reducing failures in normal operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->