### PR TITLE
feat: Add binary serialization codecs for CLP connector

### DIFF
--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpConnector.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/ClpConnector.java
@@ -15,9 +15,12 @@ package com.facebook.presto.plugin.clp;
 
 import com.facebook.airlift.bootstrap.LifeCycleManager;
 import com.facebook.airlift.log.Logger;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.plugin.clp.codec.ClpCodecProvider;
 import com.facebook.presto.plugin.clp.optimization.ClpPlanOptimizerProvider;
 import com.facebook.presto.plugin.clp.split.filter.ClpSplitFilterProvider;
 import com.facebook.presto.spi.connector.Connector;
+import com.facebook.presto.spi.connector.ConnectorCodecProvider;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.connector.ConnectorPlanOptimizerProvider;
 import com.facebook.presto.spi.connector.ConnectorRecordSetProvider;
@@ -43,6 +46,7 @@ public class ClpConnector
     private final FunctionMetadataManager functionManager;
     private final StandardFunctionResolution functionResolution;
     private final ClpSplitFilterProvider splitFilterProvider;
+    private final TypeManager typeManager;
 
     @Inject
     public ClpConnector(
@@ -52,7 +56,8 @@ public class ClpConnector
             ClpSplitManager splitManager,
             FunctionMetadataManager functionManager,
             StandardFunctionResolution functionResolution,
-            ClpSplitFilterProvider splitFilterProvider)
+            ClpSplitFilterProvider splitFilterProvider,
+            TypeManager typeManager)
     {
         this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
         this.metadata = requireNonNull(metadata, "metadata is null");
@@ -61,6 +66,7 @@ public class ClpConnector
         this.functionManager = requireNonNull(functionManager, "functionManager is null");
         this.functionResolution = requireNonNull(functionResolution, "functionResolution is null");
         this.splitFilterProvider = requireNonNull(splitFilterProvider, "splitFilterProvider is null");
+        this.typeManager = requireNonNull(typeManager, "typeManager is null");
     }
 
     @Override
@@ -91,6 +97,12 @@ public class ClpConnector
     public ConnectorSplitManager getSplitManager()
     {
         return splitManager;
+    }
+
+    @Override
+    public ConnectorCodecProvider getConnectorCodecProvider()
+    {
+        return new ClpCodecProvider(typeManager);
     }
 
     @Override

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/codec/ClpCodecProvider.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/codec/ClpCodecProvider.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.clp.codec;
+
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorCodec;
+import com.facebook.presto.spi.ConnectorSplit;
+import com.facebook.presto.spi.ConnectorTableHandle;
+import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.facebook.presto.spi.connector.ConnectorCodecProvider;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class ClpCodecProvider
+        implements ConnectorCodecProvider
+{
+    private final ConnectorCodec<ConnectorSplit> splitCodec;
+    private final ConnectorCodec<ConnectorTransactionHandle> transactionHandleCodec;
+    private final ConnectorCodec<ConnectorTableLayoutHandle> tableLayoutHandleCodec;
+    private final ConnectorCodec<ConnectorTableHandle> tableHandleCodec;
+    private final ConnectorCodec<ColumnHandle> columnHandleCodec;
+
+    public ClpCodecProvider(TypeManager typeManager)
+    {
+        requireNonNull(typeManager, "typeManager is null");
+        this.splitCodec = new ClpSplitCodec();
+        this.transactionHandleCodec = new ClpTransactionHandleCodec();
+        this.tableLayoutHandleCodec = new ClpTableLayoutHandleCodec();
+        this.tableHandleCodec = new ClpTableHandleCodec();
+        this.columnHandleCodec = new ClpColumnHandleCodec(typeManager);
+    }
+
+    @Override
+    public Optional<ConnectorCodec<ConnectorSplit>> getConnectorSplitCodec()
+    {
+        return Optional.of(splitCodec);
+    }
+
+    @Override
+    public Optional<ConnectorCodec<ConnectorTransactionHandle>> getConnectorTransactionHandleCodec()
+    {
+        return Optional.of(transactionHandleCodec);
+    }
+
+    @Override
+    public Optional<ConnectorCodec<ConnectorTableLayoutHandle>> getConnectorTableLayoutHandleCodec()
+    {
+        return Optional.of(tableLayoutHandleCodec);
+    }
+
+    @Override
+    public Optional<ConnectorCodec<ConnectorTableHandle>> getConnectorTableHandleCodec()
+    {
+        return Optional.of(tableHandleCodec);
+    }
+
+    @Override
+    public Optional<ConnectorCodec<ColumnHandle>> getColumnHandleCodec()
+    {
+        return Optional.of(columnHandleCodec);
+    }
+}

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/codec/ClpColumnHandleCodec.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/codec/ClpColumnHandleCodec.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.clp.codec;
+
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.common.type.TypeSignature;
+import com.facebook.presto.plugin.clp.ClpColumnHandle;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorCodec;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+import static java.util.Objects.requireNonNull;
+
+public class ClpColumnHandleCodec
+        implements ConnectorCodec<ColumnHandle>
+{
+    private final TypeManager typeManager;
+
+    public ClpColumnHandleCodec(TypeManager typeManager)
+    {
+        this.typeManager = requireNonNull(typeManager, "typeManager is null");
+    }
+
+    @Override
+    public byte[] serialize(ColumnHandle value)
+    {
+        ClpColumnHandle handle = (ClpColumnHandle) value;
+        try (ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
+                DataOutputStream out = new DataOutputStream(byteOut)) {
+            out.writeUTF(handle.getColumnName());
+            out.writeUTF(handle.getOriginalColumnName());
+            out.writeUTF(handle.getColumnType().getTypeSignature().toString());
+            return byteOut.toByteArray();
+        }
+        catch (IOException e) {
+            throw new RuntimeException("Failed to serialize ClpColumnHandle", e);
+        }
+    }
+
+    @Override
+    public ColumnHandle deserialize(byte[] bytes)
+    {
+        try (ByteArrayInputStream byteIn = new ByteArrayInputStream(bytes);
+                DataInputStream in = new DataInputStream(byteIn)) {
+            String columnName = in.readUTF();
+            String originalColumnName = in.readUTF();
+            String typeSignatureString = in.readUTF();
+            TypeSignature typeSignature = TypeSignature.parseTypeSignature(typeSignatureString);
+            Type type = typeManager.getType(typeSignature);
+            return new ClpColumnHandle(columnName, originalColumnName, type);
+        }
+        catch (IOException e) {
+            throw new RuntimeException("Failed to deserialize ClpColumnHandle", e);
+        }
+    }
+}

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/codec/ClpSplitCodec.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/codec/ClpSplitCodec.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.clp.codec;
+
+import com.facebook.presto.plugin.clp.ClpSplit;
+import com.facebook.presto.spi.ConnectorCodec;
+import com.facebook.presto.spi.ConnectorSplit;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.Optional;
+
+public class ClpSplitCodec
+        implements ConnectorCodec<ConnectorSplit>
+{
+    @Override
+    public byte[] serialize(ConnectorSplit value)
+    {
+        ClpSplit split = (ClpSplit) value;
+        try (ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
+                DataOutputStream out = new DataOutputStream(byteOut)) {
+            out.writeUTF(split.getPath());
+            out.writeInt(split.getType().ordinal());
+            Optional<String> kqlQuery = split.getKqlQuery();
+            out.writeBoolean(kqlQuery.isPresent());
+            if (kqlQuery.isPresent()) {
+                out.writeUTF(kqlQuery.get());
+            }
+            return byteOut.toByteArray();
+        }
+        catch (IOException e) {
+            throw new RuntimeException("Failed to serialize ClpSplit", e);
+        }
+    }
+
+    @Override
+    public ConnectorSplit deserialize(byte[] bytes)
+    {
+        try (ByteArrayInputStream byteIn = new ByteArrayInputStream(bytes);
+                DataInputStream in = new DataInputStream(byteIn)) {
+            String path = in.readUTF();
+            ClpSplit.SplitType type = ClpSplit.SplitType.values()[in.readInt()];
+            Optional<String> kqlQuery = in.readBoolean()
+                    ? Optional.of(in.readUTF())
+                    : Optional.empty();
+            return new ClpSplit(path, type, kqlQuery);
+        }
+        catch (IOException e) {
+            throw new RuntimeException("Failed to deserialize ClpSplit", e);
+        }
+    }
+}

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/codec/ClpTableHandleCodec.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/codec/ClpTableHandleCodec.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.clp.codec;
+
+import com.facebook.presto.plugin.clp.ClpTableHandle;
+import com.facebook.presto.spi.ConnectorCodec;
+import com.facebook.presto.spi.ConnectorTableHandle;
+import com.facebook.presto.spi.SchemaTableName;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+public class ClpTableHandleCodec
+        implements ConnectorCodec<ConnectorTableHandle>
+{
+    @Override
+    public byte[] serialize(ConnectorTableHandle value)
+    {
+        ClpTableHandle handle = (ClpTableHandle) value;
+        try (ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
+                DataOutputStream out = new DataOutputStream(byteOut)) {
+            out.writeUTF(handle.getSchemaTableName().getSchemaName());
+            out.writeUTF(handle.getSchemaTableName().getTableName());
+            out.writeUTF(handle.getTablePath());
+            return byteOut.toByteArray();
+        }
+        catch (IOException e) {
+            throw new RuntimeException("Failed to serialize ClpTableHandle", e);
+        }
+    }
+
+    @Override
+    public ConnectorTableHandle deserialize(byte[] bytes)
+    {
+        try (ByteArrayInputStream byteIn = new ByteArrayInputStream(bytes);
+                DataInputStream in = new DataInputStream(byteIn)) {
+            String schemaName = in.readUTF();
+            String tableName = in.readUTF();
+            String tablePath = in.readUTF();
+            return new ClpTableHandle(new SchemaTableName(schemaName, tableName), tablePath);
+        }
+        catch (IOException e) {
+            throw new RuntimeException("Failed to deserialize ClpTableHandle", e);
+        }
+    }
+}

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/codec/ClpTableLayoutHandleCodec.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/codec/ClpTableLayoutHandleCodec.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.clp.codec;
+
+import com.facebook.presto.plugin.clp.ClpTableHandle;
+import com.facebook.presto.plugin.clp.ClpTableLayoutHandle;
+import com.facebook.presto.spi.ConnectorCodec;
+import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.facebook.presto.spi.SchemaTableName;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.Optional;
+
+public class ClpTableLayoutHandleCodec
+        implements ConnectorCodec<ConnectorTableLayoutHandle>
+{
+    @Override
+    public byte[] serialize(ConnectorTableLayoutHandle value)
+    {
+        ClpTableLayoutHandle handle = (ClpTableLayoutHandle) value;
+        try (ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
+                DataOutputStream out = new DataOutputStream(byteOut)) {
+            writeClpTableHandle(out, handle.getTable());
+
+            Optional<String> kqlQuery = handle.getKqlQuery();
+            out.writeBoolean(kqlQuery.isPresent());
+            if (kqlQuery.isPresent()) {
+                out.writeUTF(kqlQuery.get());
+            }
+
+            Optional<String> metadataSql = handle.getMetadataSql();
+            out.writeBoolean(metadataSql.isPresent());
+            if (metadataSql.isPresent()) {
+                out.writeUTF(metadataSql.get());
+            }
+
+            return byteOut.toByteArray();
+        }
+        catch (IOException e) {
+            throw new RuntimeException("Failed to serialize ClpTableLayoutHandle", e);
+        }
+    }
+
+    @Override
+    public ConnectorTableLayoutHandle deserialize(byte[] bytes)
+    {
+        try (ByteArrayInputStream byteIn = new ByteArrayInputStream(bytes);
+                DataInputStream in = new DataInputStream(byteIn)) {
+            ClpTableHandle table = readClpTableHandle(in);
+
+            Optional<String> kqlQuery = in.readBoolean()
+                    ? Optional.of(in.readUTF())
+                    : Optional.empty();
+
+            Optional<String> metadataSql = in.readBoolean()
+                    ? Optional.of(in.readUTF())
+                    : Optional.empty();
+
+            return new ClpTableLayoutHandle(table, kqlQuery, metadataSql);
+        }
+        catch (IOException e) {
+            throw new RuntimeException("Failed to deserialize ClpTableLayoutHandle", e);
+        }
+    }
+
+    private static void writeClpTableHandle(DataOutputStream out, ClpTableHandle handle)
+            throws IOException
+    {
+        out.writeUTF(handle.getSchemaTableName().getSchemaName());
+        out.writeUTF(handle.getSchemaTableName().getTableName());
+        out.writeUTF(handle.getTablePath());
+    }
+
+    private static ClpTableHandle readClpTableHandle(DataInputStream in)
+            throws IOException
+    {
+        String schemaName = in.readUTF();
+        String tableName = in.readUTF();
+        String tablePath = in.readUTF();
+        return new ClpTableHandle(new SchemaTableName(schemaName, tableName), tablePath);
+    }
+}

--- a/presto-clp/src/main/java/com/facebook/presto/plugin/clp/codec/ClpTransactionHandleCodec.java
+++ b/presto-clp/src/main/java/com/facebook/presto/plugin/clp/codec/ClpTransactionHandleCodec.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.clp.codec;
+
+import com.facebook.presto.plugin.clp.ClpTransactionHandle;
+import com.facebook.presto.spi.ConnectorCodec;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+
+public class ClpTransactionHandleCodec
+        implements ConnectorCodec<ConnectorTransactionHandle>
+{
+    @Override
+    public byte[] serialize(ConnectorTransactionHandle value)
+    {
+        return new byte[0];
+    }
+
+    @Override
+    public ConnectorTransactionHandle deserialize(byte[] bytes)
+    {
+        return ClpTransactionHandle.INSTANCE;
+    }
+}

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/codec/TestClpCodecByteFixtures.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/codec/TestClpCodecByteFixtures.java
@@ -1,0 +1,235 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.clp.codec;
+
+import com.facebook.presto.common.type.BigintType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.common.type.TypeSignature;
+import com.facebook.presto.common.type.TypeSignatureParameter;
+import com.facebook.presto.common.type.VarcharType;
+import com.facebook.presto.plugin.clp.ClpColumnHandle;
+import com.facebook.presto.plugin.clp.ClpSplit;
+import com.facebook.presto.plugin.clp.ClpTableHandle;
+import com.facebook.presto.plugin.clp.ClpTableLayoutHandle;
+import com.facebook.presto.plugin.clp.ClpTransactionHandle;
+import com.facebook.presto.spi.SchemaTableName;
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Byte fixture tests that pin the exact wire format for cross-language contract verification.
+ * These byte sequences must match the C++ ClpConnectorProtocol::deserialize() implementations exactly.
+ *
+ * Wire format: Java DataOutputStream big-endian
+ * - String: 2-byte BE length + UTF-8 bytes (writeUTF)
+ * - int: 4 bytes big-endian
+ * - boolean: 1 byte (0/1)
+ * - Optional: boolean flag + conditional data
+ */
+public class TestClpCodecByteFixtures
+{
+    private static final TypeManager TYPE_MANAGER = new TypeManager()
+    {
+        @Override
+        public Type getType(TypeSignature signature)
+        {
+            switch (signature.getBase()) {
+                case "varchar":
+                    return VarcharType.createUnboundedVarcharType();
+                case "bigint":
+                    return BigintType.BIGINT;
+                default:
+                    throw new IllegalArgumentException("Unknown type: " + signature);
+            }
+        }
+
+        @Override
+        public Type getParameterizedType(String baseTypeName, List<TypeSignatureParameter> typeParameters)
+        {
+            return getType(new TypeSignature(baseTypeName));
+        }
+
+        @Override
+        public boolean canCoerce(Type actualType, Type expectedType)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<Type> getTypes()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean hasType(TypeSignature signature)
+        {
+            return getType(signature) != null;
+        }
+    };
+
+    @Test
+    public void testColumnHandleBytes()
+            throws IOException
+    {
+        ClpColumnHandleCodec codec = new ClpColumnHandleCodec(TYPE_MANAGER);
+        ClpColumnHandle handle = new ClpColumnHandle("ts", "ts", BigintType.BIGINT);
+        byte[] bytes = codec.serialize(handle);
+
+        ByteArrayOutputStream expected = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(expected);
+        out.writeUTF("ts");
+        out.writeUTF("ts");
+        out.writeUTF("bigint");
+        out.flush();
+
+        assertEquals(bytes, expected.toByteArray());
+    }
+
+    @Test
+    public void testSplitArchiveWithKqlBytes()
+            throws IOException
+    {
+        ClpSplitCodec codec = new ClpSplitCodec();
+        ClpSplit split = new ClpSplit("/a", ClpSplit.SplitType.ARCHIVE, Optional.of("*"));
+        byte[] bytes = codec.serialize(split);
+
+        ByteArrayOutputStream expected = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(expected);
+        out.writeUTF("/a");       // path
+        out.writeInt(0);          // type ordinal: ARCHIVE = 0
+        out.writeBoolean(true);   // kqlQuery present
+        out.writeUTF("*");        // kqlQuery
+        out.flush();
+
+        assertEquals(bytes, expected.toByteArray());
+    }
+
+    @Test
+    public void testSplitIrNoKqlBytes()
+            throws IOException
+    {
+        ClpSplitCodec codec = new ClpSplitCodec();
+        ClpSplit split = new ClpSplit("/b", ClpSplit.SplitType.IR, Optional.empty());
+        byte[] bytes = codec.serialize(split);
+
+        ByteArrayOutputStream expected = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(expected);
+        out.writeUTF("/b");       // path
+        out.writeInt(1);          // type ordinal: IR = 1
+        out.writeBoolean(false);  // kqlQuery absent
+        out.flush();
+
+        assertEquals(bytes, expected.toByteArray());
+    }
+
+    @Test
+    public void testTransactionHandleBytes()
+    {
+        ClpTransactionHandleCodec codec = new ClpTransactionHandleCodec();
+        byte[] bytes = codec.serialize(ClpTransactionHandle.INSTANCE);
+        assertEquals(bytes.length, 0);
+        assertEquals(bytes, new byte[0]);
+    }
+
+    @Test
+    public void testTableHandleBytes()
+            throws IOException
+    {
+        ClpTableHandleCodec codec = new ClpTableHandleCodec();
+        ClpTableHandle handle = new ClpTableHandle(new SchemaTableName("default", "logs"), "/data");
+        byte[] bytes = codec.serialize(handle);
+
+        ByteArrayOutputStream expected = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(expected);
+        out.writeUTF("default");
+        out.writeUTF("logs");
+        out.writeUTF("/data");
+        out.flush();
+
+        assertEquals(bytes, expected.toByteArray());
+    }
+
+    @Test
+    public void testTableLayoutHandleMinimalBytes()
+            throws IOException
+    {
+        ClpTableLayoutHandleCodec codec = new ClpTableLayoutHandleCodec();
+        ClpTableHandle table = new ClpTableHandle(new SchemaTableName("clp", "logs"), "");
+        ClpTableLayoutHandle handle = new ClpTableLayoutHandle(table, Optional.empty(), Optional.empty());
+
+        byte[] bytes = codec.serialize(handle);
+
+        ByteArrayOutputStream expected = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(expected);
+        out.writeUTF("clp");       // schemaName
+        out.writeUTF("logs");      // tableName
+        out.writeUTF("");          // tablePath
+        out.writeBoolean(false);   // kqlQuery absent
+        out.writeBoolean(false);   // metadataSql absent
+        out.flush();
+
+        assertEquals(bytes, expected.toByteArray());
+    }
+
+    @Test
+    public void testTableLayoutHandleWithBothOptionals()
+            throws IOException
+    {
+        ClpTableLayoutHandleCodec codec = new ClpTableLayoutHandleCodec();
+        ClpTableHandle table = new ClpTableHandle(new SchemaTableName("clp", "logs"), "/data");
+        ClpTableLayoutHandle handle = new ClpTableLayoutHandle(table, Optional.of("ERROR"), Optional.of("(end_timestamp > 100)"));
+
+        byte[] bytes = codec.serialize(handle);
+
+        ByteArrayOutputStream expected = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(expected);
+        out.writeUTF("clp");
+        out.writeUTF("logs");
+        out.writeUTF("/data");
+        out.writeBoolean(true);
+        out.writeUTF("ERROR");
+        out.writeBoolean(true);
+        out.writeUTF("(end_timestamp > 100)");
+        out.flush();
+
+        assertEquals(bytes, expected.toByteArray());
+    }
+
+    @Test
+    public void testEmptyTablePathBytes()
+            throws IOException
+    {
+        ClpTableHandleCodec codec = new ClpTableHandleCodec();
+        ClpTableHandle handle = new ClpTableHandle(new SchemaTableName("s", "t"), "");
+        byte[] bytes = codec.serialize(handle);
+
+        ByteArrayOutputStream expected = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(expected);
+        out.writeUTF("s");
+        out.writeUTF("t");
+        out.writeUTF("");
+        out.flush();
+
+        assertEquals(bytes, expected.toByteArray());
+    }
+}

--- a/presto-clp/src/test/java/com/facebook/presto/plugin/clp/codec/TestClpCodecRoundtrip.java
+++ b/presto-clp/src/test/java/com/facebook/presto/plugin/clp/codec/TestClpCodecRoundtrip.java
@@ -1,0 +1,230 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.clp.codec;
+
+import com.facebook.presto.common.type.BigintType;
+import com.facebook.presto.common.type.IntegerType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.common.type.TypeSignature;
+import com.facebook.presto.common.type.TypeSignatureParameter;
+import com.facebook.presto.common.type.VarcharType;
+import com.facebook.presto.plugin.clp.ClpColumnHandle;
+import com.facebook.presto.plugin.clp.ClpSplit;
+import com.facebook.presto.plugin.clp.ClpTableHandle;
+import com.facebook.presto.plugin.clp.ClpTableLayoutHandle;
+import com.facebook.presto.plugin.clp.ClpTransactionHandle;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+public class TestClpCodecRoundtrip
+{
+    private static final TypeManager TYPE_MANAGER = new TypeManager()
+    {
+        @Override
+        public Type getType(TypeSignature signature)
+        {
+            switch (signature.getBase()) {
+                case "varchar":
+                    return VarcharType.createUnboundedVarcharType();
+                case "bigint":
+                    return BigintType.BIGINT;
+                case "integer":
+                    return IntegerType.INTEGER;
+                default:
+                    throw new IllegalArgumentException("Unknown type: " + signature);
+            }
+        }
+
+        @Override
+        public Type getParameterizedType(String baseTypeName, List<TypeSignatureParameter> typeParameters)
+        {
+            return getType(new TypeSignature(baseTypeName));
+        }
+
+        @Override
+        public boolean canCoerce(Type actualType, Type expectedType)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<Type> getTypes()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean hasType(TypeSignature signature)
+        {
+            return getType(signature) != null;
+        }
+    };
+
+    @Test
+    public void testColumnHandleRoundtrip()
+    {
+        ClpColumnHandleCodec codec = new ClpColumnHandleCodec(TYPE_MANAGER);
+        ClpColumnHandle original = new ClpColumnHandle("ts", "timestamp", BigintType.BIGINT);
+        byte[] bytes = codec.serialize(original);
+        ClpColumnHandle deserialized = (ClpColumnHandle) codec.deserialize(bytes);
+
+        assertEquals(deserialized.getColumnName(), "ts");
+        assertEquals(deserialized.getOriginalColumnName(), "timestamp");
+        assertEquals(deserialized.getColumnType(), BigintType.BIGINT);
+    }
+
+    @Test
+    public void testSplitRoundtripArchiveWithKql()
+    {
+        ClpSplitCodec codec = new ClpSplitCodec();
+        ClpSplit original = new ClpSplit("/data/logs/archive.clp", ClpSplit.SplitType.ARCHIVE, Optional.of("ERROR"));
+        byte[] bytes = codec.serialize(original);
+        ClpSplit deserialized = (ClpSplit) codec.deserialize(bytes);
+
+        assertEquals(deserialized.getPath(), "/data/logs/archive.clp");
+        assertEquals(deserialized.getType(), ClpSplit.SplitType.ARCHIVE);
+        assertEquals(deserialized.getKqlQuery(), Optional.of("ERROR"));
+    }
+
+    @Test
+    public void testSplitRoundtripIrNoKql()
+    {
+        ClpSplitCodec codec = new ClpSplitCodec();
+        ClpSplit original = new ClpSplit("/data/ir/stream.clp.zst", ClpSplit.SplitType.IR, Optional.empty());
+        byte[] bytes = codec.serialize(original);
+        ClpSplit deserialized = (ClpSplit) codec.deserialize(bytes);
+
+        assertEquals(deserialized.getPath(), "/data/ir/stream.clp.zst");
+        assertEquals(deserialized.getType(), ClpSplit.SplitType.IR);
+        assertEquals(deserialized.getKqlQuery(), Optional.empty());
+    }
+
+    @Test
+    public void testTableHandleRoundtrip()
+    {
+        ClpTableHandleCodec codec = new ClpTableHandleCodec();
+        ClpTableHandle original = new ClpTableHandle(new SchemaTableName("default", "logs"), "/data/logs");
+        byte[] bytes = codec.serialize(original);
+        ClpTableHandle deserialized = (ClpTableHandle) codec.deserialize(bytes);
+
+        assertEquals(deserialized.getSchemaTableName().getSchemaName(), "default");
+        assertEquals(deserialized.getSchemaTableName().getTableName(), "logs");
+        assertEquals(deserialized.getTablePath(), "/data/logs");
+    }
+
+    @Test
+    public void testTableLayoutHandleRoundtripWithKql()
+    {
+        ClpTableLayoutHandleCodec codec = new ClpTableLayoutHandleCodec();
+        ClpTableHandle table = new ClpTableHandle(new SchemaTableName("clp", "logs"), "/data/logs");
+        ClpTableLayoutHandle original = new ClpTableLayoutHandle(table, Optional.of("level:ERROR"), Optional.empty());
+        byte[] bytes = codec.serialize(original);
+        ClpTableLayoutHandle deserialized = (ClpTableLayoutHandle) codec.deserialize(bytes);
+
+        assertEquals(deserialized.getTable().getSchemaTableName().getSchemaName(), "clp");
+        assertEquals(deserialized.getTable().getSchemaTableName().getTableName(), "logs");
+        assertEquals(deserialized.getTable().getTablePath(), "/data/logs");
+        assertEquals(deserialized.getKqlQuery(), Optional.of("level:ERROR"));
+        assertEquals(deserialized.getMetadataSql(), Optional.empty());
+    }
+
+    @Test
+    public void testTableLayoutHandleRoundtripWithMetadataSql()
+    {
+        ClpTableLayoutHandleCodec codec = new ClpTableLayoutHandleCodec();
+        ClpTableHandle table = new ClpTableHandle(new SchemaTableName("clp", "logs"), "/data");
+        ClpTableLayoutHandle original = new ClpTableLayoutHandle(table, Optional.empty(), Optional.of("(end_timestamp > 100)"));
+        byte[] bytes = codec.serialize(original);
+        ClpTableLayoutHandle deserialized = (ClpTableLayoutHandle) codec.deserialize(bytes);
+
+        assertEquals(deserialized.getTable().getSchemaTableName().getSchemaName(), "clp");
+        assertEquals(deserialized.getKqlQuery(), Optional.empty());
+        assertEquals(deserialized.getMetadataSql(), Optional.of("(end_timestamp > 100)"));
+    }
+
+    @Test
+    public void testTableLayoutHandleMinimalRoundtrip()
+    {
+        ClpTableLayoutHandleCodec codec = new ClpTableLayoutHandleCodec();
+        ClpTableHandle table = new ClpTableHandle(new SchemaTableName("clp", "logs"), "");
+        ClpTableLayoutHandle original = new ClpTableLayoutHandle(table, Optional.empty(), Optional.empty());
+        byte[] bytes = codec.serialize(original);
+        ClpTableLayoutHandle deserialized = (ClpTableLayoutHandle) codec.deserialize(bytes);
+
+        assertEquals(deserialized.getTable().getSchemaTableName().getSchemaName(), "clp");
+        assertEquals(deserialized.getTable().getTablePath(), "");
+        assertEquals(deserialized.getKqlQuery(), Optional.empty());
+        assertEquals(deserialized.getMetadataSql(), Optional.empty());
+    }
+
+    @Test
+    public void testTransactionHandleRoundtrip()
+    {
+        ClpTransactionHandleCodec codec = new ClpTransactionHandleCodec();
+        byte[] bytes = codec.serialize(ClpTransactionHandle.INSTANCE);
+        assertEquals(bytes.length, 0);
+
+        ConnectorTransactionHandle deserialized = codec.deserialize(bytes);
+        assertEquals(deserialized, ClpTransactionHandle.INSTANCE);
+    }
+
+    @Test
+    public void testCodecProviderReturnsAllCodecs()
+    {
+        ClpCodecProvider provider = new ClpCodecProvider(TYPE_MANAGER);
+
+        assertNotNull(provider.getColumnHandleCodec());
+        assertNotNull(provider.getConnectorSplitCodec());
+        assertNotNull(provider.getConnectorTransactionHandleCodec());
+        assertNotNull(provider.getConnectorTableHandleCodec());
+        assertNotNull(provider.getConnectorTableLayoutHandleCodec());
+
+        assertEquals(provider.getColumnHandleCodec().isPresent(), true);
+        assertEquals(provider.getConnectorSplitCodec().isPresent(), true);
+        assertEquals(provider.getConnectorTransactionHandleCodec().isPresent(), true);
+        assertEquals(provider.getConnectorTableHandleCodec().isPresent(), true);
+        assertEquals(provider.getConnectorTableLayoutHandleCodec().isPresent(), true);
+    }
+
+    @Test
+    public void testEmptyStringRoundtrip()
+    {
+        ClpColumnHandleCodec codec = new ClpColumnHandleCodec(TYPE_MANAGER);
+        ClpColumnHandle original = new ClpColumnHandle("", "", VarcharType.createUnboundedVarcharType());
+        byte[] bytes = codec.serialize(original);
+        ClpColumnHandle deserialized = (ClpColumnHandle) codec.deserialize(bytes);
+
+        assertEquals(deserialized.getColumnName(), "");
+        assertEquals(deserialized.getOriginalColumnName(), "");
+    }
+
+    @Test
+    public void testEmptyOptionalRoundtrip()
+    {
+        ClpSplitCodec codec = new ClpSplitCodec();
+        ClpSplit original = new ClpSplit("/path", ClpSplit.SplitType.ARCHIVE, Optional.empty());
+        byte[] bytes = codec.serialize(original);
+        ClpSplit deserialized = (ClpSplit) codec.deserialize(bytes);
+
+        assertEquals(deserialized.getKqlQuery(), Optional.empty());
+    }
+}


### PR DESCRIPTION
## Summary

Adds binary serialization codecs for all 5 CLP handle types (ColumnHandle, Split, TableHandle, TableLayoutHandle, TransactionHandle) using `ConnectorCodec<T>` with `DataOutputStream` big-endian encoding.

This is the Java side of the binary serialization path: the coordinator serializes handles into `customSerializedValue`, and the C++ Velox worker deserializes them via `ConnectorProtocol::deserialize()`. This eliminates the dependency on Presto's JSON protocol type system on the worker side, which is required for the standalone Velox plugin.

## Test plan

- [ ] Roundtrip tests pass: serialize → deserialize → assert all fields match for each handle type
- [ ] Byte fixture tests pass: exact byte sequences match expected DataOutputStream output
- [ ] `ClpCodecProvider` returns all 5 codec types